### PR TITLE
fix(upload): update the default upload service URL

### DIFF
--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -27,8 +27,8 @@ import {
 } from '../types.js';
 import { TurboHTTPService } from './http.js';
 
-export const defaultUploadServiceURL = 'https://upload.ardrive.io';
 export const developmentUploadServiceURL = 'https://upload.ardrive.dev';
+export const defaultUploadServiceURL = 'https://upload.ardrive.io';
 
 export class TurboUnauthenticatedUploadService
   implements TurboUnauthenticatedUploadServiceInterface
@@ -73,7 +73,7 @@ export class TurboAuthenticatedUploadService
   protected signer: TurboWalletSigner;
 
   constructor({
-    url = 'https://upload.ardrive.dev',
+    url = defaultUploadServiceURL,
     retryConfig,
     signer,
   }: TurboAuthenticatedUploadServiceConfiguration) {


### PR DESCRIPTION
The SDK should upload to arweave.net by default. Currently, you must provide `defaultTurboConfgiuration` when instantiating a `TurboAuthenticatedClient`, otherwise uploads will go to arweave.dev