### PR TITLE
fix(types): avoid using node: imports as they are only available in n…

### DIFF
--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -15,7 +15,6 @@
  */
 import { AxiosError, AxiosInstance, AxiosResponse, CanceledError } from 'axios';
 import { IAxiosRetryConfig } from 'axios-retry';
-import { Buffer } from 'node:buffer';
 import { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';
 

--- a/src/common/payment.ts
+++ b/src/common/payment.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { BigNumber } from 'bignumber.js';
-import { Buffer } from 'node:buffer';
 
 import {
   Currency,

--- a/src/common/signer.ts
+++ b/src/common/signer.ts
@@ -23,7 +23,6 @@ import bs58 from 'bs58';
 import { randomBytes } from 'crypto';
 import { Wallet as EthereumWallet, ethers, parseEther } from 'ethers';
 import { computeAddress } from 'ethers';
-import { Buffer } from 'node:buffer';
 import nacl from 'tweetnacl';
 
 import {

--- a/src/common/token/arweave.ts
+++ b/src/common/token/arweave.ts
@@ -15,7 +15,6 @@
  */
 import ArweaveModule from 'arweave';
 import { BigNumber } from 'bignumber.js';
-import { Buffer } from 'node:buffer';
 
 import {
   TokenCreateTxParams,

--- a/src/common/token/solana.ts
+++ b/src/common/token/solana.ts
@@ -23,7 +23,6 @@ import {
 } from '@solana/web3.js';
 import { BigNumber } from 'bignumber.js';
 import bs58 from 'bs58';
-import { Buffer } from 'node:buffer';
 
 import { defaultProdGatewayUrls } from '../../cli/constants.js';
 import {

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -15,9 +15,8 @@
  */
 import { AxiosError, CanceledError } from 'axios';
 import { IAxiosRetryConfig } from 'axios-retry';
-import { Buffer } from 'node:buffer';
-import { Readable } from 'node:stream';
 import { pLimit } from 'plimit-lit';
+import { Readable } from 'stream';
 
 import {
   ArweaveManifest,

--- a/src/node/signer.ts
+++ b/src/node/signer.ts
@@ -21,8 +21,7 @@ import {
   serializeTags,
   streamSigner,
 } from '@dha-team/arbundles';
-import { Buffer } from 'node:buffer';
-import { Readable } from 'node:stream';
+import { Readable } from 'stream';
 
 import { TurboDataItemAbstractSigner } from '../common/signer.js';
 import {

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -15,9 +15,8 @@
  */
 import { createReadStream, promises, statSync } from 'fs';
 import { lookup } from 'mime-types';
-import { Buffer } from 'node:buffer';
-import { Readable } from 'node:stream';
 import { join } from 'path';
+import { Readable } from 'stream';
 
 import {
   TurboAuthenticatedBaseUploadService,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,8 @@ import {
 import { IAxiosRetryConfig } from 'axios-retry';
 import { BigNumber } from 'bignumber.js';
 import { JsonRpcSigner } from 'ethers';
-import { Readable } from 'node:stream';
-import { ReadableStream } from 'node:stream/web';
+import { Readable } from 'stream';
+import { ReadableStream } from 'stream/web';
 
 import { CurrencyMap } from './common/currency.js';
 import { JWKInterface } from './common/jwk.js';

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -15,7 +15,6 @@
  */
 import { bufferTob64Url } from 'arweave/node/lib/utils.js';
 import { createHash } from 'crypto';
-import { Buffer } from 'node:buffer';
 
 import { JWKInterface } from '../common/jwk.js';
 import { Base64String, PublicArweaveAddress } from '../types.js';

--- a/src/utils/readableStream.ts
+++ b/src/utils/readableStream.ts
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Buffer } from 'node:buffer';
-import { ReadableStream } from 'node:stream/web';
+import { ReadableStream } from 'stream/web';
 
 export async function readableStreamToBuffer({
   stream,

--- a/src/web/signer.ts
+++ b/src/web/signer.ts
@@ -22,7 +22,6 @@ import {
   InjectedEthereumSigner,
   createData,
 } from '@dha-team/arbundles';
-import { Buffer } from 'node:buffer';
 
 import { TurboDataItemAbstractSigner } from '../common/signer.js';
 import {


### PR DESCRIPTION
…ode environments

This allows polyfills to properly fill these imports. Otherwise you get errors like

```bash
node:buffer
Module build failed: UnhandledSchemeError: Reading from "node:buffer" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
    at /Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:29:408376
    at Hook.eval [as callAsync] (eval at create (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:14:9224), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:14:6378)
    at Object.processResource (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:29:408301)
    at processResource (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/loader-runner/LoaderRunner.js:1:5308)
    at iteratePitchingLoaders (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/loader-runner/LoaderRunner.js:1:4667)
    at runLoaders (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/loader-runner/LoaderRunner.js:1:8590)
    at NormalModule._doBuild (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:29:408163)
    at NormalModule.build (/Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:29:410176)
    at /Users/dylanfiedler/Documents/ario/ar-io/Nextjs15-Arweave/node_modules/next/dist/compiled/webpack/bundle5.js:29:82494

Import trace for requested module:
node:buffer
./node_modules/@ardrive/turbo-sdk/lib/esm/web/signer.js
./node_modules/@ardrive/turbo-sdk/lib/esm/web/index.js
./app/utils/turboClient.ts
./app/components/DashboardPage.tsx
./app/page.tsx```