### PR TITLE
fix(exports): web exports reference an invalid build path

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
       "types": "./lib/types/node/index.d.ts"
     },
     "./web": {
-      "import": "./lib/web/index.js",
-      "require": "./lib/web/index.js",
+      "import": "./lib/esm/web/index.js",
+      "require": "./lib/cjs/web/index.js",
       "types": "./lib/types/web/index.d.ts",
       "browser": "./bundles/web.bundle.min.js"
     }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     ".": {
       "import": "./lib/esm/node/index.js",
       "require": "./lib/cjs/node/index.js",
-      "types": "./lib/types/node/index.d.ts"
+      "types": "./lib/types/node/index.d.ts",
+      "browser": "./bundles/web.bundle.min.js"
     },
     "./node": {
       "import": "./lib/esm/node/index.js",
@@ -33,8 +34,8 @@
       "types": "./lib/types/node/index.d.ts"
     },
     "./web": {
-      "import": "./lib/esm/web/index.js",
-      "require": "./lib/cjs/web/index.js",
+      "import": "./bundles/web.bundle.min.js",
+      "require": "./bundles/web.bundle.min.js",
       "types": "./lib/types/web/index.d.ts",
       "browser": "./bundles/web.bundle.min.js"
     }


### PR DESCRIPTION
The types path is correct, but the referenced index path is not.