### PR TITLE
chore(test): add ability for running tests against local docker-compose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node_version: [18.x, 20.x]
-        command: ['lint', 'format', 'test', 'build']
+        command: ['lint', 'format', 'test:docker', 'build']
     steps:
       - uses: actions/checkout@v3
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: 3.0.0
+
+services:
+  upload-service:
+    image: ghcr.io/ardriveapp/turbo-upload-service:latest
+    ports:
+      - '3000:3000'
+    environment:
+      NODE_ENV: test
+      DB_HOST: upload-service-pg
+      DB_PORT: 5432
+      DB_PASSWORD: postgres
+      PAYMENT_SERVICE_BASE_URL: http://payment-service:4000
+      MIGRATE_ON_STARTUP: true
+      JWT_SECRET: test-secret-key
+    volumes:
+      - upload-service-data-items:/temp
+    depends_on:
+      - upload-service-pg
+
+  upload-service-pg:
+    image: postgres:13.8
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - upload-service-data:/var/lib/postgresql/data
+
+  payment-service:
+    image: ghcr.io/ardriveapp/turbo-payment-service:latest
+    ports:
+      - '4000:4000'
+    environment:
+      NODE_ENV: test
+      DB_HOST: payment-service-pg
+      DB_PORT: 5433
+      DB_PASSWORD: postgres
+      PORT: 4000
+      DISABLE_LOGS: false
+      MIGRATE_ON_STARTUP: true
+      STRIPE_SECRET_KEY: secret-key
+      STRIPE_WEBHOOK_SECRET: webhook-secret-key
+      JWT_SECRET: test-secret-key
+    depends_on:
+      - payment-service-pg
+
+  payment-service-pg:
+    image: postgres:13.8
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - '5433:5432'
+    volumes:
+      - payment-service-data:/var/lib/postgresql/data
+
+volumes:
+  payment-service-data:
+  upload-service-data:
+  upload-service-data-items:

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test": "c8 mocha --config .mocharc --exit",
     "test:web": "c8 mocha --config .mocharc --exclude tests/**/*.node.test.ts --exit",
     "test:node": "c8 mocha --config .mocharc --exclude tests/**/*.web.test.ts --exit",
+    "test:docker": "docker compose up -d ; PAYMENT_SERVICE_URL=http://localhost:4000 UPLOAD_SERVICE_URL=http://localhost:3000 yarn test ; docker compose down -v",
     "prepare": "husky install",
     "example:mjs": "cd examples/mjs && yarn && node index.mjs",
     "example:cjs": "cd examples/cjs && yarn && node index.cjs",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -33,3 +33,15 @@ export async function expectAsyncErrorThrow({
     expect(error?.message).to.equal(errorMessage);
   }
 }
+
+/**
+ * Used to setup our local development configuration
+ */
+export const turboDevelopmentConfigurations = {
+  paymentServiceConfig: {
+    url: process.env.PAYMENT_SERVICE_URL ?? 'https://payment.ardrive.dev',
+  },
+  uploadServiceConfig: {
+    url: process.env.UPLOAD_SERVICE_URL ?? 'https://upload.ardrive.dev',
+  },
+};

--- a/tests/turbo.node.test.ts
+++ b/tests/turbo.node.test.ts
@@ -7,7 +7,6 @@ import { Readable } from 'node:stream';
 
 import { USD } from '../src/common/currency.js';
 import { JWKInterface } from '../src/common/jwk.js';
-import { developmentTurboConfiguration } from '../src/common/turbo.js';
 import {
   TurboAuthenticatedClient,
   TurboUnauthenticatedClient,
@@ -15,19 +14,24 @@ import {
 import { TurboFactory } from '../src/node/factory.js';
 import { jwkToPublicArweaveAddress } from '../src/utils/base64.js';
 import { FailedRequestError } from '../src/utils/errors.js';
-import { expectAsyncErrorThrow } from './helpers.js';
+import {
+  expectAsyncErrorThrow,
+  turboDevelopmentConfigurations,
+} from './helpers.js';
 
 describe('Node environment', () => {
   describe('TurboFactory', () => {
     it('should return a TurboUnauthenticatedClient when running in Node environment and not provided a privateKey', () => {
-      const turbo = TurboFactory.unauthenticated(developmentTurboConfiguration);
+      const turbo = TurboFactory.unauthenticated(
+        turboDevelopmentConfigurations,
+      );
       expect(turbo).to.be.instanceOf(TurboUnauthenticatedClient);
     });
     it('should return a TurboAuthenticatedClient when running in Node environment and  provided a privateKey', async () => {
       const jwk = await Arweave.crypto.generateJWK();
       const turbo = TurboFactory.authenticated({
         privateKey: jwk,
-        ...developmentTurboConfiguration,
+        ...turboDevelopmentConfigurations,
       });
       expect(turbo).to.be.instanceOf(TurboAuthenticatedClient);
     });
@@ -37,7 +41,7 @@ describe('Node environment', () => {
     let turbo: TurboUnauthenticatedClient;
 
     before(() => {
-      turbo = TurboFactory.unauthenticated(developmentTurboConfiguration);
+      turbo = TurboFactory.unauthenticated(turboDevelopmentConfigurations);
     });
 
     it('getFiatRates()', async () => {
@@ -184,7 +188,7 @@ describe('Node environment', () => {
       jwk = await Arweave.crypto.generateJWK();
       turbo = TurboFactory.authenticated({
         privateKey: jwk,
-        ...developmentTurboConfiguration,
+        ...turboDevelopmentConfigurations,
       });
       address = await Arweave.init({}).wallets.jwkToAddress(jwk);
     });

--- a/tests/turbo.web.test.ts
+++ b/tests/turbo.web.test.ts
@@ -6,7 +6,6 @@ import { ReadableStream } from 'node:stream/web';
 
 import { USD } from '../src/common/currency.js';
 import { JWKInterface } from '../src/common/jwk.js';
-import { developmentTurboConfiguration } from '../src/common/turbo.js';
 import {
   TurboAuthenticatedClient,
   TurboUnauthenticatedClient,
@@ -14,6 +13,7 @@ import {
 import { jwkToPublicArweaveAddress } from '../src/utils/base64.js';
 import { FailedRequestError } from '../src/utils/errors.js';
 import { TurboFactory } from '../src/web/index.js';
+import { turboDevelopmentConfigurations } from './helpers.js';
 
 describe('Browser environment', () => {
   before(() => {
@@ -26,7 +26,9 @@ describe('Browser environment', () => {
 
   describe('TurboFactory', () => {
     it('should be a TurboUnauthenticatedClient running in the browser and not provided a privateKey', () => {
-      const turbo = TurboFactory.unauthenticated(developmentTurboConfiguration);
+      const turbo = TurboFactory.unauthenticated(
+        turboDevelopmentConfigurations,
+      );
       expect(turbo).to.be.instanceOf(TurboUnauthenticatedClient);
     });
 
@@ -34,7 +36,7 @@ describe('Browser environment', () => {
       const jwk = await Arweave.crypto.generateJWK();
       const turbo = TurboFactory.authenticated({
         privateKey: jwk,
-        ...developmentTurboConfiguration,
+        ...turboDevelopmentConfigurations,
       });
       expect(turbo).to.be.instanceOf(TurboUnauthenticatedClient);
     });
@@ -44,7 +46,7 @@ describe('Browser environment', () => {
     let turbo: TurboUnauthenticatedClient;
 
     before(() => {
-      turbo = TurboFactory.unauthenticated(developmentTurboConfiguration);
+      turbo = TurboFactory.unauthenticated(turboDevelopmentConfigurations);
     });
 
     describe('unauthenticated requests', () => {
@@ -175,7 +177,7 @@ describe('Browser environment', () => {
       jwk = await Arweave.crypto.generateJWK();
       turbo = TurboFactory.authenticated({
         privateKey: jwk,
-        ...developmentTurboConfiguration,
+        ...turboDevelopmentConfigurations,
       });
       address = await Arweave.init({}).wallets.jwkToAddress(jwk);
     });


### PR DESCRIPTION
This allows tests to run against a local upload and payment service, rather than hitting dev instances. It's configurable when running.