### PR TITLE
fix(web): remove reference to `node:crypto` in websigner, use signer …

### DIFF
--- a/src/web/signer.ts
+++ b/src/web/signer.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { ArconnectSigner, createData } from 'arbundles';
-import { randomBytes } from 'node:crypto';
+import { randomBytes } from 'crypto';
 
 import { JWKInterface } from '../common/jwk.js';
 import {


### PR DESCRIPTION
…to signer to sign header

This can go straight to beta.