### PR TITLE
PE-8142: bytes to usd price

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,12 +359,26 @@ Get the current price from the Turbo Payment Service, denominated in the specifi
 ```typescript
 const turbo = TurboFactory.unauthenticated();
 const { amount } = await turbo.getFiatEstimateForBytes({
-  byteCount: 1024 * 1024 * 100,
+  byteCount: 1024 * 1024 * 1024,
   currency: 'usd', // specify the currency for the price
 });
 
-console.log(amount); // Estimated usd price for 100 MiB
+console.log(amount); // Estimated usd price for 1 GiB
 ```
+
+<details>
+  <summary>Example Output</summary>
+
+```json
+{
+  "byteCount": 1073741824,
+  "amount": 20.58,
+  "currency": "usd",
+  "winc": "2402378997310"
+}
+```
+
+</details>
 
 #### `getTokenPriceForBytes({ byteCount })`
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,20 @@ const { winc, actualTokenAmount, equivalentWincTokenAmount } =
   });
 ```
 
+#### `getFiatEstimateForBytes({ byteCount, currency })`
+
+Get the current price from the Turbo Payment Service, denominated in the specified fiat currency, for uploading a specified number of bytes to Turbo.
+
+```typescript
+const turbo = TurboFactory.unauthenticated();
+const { amount } = await turbo.getFiatEstimateForBytes({
+  byteCount: 1024 * 1024 * 100,
+  currency: 'usd', // specify the currency for the price
+});
+
+console.log(amount); // Estimated usd price for 100 MiB
+```
+
 #### `getTokenPriceForBytes({ byteCount })`
 
 Get the current price from the Turbo Payment Service, denominated in the specified token, for uploading a specified number of bytes to Turbo.
@@ -994,6 +1008,7 @@ Command Options:
 
 - `--value <value>` - Value to get the price for. e.g: 10.50 for $10.50 USD, 1024 for 1 KiB, 1.1 for 1.1 AR
 - `--type <type>` - Type of price to get. e.g: 'bytes', 'arweave', 'usd', 'kyve'. Default: 'bytes'
+- `--currency <currency>` - Currency to get the price for (e.g: 'usd', 'eur', 'gbp').
 
 e.g:
 
@@ -1007,6 +1022,21 @@ turbo price --value 1024 --type bytes
 
 ```shell
 turbo price --value 1.1 --type arweave
+```
+
+##### `fiat-estimate`
+
+Get the current fiat estimation from the Turbo Payment Service, denominated in the specified fiat currency, for uploading a specified number of bytes to Turbo.
+
+Command Options:
+
+- `--byte-count <byteCount>` - Byte value to get the token price for
+- `--currency <currency>` - Currency to get the fiat estimate for (e.g: 'usd', 'eur', 'gbp')
+
+e.g:
+
+```shell
+turbo fiat-estimate --byte-count 102400 --token solana
 ```
 
 ##### `token-price`

--- a/README.md
+++ b/README.md
@@ -1022,7 +1022,7 @@ Command Options:
 
 - `--value <value>` - Value to get the price for. e.g: 10.50 for $10.50 USD, 1024 for 1 KiB, 1.1 for 1.1 AR
 - `--type <type>` - Type of price to get. e.g: 'bytes', 'arweave', 'usd', 'kyve'. Default: 'bytes'
-- `--currency <currency>` - Currency to get the price for (e.g: 'usd', 'eur', 'gbp').
+- `--currency <currency>` - Currency unit of the reported price (e.g: 'usd', 'eur', 'gbp').
 
 e.g:
 
@@ -1044,13 +1044,13 @@ Get the current fiat estimation from the Turbo Payment Service, denominated in t
 
 Command Options:
 
-- `--byte-count <byteCount>` - Byte value to get the token price for
-- `--currency <currency>` - Currency to get the fiat estimate for (e.g: 'usd', 'eur', 'gbp')
+- `--byte-count <byteCount>` - Byte count of data to get the fiat estimate for
+- `--currency <currency>` - Currency unit of the reported price (e.g: 'usd', 'eur', 'gbp')
 
 e.g:
 
 ```shell
-turbo fiat-estimate --byte-count 102400 --token solana
+turbo fiat-estimate --byte-count 102400 --currency usd
 ```
 
 ##### `token-price`
@@ -1059,7 +1059,7 @@ Get the current price from the Turbo Payment Service, denominated in the specifi
 
 Command Options:
 
-- `--byte-count <byteCount>` - Byte value to get the token price for
+- `--byte-count <byteCount>` - Byte count of data to get the token price for
 
 e.g:
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -104,7 +104,7 @@ applyOptions(
 applyOptions(
   program
     .command('token-price')
-    .description('Get the current token price for provided byte value'),
+    .description('Get the current token price for provided byte count'),
   [optionMap.byteCount],
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, tokenPrice);
@@ -113,7 +113,7 @@ applyOptions(
 applyOptions(
   program
     .command('fiat-estimate')
-    .description('Get the current token price for provided byte value'),
+    .description('Get the current token price for provided byte count'),
   [optionMap.byteCount, optionMap.currency],
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, fiatEstimate);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -20,6 +20,7 @@
 import { Command, program } from 'commander';
 
 import { version } from '../version.js';
+import { fiatEstimate } from './commands/fiatEstimate.js';
 import {
   balance,
   cryptoFund,
@@ -95,7 +96,7 @@ applyOptions(
     .description(
       'Get the current Credits estimate for byte, crypto, or fiat value',
     ),
-  [optionMap.value, optionMap.type],
+  [optionMap.value, optionMap.type, optionMap.currency],
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, price);
 });
@@ -107,6 +108,15 @@ applyOptions(
   [optionMap.byteCount],
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, tokenPrice);
+});
+
+applyOptions(
+  program
+    .command('fiat-estimate')
+    .description('Get the current token price for provided byte value'),
+  [optionMap.byteCount, optionMap.currency],
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, fiatEstimate);
 });
 
 applyOptions(

--- a/src/cli/commands/fiatEstimate.ts
+++ b/src/cli/commands/fiatEstimate.ts
@@ -15,20 +15,14 @@
  */
 import { TurboFactory } from '../../node/index.js';
 import { FiatEstimateOptions } from '../types.js';
-import { configFromOptions, currencyFromOptions } from '../utils.js';
+import {
+  configFromOptions,
+  currencyFromOptions,
+  requiredByteCountFromOptions,
+} from '../utils.js';
 
 export async function fiatEstimate(options: FiatEstimateOptions) {
-  const byteCount =
-    options.byteCount !== undefined ? +options.byteCount : undefined;
-  if (
-    byteCount === undefined ||
-    byteCount <= 0 ||
-    isNaN(byteCount) ||
-    !Number.isInteger(byteCount)
-  ) {
-    throw new Error('Must provide a positive number for byte to get price.');
-  }
-
+  const byteCount = requiredByteCountFromOptions(options);
   const currency = currencyFromOptions(options) ?? 'usd';
 
   const turbo = TurboFactory.unauthenticated(configFromOptions(options));

--- a/src/cli/commands/fiatEstimate.ts
+++ b/src/cli/commands/fiatEstimate.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { TurboFactory } from '../../node/index.js';
-import { TokenPriceOptions } from '../types.js';
+import { FiatEstimateOptions } from '../types.js';
 import { configFromOptions, currencyFromOptions } from '../utils.js';
 
-export async function fiatEstimate(options: TokenPriceOptions) {
+export async function fiatEstimate(options: FiatEstimateOptions) {
   const byteCount =
     options.byteCount !== undefined ? +options.byteCount : undefined;
   if (

--- a/src/cli/commands/fiatEstimate.ts
+++ b/src/cli/commands/fiatEstimate.ts
@@ -31,7 +31,7 @@ export async function fiatEstimate(options: TokenPriceOptions) {
     );
   }
 
-  const currency = currencyFromOptions(options);
+  const currency = currencyFromOptions(options) ?? 'usd';
 
   const turbo = TurboFactory.unauthenticated(configFromOptions(options));
   const { fiatEstimate } = await turbo.getFiatEstimateForBytes({

--- a/src/cli/commands/fiatEstimate.ts
+++ b/src/cli/commands/fiatEstimate.ts
@@ -26,9 +26,7 @@ export async function fiatEstimate(options: TokenPriceOptions) {
     isNaN(byteCount) ||
     !Number.isInteger(byteCount)
   ) {
-    throw new Error(
-      'Must provide a positive number for byte to get price.\nFor example, to get the SOL price for 100 MiB use the following:\nturbo token-price --token solana --byte-count 1048576000',
-    );
+    throw new Error('Must provide a positive number for byte to get price.');
   }
 
   const currency = currencyFromOptions(options) ?? 'usd';

--- a/src/cli/commands/fiatEstimate.ts
+++ b/src/cli/commands/fiatEstimate.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TurboFactory } from '../../node/index.js';
+import { TokenPriceOptions } from '../types.js';
+import { configFromOptions, currencyFromOptions } from '../utils.js';
+
+export async function fiatEstimate(options: TokenPriceOptions) {
+  const byteCount =
+    options.byteCount !== undefined ? +options.byteCount : undefined;
+  if (
+    byteCount === undefined ||
+    byteCount <= 0 ||
+    isNaN(byteCount) ||
+    !Number.isInteger(byteCount)
+  ) {
+    throw new Error(
+      'Must provide a positive number for byte to get price.\nFor example, to get the SOL price for 100 MiB use the following:\nturbo token-price --token solana --byte-count 1048576000',
+    );
+  }
+
+  const currency = currencyFromOptions(options);
+
+  const turbo = TurboFactory.unauthenticated(configFromOptions(options));
+  const { fiatEstimate } = await turbo.getFiatEstimateForBytes({
+    byteCount,
+    currency,
+  });
+  const output = {
+    fiatEstimate,
+    byteCount,
+    message: `The current price estimate for ${byteCount} bytes is ${fiatEstimate} ${currency}`,
+  };
+  console.log(JSON.stringify(output, null, 2));
+}

--- a/src/cli/commands/fiatEstimate.ts
+++ b/src/cli/commands/fiatEstimate.ts
@@ -32,14 +32,13 @@ export async function fiatEstimate(options: TokenPriceOptions) {
   const currency = currencyFromOptions(options) ?? 'usd';
 
   const turbo = TurboFactory.unauthenticated(configFromOptions(options));
-  const { fiatEstimate } = await turbo.getFiatEstimateForBytes({
+  const result = await turbo.getFiatEstimateForBytes({
     byteCount,
     currency,
   });
   const output = {
-    fiatEstimate,
-    byteCount,
-    message: `The current price estimate for ${byteCount} bytes is ${fiatEstimate} ${currency}`,
+    ...result,
+    message: `The current price estimate for ${byteCount} bytes is ${result.amount} ${currency}`,
   };
   console.log(JSON.stringify(output, null, 2));
 }

--- a/src/cli/commands/price.ts
+++ b/src/cli/commands/price.ts
@@ -34,7 +34,7 @@ export async function price(options: PriceOptions) {
   if (currency !== undefined && type === 'bytes') {
     // User supplied --type bytes --currency <currency> --value <bytes>
     // This is a special case where we will provide a fiat estimate for the bytes value
-    return fiatEstimate(options);
+    return fiatEstimate({ ...options, byteCount: value });
   }
 
   const winc = await (async () => {

--- a/src/cli/commands/price.ts
+++ b/src/cli/commands/price.ts
@@ -19,7 +19,8 @@ import { TurboFactory } from '../../node/factory.js';
 import { fiatCurrencyTypes, isCurrency, tokenTypes } from '../../types.js';
 import { wincPerCredit } from '../constants.js';
 import { PriceOptions } from '../types.js';
-import { configFromOptions } from '../utils.js';
+import { configFromOptions, currencyFromOptions } from '../utils.js';
+import { fiatEstimate } from './fiatEstimate.js';
 
 export async function price(options: PriceOptions) {
   const value = options.value;
@@ -28,6 +29,13 @@ export async function price(options: PriceOptions) {
   }
 
   const type = options.type ?? 'bytes';
+
+  const currency = currencyFromOptions(options);
+  if (currency !== undefined && type === 'bytes') {
+    // User supplied --type bytes --currency <currency> --value <bytes>
+    // This is a special case where we will provide a fiat estimate for the bytes value
+    return fiatEstimate(options);
+  }
 
   const winc = await (async () => {
     if (isTokenType(type)) {

--- a/src/cli/commands/tokenPrice.ts
+++ b/src/cli/commands/tokenPrice.ts
@@ -17,21 +17,10 @@ import { isTokenType } from '../../common/index.js';
 import { TurboFactory } from '../../node/factory.js';
 import { tokenTypes } from '../../types.js';
 import { TokenPriceOptions } from '../types.js';
-import { configFromOptions } from '../utils.js';
+import { configFromOptions, requiredByteCountFromOptions } from '../utils.js';
 
 export async function tokenPrice(options: TokenPriceOptions) {
-  const byteCount =
-    options.byteCount !== undefined ? +options.byteCount : undefined;
-  if (
-    byteCount === undefined ||
-    byteCount <= 0 ||
-    isNaN(byteCount) ||
-    !Number.isInteger(byteCount)
-  ) {
-    throw new Error(
-      'Must provide a positive number for byte to get price.\nFor example, to get the SOL price for 100 MiB use the following:\nturbo token-price --token solana --byte-count 1048576000',
-    );
-  }
+  const byteCount = requiredByteCountFromOptions(options);
   const token = options.token;
 
   if (!isTokenType(token)) {

--- a/src/cli/commands/topUp.ts
+++ b/src/cli/commands/topUp.ts
@@ -20,7 +20,11 @@ import { TurboFactory } from '../../node/factory.js';
 import { fiatCurrencyTypes, isCurrency } from '../../types.js';
 import { sleep } from '../../utils/common.js';
 import { TopUpOptions } from '../types.js';
-import { addressOrPrivateKeyFromOptions, configFromOptions } from '../utils.js';
+import {
+  addressOrPrivateKeyFromOptions,
+  configFromOptions,
+  currencyFromOptions,
+} from '../utils.js';
 
 function openUrl(url: string) {
   if (process.platform === 'darwin') {
@@ -45,17 +49,7 @@ export async function topUp(options: TopUpOptions) {
     throw new Error('Must provide a --value to top up');
   }
 
-  const currency = (options.currency ?? 'usd').toLowerCase();
-
-  if (!isCurrency(currency)) {
-    throw new Error(
-      `Invalid fiat currency type ${currency}!\nPlease use one of these:\n${JSON.stringify(
-        fiatCurrencyTypes,
-        null,
-        2,
-      )}`,
-    );
-  }
+  const currency = currencyFromOptions(options) ?? 'usd';
 
   // TODO: Pay in CLI prompts via --cli options
 

--- a/src/cli/commands/topUp.ts
+++ b/src/cli/commands/topUp.ts
@@ -17,7 +17,6 @@ import { exec } from 'child_process';
 
 import { currencyMap } from '../../common/currency.js';
 import { TurboFactory } from '../../node/factory.js';
-import { fiatCurrencyTypes, isCurrency } from '../../types.js';
 import { sleep } from '../../utils/common.js';
 import { TopUpOptions } from '../types.js';
 import {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -67,6 +67,10 @@ export type TokenPriceOptions = GlobalOptions & {
   byteCount: string | undefined;
 };
 
+export type FiatEstimateOptions = TokenPriceOptions & {
+  currency: string | undefined;
+};
+
 export type PriceOptions = TokenPriceOptions & {
   value: string | undefined;
   type: string | undefined;

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -73,6 +73,7 @@ export type FiatEstimateOptions = TokenPriceOptions & {
 
 export type PriceOptions = TokenPriceOptions & {
   value: string | undefined;
+  currency: string | undefined;
   type: string | undefined;
 };
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -351,7 +351,7 @@ export function currencyFromOptions<
 >(options: T): Currency | undefined {
   const currency = options.currency?.toLowerCase();
 
-  if (currency !== undefined && !isCurrency(currency)) {
+  if (!isCurrency(currency)) {
     throw new Error(
       `Invalid fiat currency type ${currency}!\nPlease use one of these:\n${JSON.stringify(
         fiatCurrencyTypes,

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -18,12 +18,15 @@ import { Command, OptionValues } from 'commander';
 import { readFileSync, statSync } from 'fs';
 
 import {
+  Currency,
   TokenType,
   TurboAuthenticatedClient,
   TurboFactory,
   TurboUnauthenticatedConfiguration,
   defaultTurboConfiguration,
   developmentTurboConfiguration,
+  fiatCurrencyTypes,
+  isCurrency,
   isTokenType,
   privateKeyFromKyveMnemonic,
 } from '../node/index.js';
@@ -340,4 +343,22 @@ export function getTagsFromOptions(
   options: UploadOptions,
 ): { name: string; value: string }[] {
   return parseTags(options.tags);
+}
+
+export function currencyFromOptions<
+  O extends GlobalOptions & { currency?: string },
+>(options: O): Currency | undefined {
+  const currency = options.currency?.toLowerCase();
+
+  if (currency !== undefined && !isCurrency(currency)) {
+    throw new Error(
+      `Invalid fiat currency type ${currency}!\nPlease use one of these:\n${JSON.stringify(
+        fiatCurrencyTypes,
+        null,
+        2,
+      )}`,
+    );
+  }
+
+  return currency;
 }

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -50,11 +50,11 @@ export function exitWithErrorLog(error: unknown) {
   process.exit(1);
 }
 
-export async function runCommand<O extends OptionValues>(
+export async function runCommand<T extends OptionValues>(
   command: Command,
-  action: (options: O) => Promise<void>,
+  action: (options: T) => Promise<void>,
 ) {
-  const options = command.optsWithGlobals<O>();
+  const options = command.optsWithGlobals<T>();
 
   try {
     await action(options);
@@ -347,8 +347,8 @@ export function getTagsFromOptions(
 }
 
 export function currencyFromOptions<
-  O extends GlobalOptions & { currency?: string },
->(options: O): Currency | undefined {
+  T extends GlobalOptions & { currency?: string },
+>(options: T): Currency | undefined {
   const currency = options.currency?.toLowerCase();
 
   if (currency !== undefined && !isCurrency(currency)) {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -39,6 +39,7 @@ import { NoWalletProvidedError } from './errors.js';
 import {
   AddressOptions,
   GlobalOptions,
+  TokenPriceOptions,
   UploadFolderOptions,
   UploadOptions,
   WalletOptions,
@@ -361,4 +362,19 @@ export function currencyFromOptions<
   }
 
   return currency;
+}
+
+export function requiredByteCountFromOptions({
+  byteCount,
+}: TokenPriceOptions): number {
+  const byteCountValue = byteCount !== undefined ? +byteCount : undefined;
+  if (
+    byteCountValue === undefined ||
+    byteCountValue <= 0 ||
+    isNaN(byteCountValue) ||
+    !Number.isInteger(byteCountValue)
+  ) {
+    throw new Error('Must provide a positive number for byte count.');
+  }
+  return byteCountValue;
 }

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -370,9 +370,9 @@ export function requiredByteCountFromOptions({
   const byteCountValue = byteCount !== undefined ? +byteCount : undefined;
   if (
     byteCountValue === undefined ||
-    byteCountValue <= 0 ||
     isNaN(byteCountValue) ||
-    !Number.isInteger(byteCountValue)
+    !Number.isInteger(byteCountValue) ||
+    byteCountValue <= 0
   ) {
     throw new Error('Must provide a positive number for byte count.');
   }

--- a/src/common/payment.ts
+++ b/src/common/payment.ts
@@ -320,7 +320,7 @@ export class TurboUnauthenticatedPaymentService
 
     return {
       byteCount,
-      amount: formattedFiatPrice, // ensure number output
+      amount: formattedFiatPrice,
       currency,
       winc: wincPriceForGivenBytes[0].winc,
     };

--- a/src/common/payment.ts
+++ b/src/common/payment.ts
@@ -290,9 +290,6 @@ export class TurboUnauthenticatedPaymentService
     return response;
   }
 
-  //   WINC of X bytes / WINC of 1 GiB = fraction of a GiB
-  //   Then multiply by fiat cost of 1 GiB to get fiat cost of X bytes
-
   public async getFiatEstimateForBytes({
     byteCount,
     currency,

--- a/src/common/payment.ts
+++ b/src/common/payment.ts
@@ -301,9 +301,9 @@ export class TurboUnauthenticatedPaymentService
     const wincPriceForOneGiB = await this.getUploadCosts({
       bytes: [2 ** 30],
     });
-    // get the winc price for one thousand fiat units (10 USD, or 1000 JPY, etc.)
+    // get the winc price for one thousand fiat units (1,000 USD, or 100,000 JPY, etc.)
     const wincPriceForOneThousandFiatUnits = await this.getWincForFiat({
-      amount: { type: currency, amount: 1000 },
+      amount: { type: currency, amount: 1_000_00 },
     });
 
     const wincPriceForGivenBytes = new BigNumber(wincPriceForOneGiB[0].winc)
@@ -312,12 +312,12 @@ export class TurboUnauthenticatedPaymentService
 
     const wincPriceForOneFiatUnit = new BigNumber(
       wincPriceForOneThousandFiatUnits.winc,
-    ).dividedBy(new BigNumber(10));
+    ).dividedBy(new BigNumber(1_000)); // convert back to 1 USD or 100 JPY
 
     const fiatPriceForBytes = +wincPriceForGivenBytes
       .dividedBy(wincPriceForOneFiatUnit)
       .times(currency === 'jpy' ? 100 : 1) // Convert to zero decimal if currency is JPY
-      .toFixed(currency === 'jpy' ? 0 : 2); // Convert to string with 2 decimal places
+      .toFixed(currency === 'jpy' ? 0 : 2); // Convert to string with 2 decimal places, when not zero decimal currency
 
     return {
       byteCount,
@@ -325,6 +325,7 @@ export class TurboUnauthenticatedPaymentService
       currency,
     };
   }
+
   public async getTokenPriceForBytes({
     byteCount,
   }: {

--- a/src/common/payment.ts
+++ b/src/common/payment.ts
@@ -315,14 +315,12 @@ export class TurboUnauthenticatedPaymentService
     // Step 4: Format and round up so the estimated cost is always enough to cover the upload
     const formattedFiatPrice =
       currency === 'jpy'
-        ? fiatPriceForGivenBytes.integerValue(BigNumber.ROUND_CEIL) // no decimals for JPY
-        : fiatPriceForGivenBytes.decimalPlaces(2, BigNumber.ROUND_CEIL); // 2 decimal precision
-
-    const fiatPriceForBytes = formattedFiatPrice.toString();
+        ? +fiatPriceForGivenBytes.integerValue(BigNumber.ROUND_CEIL) // no decimals for JPY
+        : +fiatPriceForGivenBytes.decimalPlaces(2, BigNumber.ROUND_CEIL); // 2 decimal precision
 
     return {
       byteCount,
-      amount: +fiatPriceForBytes, // ensure number output
+      amount: formattedFiatPrice, // ensure number output
       currency,
       winc: wincPriceForGivenBytes[0].winc,
     };

--- a/src/common/payment.ts
+++ b/src/common/payment.ts
@@ -321,7 +321,7 @@ export class TurboUnauthenticatedPaymentService
 
     return {
       byteCount,
-      fiatEstimate: fiatPriceForBytes,
+      amount: fiatPriceForBytes,
       currency,
     };
   }

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -32,6 +32,7 @@ import {
   TurboCryptoFundResponse,
   TurboCurrenciesResponse,
   TurboDataItemSigner,
+  TurboFiatEstimateForBytesResponse,
   TurboFiatToArResponse,
   TurboFileFactory,
   TurboFundWithTokensParams,
@@ -171,6 +172,22 @@ export class TurboUnauthenticatedClient
     params: TurboWincForTokenParams,
   ): Promise<TurboWincForTokenResponse> {
     return this.paymentService.getWincForToken(params);
+  }
+
+  /**
+   * Determines the fiat estimate for a given byte count in a specific currency, including all Turbo cost adjustments and fees.
+   */
+  getFiatEstimateForBytes({
+    byteCount,
+    currency,
+  }: {
+    byteCount: number;
+    currency: Currency;
+  }): Promise<TurboFiatEstimateForBytesResponse> {
+    return this.paymentService.getFiatEstimateForBytes({
+      byteCount,
+      currency,
+    });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,7 +119,7 @@ export type TurboTokenPriceForBytesResponse = {
 
 export type TurboFiatEstimateForBytesResponse = {
   byteCount: number;
-  fiatEstimate: number;
+  amount: number;
   currency: Currency;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export const fiatCurrencyTypes = [
   'brl',
 ] as const;
 export type Currency = (typeof fiatCurrencyTypes)[number];
-export function isCurrency(currency: string): currency is Currency {
+export function isCurrency(currency: unknown): currency is Currency {
   return fiatCurrencyTypes.includes(currency as Currency);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export type TurboTokenPriceForBytesResponse = {
 export type TurboFiatEstimateForBytesResponse = {
   byteCount: number;
   amount: number;
+  winc: string;
   currency: Currency;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,12 @@ export type TurboTokenPriceForBytesResponse = {
   token: TokenType;
 };
 
+export type TurboFiatEstimateForBytesResponse = {
+  byteCount: number;
+  fiatEstimate: number;
+  currency: Currency;
+};
+
 export type TurboWincForFiatParams = {
   amount: CurrencyMap;
   nativeAddress?: NativeAddress;
@@ -674,6 +680,13 @@ export interface TurboUnauthenticatedPaymentServiceInterface {
   getWincForToken(
     params: TurboWincForTokenParams,
   ): Promise<TurboWincForTokenResponse>;
+  getFiatEstimateForBytes({
+    byteCount,
+    currency,
+  }: {
+    byteCount: number;
+    currency: Currency;
+  }): Promise<TurboFiatEstimateForBytesResponse>;
   getTokenPriceForBytes({
     byteCount,
   }: {

--- a/tests/turbo.node.test.ts
+++ b/tests/turbo.node.test.ts
@@ -33,6 +33,7 @@ import {
   NativeAddress,
   TokenType,
   TurboSigner,
+  fiatCurrencyTypes,
   tokenTypes,
 } from '../src/types.js';
 import { signerFromKyveMnemonic } from '../src/utils/common.js';
@@ -347,9 +348,24 @@ describe('Node environment', () => {
       assert.equal(equivalentWincTokenAmount, '100000');
       assert.equal(fees.length, 1);
     });
+    const oneHundredMiBInBytes = 1024 * 1024 * 100; // 100 MiB
+
+    describe.only('getFiatEstimateForBytes()', async () => {
+      for (const fiat of fiatCurrencyTypes) {
+        it(`should return the correct fiat estimate for ${fiat} for 100 MiB`, async () => {
+          const { amount, byteCount: bytesResult } =
+            await turbo.getFiatEstimateForBytes({
+              byteCount: oneHundredMiBInBytes,
+              currency: fiat,
+            });
+          assert.ok(amount !== undefined);
+          assert.equal(bytesResult, oneHundredMiBInBytes);
+          assert.ok(typeof +amount === 'number');
+        });
+      }
+    });
 
     describe('getTokenPriceForBytes()', async () => {
-      const bytes = 1024 * 1024 * 100; // 100 MiB
       for (const token of tokenTypes) {
         it(`should return the correct token price for the given bytes for ${token}`, async () => {
           const { tokenPrice, byteCount: bytesResult } =
@@ -357,10 +373,10 @@ describe('Node environment', () => {
               ...turboTestEnvConfigurations,
               token,
             }).getTokenPriceForBytes({
-              byteCount: bytes,
+              byteCount: oneHundredMiBInBytes,
             });
           assert.ok(tokenPrice !== undefined);
-          assert.equal(bytesResult, bytes);
+          assert.equal(bytesResult, oneHundredMiBInBytes);
           assert.ok(typeof +tokenPrice === 'number');
         });
       }

--- a/tests/turbo.node.test.ts
+++ b/tests/turbo.node.test.ts
@@ -350,7 +350,7 @@ describe('Node environment', () => {
     });
     const oneHundredMiBInBytes = 1024 * 1024 * 100; // 100 MiB
 
-    describe.only('getFiatEstimateForBytes()', async () => {
+    describe('getFiatEstimateForBytes()', async () => {
       for (const fiat of fiatCurrencyTypes) {
         it(`should return the correct fiat estimate for ${fiat} for 100 MiB`, async () => {
           const { amount, byteCount: bytesResult } =


### PR DESCRIPTION
this PR adds `fiat-estimate` command with optional `--currency` and required `--byte-count` options. it also adds `--currency` option to `price` command. when currency exists and price --type is bytes, we will use the fiatEstimate special path. this will result in two API calls -- could iterate this into the service level

In the below examples we compare the price estimate of the workflow to the payment API. On the bytes request we get the same winc result as expected. on the fiat estimates we get the amount of winc a user would receive the fiat. those values are expected to be close but not exact because fiat payments can only get fractional down its base value

400,000 bytes example:

```sh
> yarn build:esm && node lib/esm/cli/cli.js fiat-estimate --currency jpy --byte-count 400000
{
  "byteCount": 400000,
  "amount": 2,
  "currency": "jpy",
  "winc": "902338689",
  "message": "The current price estimate for 400000 bytes is 2 jpy"
}

# API winc price for bytes
> curl https://payment.ardrive.dev/v1/price/bytes/400000                                    
{"winc":"902338689","adjustments":[]}%                                                                    

# API winc price for 2 jpy
> curl https://payment.ardrive.dev/v1/price/jpy/2       
{"winc":"2256954240","adjustments":[],"fees":[{"adjustmentAmount":0,"currencyType":"jpy","description":"Inclusive usage fee on all payments to cover infrastructure costs and payment provider fees.","name":"Turbo Infrastructure Fee","operator":"multiply","operatorMagnitude":0.766}],"actualPaymentAmount":2,"quotedPaymentAmount":2}%                                     
```

760 MiB example:

```sh
> yarn build:esm && node lib/esm/cli/cli.js fiat-estimate --currency usd --byte-count 796917760
{
  "byteCount": 796917760,
  "amount": 14.34,
  "currency": "usd",
  "winc": "1797724315557",
  "message": "The current price estimate for 796917760 bytes is 14.34 usd"
}

# API price for bytes:
> curl https://payment.ardrive.dev/v1/price/bytes/796917760      
{"winc":"1797724315557","adjustments":[]}%                                                                


# API price for USD
> curl https://payment.ardrive.dev/v1/price/usd/1434                                           
{"winc":"1797054009820","adjustments":[],"fees":[{"adjustmentAmount":-336,"currencyType":"usd","description":"Inclusive usage fee on all payments to cover infrastructure costs and payment provider fees.","name":"Turbo Infrastructure Fee","operator":"multiply","operatorMagnitude":0.766}],"actualPaymentAmount":1434,"quotedPaymentAmount":1434}%  
```


New price --currency example:
```sh
> yarn build:esm && node lib/esm/cli/cli.js price --type bytes --value 102400 --currency usd
{
  "byteCount": 102400,
  "amount": 0.01,
  "currency": "usd",
  "winc": "229108711",
  "message": "The current price estimate for 102400 bytes is 0.01 usd"
}
```