### PR TITLE
fixed small bug that prevents retrieving correct relative paths under windows

### DIFF
--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -15,7 +15,7 @@
  */
 import { createReadStream, promises, statSync } from 'fs';
 import { lookup } from 'mime-types';
-import { join } from 'path';
+import { join, normalize } from 'path';
 import { Readable } from 'stream';
 
 import {
@@ -98,7 +98,7 @@ export class TurboAuthenticatedUploadService extends TurboAuthenticatedBaseUploa
       folderPath = folderPath.slice(2);
     }
 
-    const relativePath = file.replace(folderPath + '/', '');
+    const relativePath = file.replace(normalize(folderPath + '/'), '');
     return relativePath;
   }
 


### PR DESCRIPTION
hey there!

While playing around with the sdk and trying to upload an entire folder, I noticed that the relative paths in the manifest are not working as they are intended under windows, as windows is using backslashes instead of normal slashes for paths. This causes the getRelativePath function to return the absolute path instead of the relative path. I think/hope I fixed it in an elegant manner, let me know!