### PR TITLE
fix(web): convert ReadableStream to Blob for all browser environments

### DIFF
--- a/packages/turbo-sdk/src/common/http.test.ts
+++ b/packages/turbo-sdk/src/common/http.test.ts
@@ -1,0 +1,109 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { TurboHTTPService, defaultRetryConfig } from './http.js';
+import { Logger } from './logger.js';
+
+function makeService() {
+  return new TurboHTTPService({
+    url: 'https://example.com',
+    retryConfig: defaultRetryConfig(Logger.default),
+    logger: Logger.default,
+  });
+}
+
+function makeReadableStream(content: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(content));
+      controller.close();
+    },
+  });
+}
+
+// NOTE: isBrowser is a module-level const evaluated at load time, so browser-path
+// behavior (ReadableStream → Blob) cannot be simulated in Node.js unit tests.
+// That path is exercised by the web integration tests (tests/turbo.web.test.ts).
+describe('TurboHTTPService.post — toFetchBody (Node.js environment)', () => {
+  let capturedInput: RequestInfo | URL | undefined;
+  let capturedInit: RequestInit | undefined;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    capturedInput = undefined;
+    capturedInit = undefined;
+    originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      capturedInput = input;
+      capturedInit = init;
+      return new Response(JSON.stringify({ id: 'test-id' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sends a ReadableStream body with duplex: "half" in Node.js environment', async () => {
+    const service = makeService();
+    const stream = makeReadableStream('hello world');
+
+    await service.post({
+      endpoint: '/tx/arweave',
+      data: stream,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+
+    assert.ok(capturedInit, 'fetch should have been called');
+    assert.ok(
+      capturedInit!.body instanceof ReadableStream,
+      `Expected ReadableStream body in Node.js env, got: ${capturedInit!.body?.constructor?.name}`,
+    );
+    assert.equal(
+      // @ts-ignore — duplex is not in standard RequestInit types but is set by the SDK
+      capturedInit!.duplex,
+      'half',
+      'duplex should be "half" for Node.js streaming',
+    );
+  });
+
+  it('sends a Uint8Array body for Buffer data in Node.js environment', async () => {
+    const service = makeService();
+    const buffer = Buffer.from('buffered content');
+
+    await service.post({
+      endpoint: '/tx/arweave',
+      data: buffer,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+
+    assert.ok(capturedInit, 'fetch should have been called');
+    assert.ok(
+      capturedInit!.body instanceof Uint8Array,
+      `Expected Uint8Array body for Buffer in Node.js env, got: ${capturedInit!.body?.constructor?.name}`,
+    );
+  });
+
+  it('posts to the correct URL', async () => {
+    const service = makeService();
+    const stream = makeReadableStream('data');
+
+    await service.post({
+      endpoint: '/tx/arweave',
+      data: stream,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+
+    assert.ok(
+      String(capturedInput).endsWith('/tx/arweave'),
+      `Expected URL to end with /tx/arweave, got: ${capturedInput}`,
+    );
+  });
+});

--- a/packages/turbo-sdk/src/common/http.ts
+++ b/packages/turbo-sdk/src/common/http.ts
@@ -265,13 +265,17 @@ async function toFetchBody(
 ): Promise<{ body: BodyInit; duplex?: 'half' }> {
   // Handle ReadableStream
   if (data instanceof ReadableStream) {
-    if (isFirefoxOrSafari()) {
-      // Convert stream to blob for Firefox/Safari
+    if (isBrowser) {
+      // Convert to Blob for all browser environments.
+      // Chrome's streaming fetch ({ body: ReadableStream, duplex: 'half' }) fails with
+      // "ReadableStream is disturbed" when the event-tracking wrapper locks the stream
+      // via getReader() before fetch consumes it. Firefox/Safari had the same issue and
+      // already used Blob conversion — this extends that fix to Chrome and all others.
       const blob = await new Response(data).blob();
       return { body: blob };
     }
 
-    // Chrome/Edge/Opera support streaming
+    // Node.js: use streaming with duplex: 'half'
     return { body: data, duplex: 'half' };
   }
 
@@ -290,13 +294,4 @@ async function toFetchBody(
   return { body: Uint8Array.from(data) };
 }
 
-function isFirefoxOrSafari(): boolean {
-  if (!isBrowser) return false;
-  const ua = navigator.userAgent;
-  return (
-    ua.includes('Firefox') ||
-    (ua.includes('Safari') &&
-      !ua.includes('Chrome') &&
-      !ua.includes('Chromium'))
-  );
-}
+


### PR DESCRIPTION
## Context
`uploadFile()` fails in browser environments (Chrome + Next.js/Turbopack) with:

```
Failed to upload file after 6 attempts
Failed to execute 'fetch' on 'Window': The provided ReadableStream is disturbed
```

As reported here in #396.

## Root cause

`createReadableStreamWithEvents` in `events.ts` calls `originalStream.getReader()` inside the `start()` callback, which runs immediately when the wrapper stream is constructed. Chrome's fetch is stricter than Firefox/Safari — it considers the stream already "disturbed" when `{ body: ReadableStream, duplex: 'half' }` is passed to fetch.

## New Fix

`toFetchBody` in `http.ts` already converted `ReadableStream → Blob` for Firefox/Safari via `isFirefoxOrSafari()`. This PR extends that same conversion to all browser environments by replacing the guard with `isBrowser`, and removes the now-unused `isFirefoxOrSafari` function.

## Testing

- Reproduced the bug on Chrome with Next.js 15 + Turbopack (exact environment from #396)
- Verified fix resolves the error on Chrome, Firefox, Safari, and Arc Browser (the browser that I use)
- Added unit tests for `TurboHTTPService.post` covering the Node.js fetch body path
- All 50 unit tests pass