### PR TITLE
fix(streams): use native ReadableStream vs the node import

### DIFF
--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -15,8 +15,7 @@
  */
 import { AxiosError, AxiosInstance, AxiosResponse, CanceledError } from 'axios';
 import { IAxiosRetryConfig } from 'axios-retry';
-import { Readable } from 'stream';
-import { ReadableStream } from 'stream/web';
+import { Readable } from 'node:stream';
 
 import {
   TurboHTTPServiceInterface,

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -16,9 +16,8 @@
 import { AxiosError, CanceledError } from 'axios';
 import { IAxiosRetryConfig } from 'axios-retry';
 import { EventEmitter } from 'eventemitter3';
+import { Readable } from 'node:stream';
 import { pLimit } from 'plimit-lit';
-import { Readable } from 'stream';
-import { ReadableStream } from 'stream/web';
 
 import {
   ArweaveManifest,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,7 @@ import {
 import { IAxiosRetryConfig } from 'axios-retry';
 import { BigNumber } from 'bignumber.js';
 import { JsonRpcSigner } from 'ethers';
-import { Readable } from 'stream';
-import { ReadableStream } from 'stream/web';
+import { Readable } from 'node:stream';
 
 import { CurrencyMap } from './common/currency.js';
 import { JWKInterface } from './common/jwk.js';

--- a/src/utils/readableStream.ts
+++ b/src/utils/readableStream.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReadableStream } from 'stream/web';
-
 export async function readableStreamToBuffer({
   stream,
   size,

--- a/src/web/events.ts
+++ b/src/web/events.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReadableStream } from 'stream/web';
-
 import {
   BaseUploadEmitter,
   TurboUploadEmitterBaseFactory,

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReadableStream } from 'stream/web';
-
 import {
   TurboAuthenticatedBaseUploadService,
   defaultUploadServiceURL,

--- a/tests/turbo.web.test.ts
+++ b/tests/turbo.web.test.ts
@@ -10,7 +10,6 @@ import { BigNumber } from 'bignumber.js';
 import { expect } from 'chai';
 import { TransactionResponse } from 'ethers';
 import { File } from 'node-fetch';
-import { ReadableStream } from 'node:stream/web';
 import { restore, stub } from 'sinon';
 
 import { USD } from '../src/common/currency.js';


### PR DESCRIPTION
ReadableStream will be available by default for browser based clients. This is purely a type workaround as the tsconfig specificifies that `dom` types/classes are allowed, avoiding the need for direct imports from `node:streams/web`. One interesting problem to solve is if someone running a node environment, but wants to use ReadableStream exported by node:streams/web will typescript allow that? Not sure. This at least unblocks for now.