### PR TITLE
fix(api): remove Readable.from in uploadData when dealing with a buffer

### DIFF
--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -151,7 +151,7 @@ export abstract class TurboAuthenticatedBaseUploadService
       })();
 
       return this.uploadFile({
-        fileStreamFactory: () => Readable.from(dataBuffer),
+        fileStreamFactory: () => dataBuffer,
         fileSizeFactory: () => dataBuffer.byteLength,
         signal,
         dataItemOpts,

--- a/src/web/signer.ts
+++ b/src/web/signer.ts
@@ -74,14 +74,19 @@ export class TurboWebArweaveSigner extends TurboDataItemAbstractSigner {
 
     const fileStream = fileStreamFactory();
 
-    // TODO: converts the readable stream to a buffer bc incrementally signing ReadableStreams is not trivial
-    const buffer =
-      fileStream instanceof Buffer
-        ? fileStream
-        : await readableStreamToBuffer({
-            stream: fileStream,
-            size: fileSizeFactory(),
-          });
+    // TODO: here we convert the readable stream to a buffer bc incrementally signing ReadableStreams is not trivial
+    // we should add support for incrementally signing ReadableStreams in the future
+    let buffer: Buffer;
+    if (Buffer.isBuffer(fileStream)) {
+      buffer = fileStream;
+    } else if (fileStream instanceof ReadableStream) {
+      buffer = await readableStreamToBuffer({
+        stream: fileStream,
+        size: fileSizeFactory(),
+      });
+    } else {
+      throw new Error('Unsupported file stream type for web signer');
+    }
 
     let signedDataItem: DataItem;
     this.logger.debug('Signing data item...');

--- a/tests/turbo.node.test.ts
+++ b/tests/turbo.node.test.ts
@@ -33,6 +33,7 @@ import {
   NativeAddress,
   TokenType,
   TurboSigner,
+  UploadDataType,
   tokenTypes,
 } from '../src/types.js';
 import { signerFromKyveMnemonic } from '../src/utils/common.js';
@@ -593,11 +594,12 @@ describe('Node environment', () => {
         },
       ];
 
-      const uploadDataTypeInputsMap = {
+      const uploadDataTypeInputsMap: Record<string, UploadDataType> = {
         string: 'a test string',
         Buffer: Buffer.from('a test string'),
         Uint8Array: new Uint8Array(Buffer.from('a test string')),
-        ArrayBuffer: Buffer.from('a test string').buffer,
+        ArrayBuffer: new TextEncoder().encode('a test string')
+          .buffer as ArrayBuffer,
       };
 
       for (const [label, input] of Object.entries(uploadDataTypeInputsMap)) {

--- a/tests/turbo.web.test.ts
+++ b/tests/turbo.web.test.ts
@@ -27,6 +27,7 @@ import {
   SolanaToken,
   TurboFactory,
   TurboWebArweaveSigner,
+  UploadDataType,
   WinstonToTokenAmount,
 } from '../src/web/index.js';
 import {
@@ -511,10 +512,12 @@ describe('Browser environment', () => {
     });
 
     describe('uploadData()', () => {
-      const uploadDataTypeInputsMap = {
+      const uploadDataTypeInputsMap: Record<string, UploadDataType> = {
         string: 'a test string',
         Uint8Array: new TextEncoder().encode('a test string'),
-        ArrayBuffer: new TextEncoder().encode('a test string').buffer,
+        ArrayBuffer: new TextEncoder().encode('a test string')
+          .buffer as ArrayBuffer,
+        Buffer: Buffer.from('a test string'),
         Blob: new Blob(['a test string'], { type: 'text/plain' }),
       };
       for (const [label, input] of Object.entries(uploadDataTypeInputsMap)) {


### PR DESCRIPTION
Readable is not available in web environments, and cannot be handled by the web signer.