### PR TITLE
feat(signer): send x-signature-type in signed request headers

### DIFF
--- a/packages/turbo-sdk/src/common/signer.test.ts
+++ b/packages/turbo-sdk/src/common/signer.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ArweaveSigner,
+  EthereumSigner,
+  HexSolanaSigner,
+} from '@dha-team/arbundles';
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { testEthWallet, testJwk, testSolWallet } from '../../tests/helpers.js';
+import { TurboNodeSigner } from '../node/signer.js';
+import { TokenType, TurboSigner } from '../types.js';
+
+describe('TurboDataItemAbstractSigner.generateSignedRequestHeaders', () => {
+  // arbundles SignatureConfig: ARWEAVE=1, ETHEREUM=3, SOLANA=4
+  const cases: {
+    name: string;
+    token: TokenType;
+    signer: TurboSigner;
+    expectedSignatureType: string;
+  }[] = [
+    {
+      name: 'arweave',
+      token: 'arweave',
+      signer: new ArweaveSigner(testJwk),
+      expectedSignatureType: '1',
+    },
+    {
+      name: 'ethereum',
+      token: 'ethereum',
+      signer: new EthereumSigner(testEthWallet),
+      expectedSignatureType: '3',
+    },
+    {
+      name: 'solana',
+      token: 'solana',
+      signer: new HexSolanaSigner(testSolWallet),
+      expectedSignatureType: '4',
+    },
+  ];
+
+  for (const { name, token, signer, expectedSignatureType } of cases) {
+    it(`emits x-signature-type for a ${name} signer`, async () => {
+      const turboSigner = new TurboNodeSigner({ signer, token });
+      const headers = await turboSigner.generateSignedRequestHeaders();
+
+      // The header must match the signer's own signatureType...
+      assert.equal(
+        headers['x-signature-type'],
+        signer.signatureType.toString(),
+      );
+      // ...and equal the expected arbundles SignatureConfig value.
+      assert.equal(headers['x-signature-type'], expectedSignatureType);
+
+      // The pre-existing headers are still present and well-formed.
+      assert.ok(headers['x-public-key']?.length > 0);
+      assert.ok(headers['x-nonce']?.length > 0);
+      assert.ok(headers['x-signature']?.length > 0);
+    });
+  }
+});

--- a/packages/turbo-sdk/src/common/signer.ts
+++ b/packages/turbo-sdk/src/common/signer.ts
@@ -133,6 +133,10 @@ export abstract class TurboDataItemAbstractSigner
       'x-public-key': publicKey,
       'x-nonce': nonce,
       'x-signature': toB64Url(Buffer.from(signature)),
+      // Advertise the signature scheme so the service verifies with the right
+      // algorithm. Absent this, the server defaults to Arweave and every
+      // non-Arweave signed request (Ethereum, Solana, …) fails verification.
+      'x-signature-type': this.signer.signatureType.toString(),
     };
   }
 

--- a/packages/turbo-sdk/src/common/signer.ts
+++ b/packages/turbo-sdk/src/common/signer.ts
@@ -47,6 +47,7 @@ import {
   TurboFileFactory,
   TurboLogger,
   TurboSignedDataItemFactory,
+  TurboSignedRequestHeaders,
   TurboSigner,
   WalletAdapter,
   isEthereumWalletAdapter,
@@ -124,7 +125,7 @@ export abstract class TurboDataItemAbstractSigner
     }
   }
 
-  public async generateSignedRequestHeaders() {
+  public async generateSignedRequestHeaders(): Promise<TurboSignedRequestHeaders> {
     const nonce = randomBytes(16).toString('hex');
     const buffer = Buffer.from(nonce);
     const signature = await this.signer.sign(Uint8Array.from(buffer));

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -504,6 +504,10 @@ export type TurboSignedRequestHeaders = {
   'x-public-key': string;
   'x-nonce': string;
   'x-signature': string;
+  // arbundles SignatureConfig value (e.g. ARWEAVE=1, ETHEREUM=3, SOLANA=4).
+  // Lets the service select the correct signature-verification scheme;
+  // without it the server cannot distinguish a non-Arweave signed request.
+  'x-signature-type': string;
 };
 
 type TurboAuthConfiguration = {

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -507,7 +507,10 @@ export type TurboSignedRequestHeaders = {
   // arbundles SignatureConfig value (e.g. ARWEAVE=1, ETHEREUM=3, SOLANA=4).
   // Lets the service select the correct signature-verification scheme;
   // without it the server cannot distinguish a non-Arweave signed request.
-  'x-signature-type': string;
+  // Optional on the type for backwards compatibility (so existing consumers
+  // that construct this type directly keep compiling); `generateSignedRequestHeaders`
+  // always populates it at runtime.
+  'x-signature-type'?: string;
 };
 
 type TurboAuthConfiguration = {


### PR DESCRIPTION
## Summary

`generateSignedRequestHeaders()` emitted only `x-public-key` / `x-nonce` / `x-signature`. A service receiving the request had no way to know which signature scheme to verify with, so it defaults to **Arweave** — and **every non-Arweave signed request (Ethereum, Solana, …) fails verification.**

This adds the missing `x-signature-type` header, set to the arbundles `SignatureConfig` value of the active signer (`ARWEAVE=1`, `ETHEREUM=3`, `SOLANA=4`), and adds the field to the `TurboSignedRequestHeaders` type.

## Why

Without the type header, only Arweave wallets can authenticate signed credit/balance/price routes through the SDK. This unblocks **Ethereum and Solana** wallets on those routes (e.g. balance lookups and, with the corresponding service support, ArNS purchases paid with credits).

## Changes

- `common/signer.ts` — emit `'x-signature-type': this.signer.signatureType.toString()` from `generateSignedRequestHeaders()`.
- `types.ts` — add `'x-signature-type': string` to `TurboSignedRequestHeaders`.
- `common/signer.test.ts` — new unit test asserting the header is emitted and matches both the signer's own `signatureType` and the expected value across Arweave / Ethereum / Solana signers.

## What already lines up (no change needed)

The signed bytes (UTF-8 of the nonce), public-key encoding (`toB64Url` of raw key), and signature encoding (b64url) are unchanged — this only **advertises** the scheme so the verifier can pick the right algorithm.

## Test plan

- `node --test src/common/signer.test.ts` → 3/3 pass
- `tsc --noEmit` → clean
- eslint + prettier → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mqXHvaS8MdXvuWXCvDcnn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signed requests now include a signature type header for supported wallets, improving compatibility across signing methods.
* **Bug Fixes**
  * Added coverage to ensure signed request headers include all required values and match the expected signature type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->