### PR TITLE
Another optimization regarding file/folder paths

### DIFF
--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -15,7 +15,7 @@
  */
 import { createReadStream, promises, statSync } from 'fs';
 import { lookup } from 'mime-types';
-import { join, normalize } from 'path';
+import { join } from 'path';
 import { Readable } from 'stream';
 
 import {
@@ -56,6 +56,8 @@ export class TurboAuthenticatedUploadService extends TurboAuthenticatedBaseUploa
     for (const file of files) {
       if (file === '.DS_Store') {
         continue;
+      } else if (file.includes('\\')){
+        throw('Files/Sub-folders with backslashes are not supported');
       }
       const absoluteFilePath = join(folderPath, file);
       const stat = await promises.stat(absoluteFilePath);
@@ -97,7 +99,8 @@ export class TurboAuthenticatedUploadService extends TurboAuthenticatedBaseUploa
     if (folderPath.startsWith('./')) {
       folderPath = folderPath.slice(2);
     }
-    const relativePath = file.replace(normalize(folderPath + '/'), '');
+    let relativePath = file.replace(join(folderPath + '/'), '');
+    relativePath = relativePath.replace(/\\/g,'/'); //only needed for windows sub-folders
     return relativePath;
   }
 


### PR DESCRIPTION
hello again! :)

I thought about the fix yesterday again, and figured out that sub-folders are still "broken" for windows, because the getRelativePath function would still return backslashes for them, instead of regular ones. This would then make the file(s) inaccessible as you can't navigate to backslash folders with a browser.

This in mind, I also thought that it would make sense to not support files/sub-directories at all that contain backslashes (they are technically possible under unix), as these, as well can not be accessed thru the browser after being uploaded.

I really hope this is useful for you