### PR TITLE
chore: allow for running tests dynamically

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,14 +58,16 @@
     "test": "c8 mocha --config .mocharc --exit",
     "test:web": "c8 mocha --config .mocharc --exclude tests/**/*.node.test.ts --exit",
     "test:node": "c8 mocha --config .mocharc --exclude tests/**/*.web.test.ts --exit",
-    "test:docker": "docker compose up --quiet-pull -d; yarn dotenv -e .env.test yarn test \"$@\" ; docker-compose down -v",
+    "test:docker": "./run-tests.sh",
     "prepare": "husky install",
     "examples": "yarn example:esm & yarn example:cjs & yarn example:ts:esm & yarn example:ts:cjs",
     "example:esm": "cd examples/esm && yarn && node index.mjs",
     "example:cjs": "cd examples/cjs && yarn && node index.cjs",
     "example:web": "http-server --port 8080 --host -o examples/web",
     "example:ts:esm": "cd examples/typescript/esm && yarn && yarn test",
-    "example:ts:cjs": "cd examples/typescript/cjs && yarn && yarn test"
+    "example:ts:cjs": "cd examples/typescript/cjs && yarn && yarn test",
+    "docker:up": "docker compose up --quiet-pull --pull always -d",
+    "docker:down": "docker compose down -v"
   },
   "dependencies": {
     "arbundles": "0.9.9",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docker compose up --quiet-pull -d --pull always
+
+# Run tests and capture the exit code
+yarn dotenv -e .env.test -- -- yarn test "$@"
+exit_code=$?
+
+# Tear down the docker-compose setup
+docker-compose down -v
+
+# Exit with the captured exit code
+exit $exit_code


### PR DESCRIPTION
Allows you to run scoped tests via `yarn test -g "fund"`