### PR TITLE
chore: add script to mine blocks in docker compose

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
 NODE_ENV=test
 UPLOAD_SERVICE_URL=http://localhost:3000
 PAYMENT_SERVICE_URL=http://localhost:4000
-ARWEAVE_GATEWAY=http://arlocal:1984
+ARWEAVE_GATEWAY=http://localhost:1984

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,16 @@ services:
     ports:
       - '1984:1984'
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://arlocal:1984/']
+      test: ['CMD', 'curl', '-f', 'http://localhost:1984/']
       interval: 10s
       timeout: 10s
-      retries: 5
+      retries: 3
+
+  arlocal-setup:
+    image: curlimages/curl:latest
+    command: /bin/sh -c "while ! curl -f http://arlocal:1984/ >/dev/null 2>&1; do sleep 1; done; curl http://arlocal:1984/mine"
+    depends_on:
+      - arlocal
 
   upload-service:
     image: ghcr.io/ardriveapp/upload-service:latest
@@ -39,7 +45,7 @@ services:
     depends_on:
       - upload-service-pg
       - payment-service
-      - arlocal
+      - arlocal-setup
 
   upload-service-pg:
     image: postgres:13.8
@@ -76,7 +82,7 @@ services:
       ARWEAVE_GATEWAY: ${ARWEAVE_GATEWAY:-http://arlocal:1984}
     depends_on:
       - payment-service-pg
-      - arlocal
+      - arlocal-setup
 
   payment-service-pg:
     image: postgres:13.8

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "c8 mocha --config .mocharc --exit",
     "test:web": "c8 mocha --config .mocharc --exclude tests/**/*.node.test.ts --exit",
     "test:node": "c8 mocha --config .mocharc --exclude tests/**/*.web.test.ts --exit",
-    "test:docker": "docker compose up --quiet-pull -d; yarn dotenv -e .env.test yarn test; docker-compose down -v",
+    "test:docker": "docker compose up --pull always --quiet-pull -d; yarn dotenv -e .env.test yarn test; docker-compose down -v",
     "prepare": "husky install",
     "examples": "yarn example:esm & yarn example:cjs & yarn example:ts:esm & yarn example:ts:cjs",
     "example:esm": "cd examples/esm && yarn && node index.mjs",


### PR DESCRIPTION
Two tests now failing related to credit transactions.

Remaining test failures:
```
 1) Node environment
       TurboUnauthenticatedNodeClient
         submitFundTransaction()
           should properly submit an existing payment transaction ID to the Turbo Payment Service for processing:
     FailedRequestError: Failed request: 404: Not Found
      at TurboHTTPService.post (file:///Users/dylanfiedler/Documents/ardrive/turbo/turbo-sdk/src/common/http.ts:109:13)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async TurboUnauthenticatedPaymentService.submitFundTransaction (file:///Users/dylanfiedler/Documents/ardrive/turbo/turbo-sdk/src/common/payment.ts:178:22)
      at async Context.<anonymous> (file:///Users/dylanfiedler/Documents/ardrive/turbo/turbo-sdk/tests/turbo.node.test.ts:241:44)

  2) Browser environment
       TurboUnauthenticatedWebClient
         submitFundTransaction()
           should properly submit an existing payment transaction ID to the Turbo Payment Service for processing:
     FailedRequestError: Failed request: 404: Not Found
      at TurboHTTPService.post (file:///Users/dylanfiedler/Documents/ardrive/turbo/turbo-sdk/src/common/http.ts:109:13)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async TurboUnauthenticatedPaymentService.submitFundTransaction (file:///Users/dylanfiedler/Documents/ardrive/turbo/turbo-sdk/src/common/payment.ts:178:22)
      at async Context.<anonymous> (file:///Users/dylanfiedler/Documents/ardrive/turbo/turbo-sdk/tests/turbo.web.test.ts:234:44)
```