### PR TITLE
fix(deps): pin `@keplr-wallet/cosmos` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,9 @@
     "tweetnacl": "^1.0.3",
     "winston": "^3.14.1"
   },
+  "resolutions": {
+    "@keplr-wallet/cosmos": "0.12.123"
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,7 +1024,7 @@
     buffer "^6.0.3"
     delay "^4.4.0"
 
-"@keplr-wallet/cosmos@^0.12.96":
+"@keplr-wallet/cosmos@0.12.123", "@keplr-wallet/cosmos@^0.12.96":
   version "0.12.123"
   resolved "https://registry.yarnpkg.com/@keplr-wallet/cosmos/-/cosmos-0.12.123.tgz#0a0eef06ff2bc2771f52a79720afa6735dc49e5c"
   integrity sha512-Wwfya+b6XQ304I+8TkyhTrPD0YX6+37qzJ1Zy+jPOJY46Y/kztn42G1ysMu/l7DxYDmHrpzdFT6mXcJ25foigQ==


### PR DESCRIPTION
This dep changed the use of starknet, causing breaking changes when uploading with kyve. Pinning to a working version until we resolve.

Reference: https://github.com/chainapsis/keplr-wallet/commit/2a8ca006f1992de94c509bb5220b0d65ced927f5