### PR TITLE
feat(arns): buy/extend/upgrade ArNS names paying with Turbo credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Welcome to the `@ardrive/turbo-sdk`! This SDK provides functionality for interac
   - [TurboFactory](#turbofactory)
   - [TurboUnauthenticatedClient](#turbounauthenticatedclient)
   - [TurboAuthenticatedClient](#turboauthenticatedclient)
+- [ArNS Names (paid with Turbo Credits)](#arns-names-paid-with-turbo-credits)
+  - [Purchase lifecycle](#purchase-lifecycle)
+  - [Connecting a signer](#connecting-a-signer)
+  - [Pricing a name](#pricing-a-name)
+  - [Buying a name](#buying-a-name)
+  - [Extend, increase undernames, upgrade](#extend-increase-undernames-upgrade)
+  - [Polling purchase status](#polling-purchase-status)
+  - [ANT custody: transfer & manage records](#ant-custody-transfer--manage-records)
+  - [Error handling & retries](#error-handling--retries)
+  - [Dependency note (@solana/codecs)](#dependency-note-solanacodecs)
 - [Signers](#signers)
   - [Arweave](#arweave)
   - [Ethereum](#ethereum)
@@ -984,6 +994,213 @@ const { givenApprovals, receivedApprovals } =
     userAddress: '2cor...VUa',
   });
 ```
+
+## ArNS Names (paid with Turbo Credits)
+
+The authenticated client can buy and manage [ArNS](https://ar.io/arns) names and pay for them with the connected wallet's **Turbo Credits** — no on-chain ARIO token balance required. The bundler performs the on-chain ARIO purchase on your behalf and debits your credit balance.
+
+- **Purchases / management (charge credits):** `getArNSPriceForName`, `purchaseArNSName` (+ the intent wrappers `buyArNSName`, `extendArNSLease`, `increaseArNSUndernameLimit`, `upgradeArNSName`), and `getArNSPurchaseStatus`.
+- **ANT custody:** `transferArNSAnt`, `setArNSRecord`, `removeArNSRecord`.
+
+> Reads such as resolving a name or fetching a record are provided by [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk) and are intentionally out of scope for this client.
+
+### Purchase lifecycle
+
+Every purchase is identified by a client-minted **UUID `nonce`**. The nonce is:
+
+1. **Signed** by your wallet and sent to the bundler (proving intent).
+2. The **idempotency key** for the purchase.
+3. The **status-lookup key** — poll `getArNSPurchaseStatus({ nonce })` until the purchase reaches a terminal state.
+
+`purchaseArNSName` returns the `nonce` on **both** `response.nonce` and `response.purchaseReceipt.nonce`. A purchase is **terminal-success** once its status carries a `messageId` (the Solana transaction id of the on-chain ArNS write) and **terminal-failure** once it carries a `failedDate`.
+
+```
+buyArNSName() ──▶ POST /arns/purchase  ──▶ { nonce, purchaseReceipt, arioWriteResult }
+                                                     │
+                    poll getArNSPurchaseStatus({ nonce })
+                                                     │
+              ┌──────────────────────────────────────┴───────────────────────┐
+        messageId present (success)                                 failedDate present (failure)
+```
+
+### Connecting a signer
+
+ArNS purchases are authenticated per wallet. Construct the client with `TurboFactory.authenticated` using any supported identity — the credit balance is keyed to that wallet's native address:
+
+```typescript
+import { TurboFactory } from '@ardrive/turbo-sdk';
+
+// Arweave
+const turbo = TurboFactory.authenticated({ privateKey: arweaveJwk });
+
+// Ethereum
+const turbo = TurboFactory.authenticated({
+  privateKey: ethHexadecimalPrivateKey,
+  token: 'ethereum',
+});
+
+// Solana — request nonces are signed with arbundles' HexSolanaSigner (ed25519)
+const turbo = TurboFactory.authenticated({
+  privateKey: bs58SolanaSecretKey,
+  token: 'solana',
+});
+```
+
+### Pricing a name
+
+`getArNSPriceForName(params)` returns the cost in both Turbo Credits (`winc`) and `mARIO`. Params are validated client-side per intent (a `ProvidedInputError` is thrown for missing/invalid fields before any request is sent).
+
+```typescript
+const { winc, mARIO } = await turbo.getArNSPriceForName({
+  intent: 'Buy-Name',
+  name: 'my-name',
+  type: 'lease', // 'lease' | 'permabuy'
+  years: 1, // required for leases
+  processId: 'ant-process-id', // the ANT the name resolves to
+});
+```
+
+### Buying a name
+
+`buyArNSName(params)` is the `Buy-Name` convenience wrapper over `purchaseArNSName`. Optionally, `paidBy` delegates the charge to one or more addresses that have shared credits with you.
+
+```typescript
+// Lease for 1 year
+const receipt = await turbo.buyArNSName({
+  name: 'my-name',
+  type: 'lease',
+  years: 1,
+  processId: 'ant-process-id',
+});
+
+// Permanent buy, charged to a delegated payer
+const receipt = await turbo.buyArNSName({
+  name: 'my-name',
+  type: 'permabuy',
+  processId: 'ant-process-id',
+  paidBy: '<delegated-payer-address>', // or an array of addresses
+});
+
+console.log(receipt.nonce); // capture this to poll status / retry idempotently
+```
+
+Full runnable example (buy → poll to terminal):
+
+```typescript
+import { InsufficientCreditsError, TurboFactory } from '@ardrive/turbo-sdk';
+
+const turbo = TurboFactory.authenticated({ privateKey: arweaveJwk });
+
+async function buyName() {
+  try {
+    const { nonce } = await turbo.buyArNSName({
+      name: 'my-name',
+      type: 'lease',
+      years: 1,
+      processId: 'ant-process-id',
+    });
+
+    // Poll until terminal (success => messageId, failure => failedDate)
+    for (;;) {
+      const status = await turbo.getArNSPurchaseStatus({ nonce });
+      if (status.messageId) {
+        console.log('Purchased. ArNS write tx:', status.messageId);
+        return status;
+      }
+      if (status.failedDate) {
+        throw new Error(`Purchase failed at ${status.failedDate}`);
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  } catch (err) {
+    if (err instanceof InsufficientCreditsError) {
+      console.error('Not enough Turbo Credits — top up and retry.');
+    }
+    throw err;
+  }
+}
+```
+
+### Extend, increase undernames, upgrade
+
+Each intent has a typed wrapper that enforces its required fields:
+
+```typescript
+// Extend an existing lease by N years
+await turbo.extendArNSLease({ name: 'my-name', years: 2 });
+
+// Increase the undername limit
+await turbo.increaseArNSUndernameLimit({ name: 'my-name', increaseQty: 5 });
+
+// Upgrade a lease to a permanent name
+await turbo.upgradeArNSName({ name: 'my-name' });
+```
+
+All of them return the same `{ nonce, purchaseReceipt, arioWriteResult }` shape as `buyArNSName` and are polled the same way. `purchaseArNSName(params)` is the general form if you prefer to pass `intent` explicitly.
+
+### Polling purchase status
+
+`getArNSPurchaseStatus({ nonce })` is available on both the authenticated and unauthenticated clients:
+
+```typescript
+const status = await turbo.getArNSPurchaseStatus({ nonce });
+// status.messageId  -> present on terminal success (Solana ArNS write tx id)
+// status.failedDate -> present on terminal failure
+```
+
+### ANT custody: transfer & manage records
+
+Turbo can custody the ANT (Metaplex Core asset) backing your name. These methods let you take self-custody or manage resolution records. Each is authenticated with an **action-bound, single-use signature**: the wallet signs a canonical `arns\n<action>\n<fields…>` message plus the UUID nonce, so a captured signature can't be replayed against a different operation.
+
+```typescript
+// Self-custody exit: move the ANT to a Solana pubkey you control
+await turbo.transferArNSAnt({
+  antId: 'ant-id',
+  target: 'your-solana-pubkey',
+});
+
+// Set a resolution record (undername defaults to '@')
+await turbo.setArNSRecord({
+  antId: 'ant-id',
+  undername: 'docs', // omit for the apex '@' record
+  transactionId: 'arweave-tx-id',
+  ttlSeconds: 900,
+});
+
+// Remove a resolution record
+await turbo.removeArNSRecord({ antId: 'ant-id', undername: 'docs' });
+```
+
+### Error handling & retries
+
+- **`InsufficientCreditsError`** (HTTP `402`) — the wallet (or delegated payer) doesn't hold enough Turbo Credits. Prompt the user to top up, then retry. It exposes `.status === 402` and is exported from the package root.
+- **`ProvidedInputError`** — thrown client-side (before any network call) when required per-intent params are missing/invalid (e.g. a lease `Buy-Name` without `years`, or `Extend-Lease` without a positive `years`).
+- **`FailedRequestError`** — any other non-2xx response; inspect `.status` (e.g. `401`, `503`).
+
+**Idempotency / retry guidance:** the `nonce` is the idempotency key. Capture `response.nonce` up front; if the network drops after the request is sent, re-poll `getArNSPurchaseStatus({ nonce })` rather than blindly re-buying. On a `402`, top up and issue a fresh purchase — the captured nonce still lets you reconcile status.
+
+```typescript
+import { InsufficientCreditsError } from '@ardrive/turbo-sdk';
+
+try {
+  await turbo.buyArNSName({ name, type: 'permabuy', processId });
+} catch (err) {
+  if (err instanceof InsufficientCreditsError) {
+    // surface a top-up flow to the user
+  } else {
+    throw err;
+  }
+}
+```
+
+### Dependency note (@solana/codecs)
+
+ArNS/ARIO support pulls in `@solana/spl-token`, whose transitive `@solana/spl-token-metadata@0.1.6` imports `getDataEnumCodec` from `@solana/codecs@2.0.0-rc.1`. In `@solana/codecs@3+` that export was renamed to `getDiscriminatedUnionCodec`. If a web app **dedupes** `@solana/codecs` to `6.x` for its whole dependency graph, `spl-token-metadata`'s `getDataEnumCodec` import resolves to a version that no longer exports it, and the build breaks.
+
+There is no single codecs version that satisfies both `spl-token-metadata` (needs the old `getDataEnumCodec`) and `@solana/kit` (needs `5.x`), and `spl-token-metadata` has no release that uses the renamed API — so the fix belongs at the app's dependency-resolution layer, **not** at symbol-aliasing:
+
+- **Recommended:** stop deduping `@solana/codecs` so `@solana/spl-token-metadata` keeps its own nested `2.0.0-rc.1` copy. In Vite, ensure `@solana/codecs` is **not** in `resolve.dedupe`; with pnpm/yarn, allow the nested version (avoid a hoisted-to-`6.x` override for that subtree). This is cleaner than the `getDataEnumCodec → getDiscriminatedUnionCodec` alias plugin some apps use today, and removes the need for that shim.
+- If you must keep a single hoisted codecs copy, a build-time alias mapping `getDataEnumCodec` to `getDiscriminatedUnionCodec` remains the fallback.
 
 ## Signers
 

--- a/README.md
+++ b/README.md
@@ -1064,8 +1064,20 @@ const { winc, mARIO } = await turbo.getArNSPriceForName({
 
 `buyArNSName(params)` is the `Buy-Name` convenience wrapper over `purchaseArNSName`. Optionally, `paidBy` delegates the charge to one or more addresses that have shared credits with you.
 
+**`processId` is optional**, and it selects who owns the ANT (Metaplex Core asset) the name resolves to:
+
+- **Omit `processId`** → **Turbo custodial provisioning** (Model A): Turbo spawns and _owns_ the ANT for you. You can take self-custody later via `transferArNSAnt` (see "ANT custody" below).
+- **Supply `processId`** → **user-owned ANT** (Model B): the name points at an ANT you already own; Turbo never takes custody.
+
 ```typescript
-// Lease for 1 year
+// Custodial lease (Model A): omit processId → Turbo owns the ANT
+const receipt = await turbo.buyArNSName({
+  name: 'my-name',
+  type: 'lease',
+  years: 1,
+});
+
+// Lease against your own ANT (Model B) for 1 year
 const receipt = await turbo.buyArNSName({
   name: 'my-name',
   type: 'lease',
@@ -1077,7 +1089,7 @@ const receipt = await turbo.buyArNSName({
 const receipt = await turbo.buyArNSName({
   name: 'my-name',
   type: 'permabuy',
-  processId: 'ant-process-id',
+  processId: 'ant-process-id', // optional — omit for Turbo custodial provisioning
   paidBy: '<delegated-payer-address>', // or an array of addresses
 });
 
@@ -1795,13 +1807,19 @@ Command Options:
 - `--name <name>` - ArNS name to buy
 - `--type <lease|permabuy>` - Purchase type
 - `--years <years>` - Lease duration in years (required for `lease`)
-- `--process-id <processId>` - ANT process ID the name resolves to
+- `--process-id <processId>` - ANT process ID the name resolves to. **Optional**: omit it for Turbo custodial provisioning (Turbo spawns + owns the ANT — Model A; take self-custody later via `transfer-arns-ant`); supply it to point the name at a user-owned ANT (Model B).
 - `--paid-by <paidBy...>` - Optional delegated payer address(es) whose credits cover the purchase
 
 e.g:
 
 ```shell
-# Lease a name for 1 year with an Arweave wallet against a local bundler
+# Custodial lease (Model A): omit --process-id → Turbo provisions + owns the ANT
+turbo buy-arns-name --name my-name --type lease --years 1 \
+  --wallet-file ../path/to/my/wallet.json --payment-url http://localhost:4001
+```
+
+```shell
+# Lease a name for 1 year against your own ANT (Model B) with an Arweave wallet
 turbo buy-arns-name --name my-name --type lease --years 1 \
   --process-id agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA \
   --wallet-file ../path/to/my/wallet.json --payment-url http://localhost:4001

--- a/README.md
+++ b/README.md
@@ -1744,6 +1744,185 @@ e.g:
 turbo list-shares --address 2cor...VUa --wallet-file ../path/to/my/wallet
 ```
 
+#### ArNS Commands
+
+Buy and manage [ArNS](#arns-names-paid-with-turbo-credits) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-purchase-status`.
+
+All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. The write commands (`buy-arns-name`, `extend-arns-lease`, `increase-arns-undernames`, `upgrade-arns-name`, `transfer-arns-ant`, `set-arns-record`, `remove-arns-record`) require a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`); the read-only commands (`arns-price`, `arns-purchase-status`) do not.
+
+When a purchase is rejected for lack of Turbo Credits (HTTP 402), the command prints a clear "insufficient credits — top up your balance and retry" message and exits non-zero.
+
+##### `arns-price`
+
+Get the Turbo Credit price (in `winc` + `mARIO`, plus the equivalent Credits) to buy, extend, increase undernames on, or upgrade an ArNS name. The intent is inferred from the flags you pass:
+
+- `--type <lease|permabuy>` → Buy-Name (a lease also needs `--years`)
+- `--increase-qty <qty>` → Increase-Undername-Limit
+- `--years <years>` (without `--type`) → Extend-Lease
+- only `--name` → Upgrade-Name
+
+Command Options:
+
+- `--name <name>` - ArNS name to price
+- `--type <lease|permabuy>` - Purchase type for a Buy-Name price
+- `--years <years>` - Lease duration in years (Buy-Name lease / Extend-Lease)
+- `--increase-qty <qty>` - Number of additional undernames to price
+- `--process-id <processId>` - ANT process ID (optional for pricing; only needed for an actual purchase)
+
+e.g:
+
+```shell
+# Price a 1-year lease against a local bundler
+turbo arns-price --name my-name --type lease --years 1 --payment-url http://localhost:4001
+```
+
+```shell
+# Price a permabuy
+turbo arns-price --name my-name --type permabuy
+```
+
+```shell
+# Price extending an existing lease by 2 years
+turbo arns-price --name my-name --years 2
+```
+
+##### `buy-arns-name`
+
+Buy an ArNS name (lease or permabuy) paying with Turbo Credits. Prints the purchase receipt and a `nonce` to track the on-chain write.
+
+Command Options:
+
+- `--name <name>` - ArNS name to buy
+- `--type <lease|permabuy>` - Purchase type
+- `--years <years>` - Lease duration in years (required for `lease`)
+- `--process-id <processId>` - ANT process ID the name resolves to
+- `--paid-by <paidBy...>` - Optional delegated payer address(es) whose credits cover the purchase
+
+e.g:
+
+```shell
+# Lease a name for 1 year with an Arweave wallet against a local bundler
+turbo buy-arns-name --name my-name --type lease --years 1 \
+  --process-id agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA \
+  --wallet-file ../path/to/my/wallet.json --payment-url http://localhost:4001
+```
+
+```shell
+# Permabuy a name using a Solana wallet
+turbo buy-arns-name --name my-name --type permabuy \
+  --process-id agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA \
+  --token solana --wallet-file ../path/to/sol/secret-key.json
+```
+
+##### `extend-arns-lease`
+
+Extend an existing ArNS name lease with Turbo Credits.
+
+Command Options:
+
+- `--name <name>` - ArNS name whose lease to extend
+- `--years <years>` - Number of years to extend by
+- `--paid-by <paidBy...>` - Optional delegated payer address(es)
+
+e.g:
+
+```shell
+turbo extend-arns-lease --name my-name --years 2 --wallet-file ../path/to/my/wallet.json
+```
+
+##### `increase-arns-undernames`
+
+Increase the undername limit of an ArNS name with Turbo Credits.
+
+Command Options:
+
+- `--name <name>` - ArNS name to modify
+- `--increase-qty <qty>` - Number of additional undernames
+- `--paid-by <paidBy...>` - Optional delegated payer address(es)
+
+e.g:
+
+```shell
+turbo increase-arns-undernames --name my-name --increase-qty 10 --wallet-file ../path/to/my/wallet.json
+```
+
+##### `upgrade-arns-name`
+
+Upgrade an ArNS leased name to a permanent (permabuy) name with Turbo Credits.
+
+Command Options:
+
+- `--name <name>` - ArNS name to upgrade
+- `--paid-by <paidBy...>` - Optional delegated payer address(es)
+
+e.g:
+
+```shell
+turbo upgrade-arns-name --name my-name --wallet-file ../path/to/my/wallet.json
+```
+
+##### `arns-purchase-status`
+
+Get the status of an ArNS purchase by its nonce (returned by the buy/extend/upgrade commands). The response includes a `state` of `pending`, `success`, or `failed`.
+
+Command Options:
+
+- `--nonce <nonce>` - The purchase nonce to look up
+
+e.g:
+
+```shell
+turbo arns-purchase-status --nonce 3f8c...e21 --payment-url http://localhost:4001
+```
+
+##### `transfer-arns-ant`
+
+Self-custody exit: transfer a Turbo-custodied ANT to a Solana public key you control. Authenticated with an action-bound, single-use signature.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT (Metaplex Core asset) ID to transfer
+- `--target <address>` - Target Solana pubkey to transfer the ANT to
+
+e.g:
+
+```shell
+turbo transfer-arns-ant --ant-id ant-123 --target 7xKX...gAsU --wallet-file ../path/to/my/wallet.json
+```
+
+##### `set-arns-record`
+
+Set a resolution record on a Turbo-custodied ANT.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID to set a record on
+- `--undername <undername>` - Undername record to set (defaults to `@`, the apex record)
+- `--transaction-id <transactionId>` - Arweave transaction ID the record resolves to
+- `--ttl-seconds <ttlSeconds>` - TTL in seconds for the record
+
+e.g:
+
+```shell
+turbo set-arns-record --ant-id ant-123 --undername docs \
+  --transaction-id A1b2...Xyz --ttl-seconds 900 --wallet-file ../path/to/my/wallet.json
+```
+
+##### `remove-arns-record`
+
+Remove a resolution record (undername) from a Turbo-custodied ANT.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID to remove a record from
+- `--undername <undername>` - Undername record to remove
+
+e.g:
+
+```shell
+turbo remove-arns-record --ant-id ant-123 --undername docs --wallet-file ../path/to/my/wallet.json
+```
+
 ## Turbo Credit Sharing
 
 Users can share their purchased Credits with other users' wallets by creating Credit Share Approvals. These approvals are created by uploading a signed data item with tags indicating the recipient's wallet address, the amount of Credits to share, and an optional amount of seconds that the approval will expire in. The recipient can then use the shared Credits to pay for their own uploads to Turbo.

--- a/packages/turbo-sdk/src/cli/cli.ts
+++ b/packages/turbo-sdk/src/cli/cli.ts
@@ -22,6 +22,17 @@ import { Command, program } from 'commander';
 import { readFileSync, readdirSync } from 'fs';
 
 import { version } from '../version.js';
+import {
+  arnsPrice,
+  arnsPurchaseStatus,
+  buyArNSName,
+  extendArNSLease,
+  increaseArNSUndernames,
+  removeArNSRecord,
+  setArNSRecord,
+  transferArNSAnt,
+  upgradeArNSName,
+} from './commands/arns.js';
 import { fiatEstimate } from './commands/fiatEstimate.js';
 import {
   balance,
@@ -37,11 +48,20 @@ import { shareCredits } from './commands/shareCredits.js';
 import { tokenPrice } from './commands/tokenPrice.js';
 import { x402UploadUnsignedFile } from './commands/x402UploadUnsignedData.js';
 import {
+  arnsPriceOptions,
+  arnsPurchaseStatusOptions,
+  buyArNSNameOptions,
+  extendArNSLeaseOptions,
   globalOptions,
+  increaseArNSUndernamesOptions,
   listSharesOptions,
   optionMap,
+  removeArNSRecordOptions,
   revokeCreditsOptions,
+  setArNSRecordOptions,
   shareCreditsOptions,
+  transferArNSAntOptions,
+  upgradeArNSNameOptions,
   uploadFileOptions,
   uploadFolderOptions,
   walletOptions,
@@ -160,6 +180,97 @@ applyOptions(
   listSharesOptions,
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, listShares);
+});
+
+applyOptions(
+  program
+    .command('arns-price')
+    .description(
+      'Get the Turbo Credit (winc + mARIO) price to buy, extend, increase undernames, or upgrade an ArNS name',
+    ),
+  arnsPriceOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, arnsPrice);
+});
+
+applyOptions(
+  program
+    .command('buy-arns-name')
+    .description('Buy an ArNS name (lease or permabuy) with Turbo Credits'),
+  buyArNSNameOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, buyArNSName);
+});
+
+applyOptions(
+  program
+    .command('extend-arns-lease')
+    .description('Extend an ArNS name lease with Turbo Credits'),
+  extendArNSLeaseOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, extendArNSLease);
+});
+
+applyOptions(
+  program
+    .command('increase-arns-undernames')
+    .description(
+      'Increase the undername limit of an ArNS name with Turbo Credits',
+    ),
+  increaseArNSUndernamesOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, increaseArNSUndernames);
+});
+
+applyOptions(
+  program
+    .command('upgrade-arns-name')
+    .description(
+      'Upgrade an ArNS leased name to a permabuy with Turbo Credits',
+    ),
+  upgradeArNSNameOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, upgradeArNSName);
+});
+
+applyOptions(
+  program
+    .command('arns-purchase-status')
+    .description('Get the status of an ArNS purchase by its nonce'),
+  arnsPurchaseStatusOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, arnsPurchaseStatus);
+});
+
+applyOptions(
+  program
+    .command('transfer-arns-ant')
+    .description(
+      'Transfer a Turbo-custodied ANT to a Solana pubkey you control',
+    ),
+  transferArNSAntOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, transferArNSAnt);
+});
+
+applyOptions(
+  program
+    .command('set-arns-record')
+    .description('Set a resolution record on a Turbo-custodied ANT'),
+  setArNSRecordOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, setArNSRecord);
+});
+
+applyOptions(
+  program
+    .command('remove-arns-record')
+    .description(
+      'Remove a resolution record (undername) from a Turbo-custodied ANT',
+    ),
+  removeArNSRecordOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, removeArNSRecord);
 });
 
 applyOptions(

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -1,0 +1,545 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { InsufficientCreditsError } from '../../utils/errors.js';
+import {
+  ArNSPriceOptions,
+  ArNSPurchaseOptions,
+  ArNSPurchaseStatusOptions,
+  RemoveArNSRecordOptions,
+  SetArNSRecordOptions,
+  TransferArNSAntOptions,
+} from '../types.js';
+import {
+  ArNSCustodyClient,
+  ArNSPriceClient,
+  ArNSPurchaseClient,
+  ArNSStatusClient,
+  arnsPrice,
+  arnsPriceParamsFromOptions,
+  arnsPurchaseStatus,
+  buyArNSName,
+  extendArNSLease,
+  increaseArNSUndernames,
+  removeArNSRecord,
+  setArNSRecord,
+  transferArNSAnt,
+  upgradeArNSName,
+} from './arns.js';
+
+// Records every call so tests can assert the exact SDK method + params the
+// option->params mapping produced, without touching the network.
+class FakeTurbo
+  implements
+    ArNSPriceClient,
+    ArNSStatusClient,
+    ArNSPurchaseClient,
+    ArNSCustodyClient
+{
+  public calls: { method: string; params: unknown }[] = [];
+  public error: unknown = undefined;
+  private record<T>(method: string, params: unknown, response: T): Promise<T> {
+    this.calls.push({ method, params });
+    if (this.error) return Promise.reject(this.error);
+    return Promise.resolve(response);
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+
+  private purchaseResponse = {
+    purchaseReceipt: { name: 'foo', nonce: 'srv-nonce' },
+    arioWriteResult: { id: 'sol-tx' },
+    nonce: 'nonce-123',
+  } as unknown as Awaited<ReturnType<ArNSPurchaseClient['buyArNSName']>>;
+
+  getArNSPriceForName(params: unknown) {
+    return this.record('getArNSPriceForName', params, {
+      winc: '1500000000000',
+      mARIO: '2500',
+    });
+  }
+  getArNSPurchaseStatus(params: unknown) {
+    return this.record('getArNSPurchaseStatus', params, {
+      name: 'foo',
+      intent: 'Buy-Name',
+      nonce: 'nonce-123',
+      owner: 'owner-1',
+      wincQty: '1',
+      mARIOQty: '1',
+      usdArRate: 1,
+      usdArioRate: 1,
+      paidBy: [],
+      messageId: 'sol-tx-success',
+    } as unknown as Awaited<
+      ReturnType<ArNSStatusClient['getArNSPurchaseStatus']>
+    >);
+  }
+  buyArNSName(params: unknown) {
+    return this.record('buyArNSName', params, this.purchaseResponse);
+  }
+  extendArNSLease(params: unknown) {
+    return this.record('extendArNSLease', params, this.purchaseResponse);
+  }
+  increaseArNSUndernameLimit(params: unknown) {
+    return this.record(
+      'increaseArNSUndernameLimit',
+      params,
+      this.purchaseResponse,
+    );
+  }
+  upgradeArNSName(params: unknown) {
+    return this.record('upgradeArNSName', params, this.purchaseResponse);
+  }
+  transferArNSAnt(params: unknown) {
+    return this.record('transferArNSAnt', params, {
+      antId: 'ant-1',
+      target: 'tgt-1',
+      messageId: 'm',
+    });
+  }
+  setArNSRecord(params: unknown) {
+    return this.record('setArNSRecord', params, {
+      antId: 'ant-1',
+      undername: '@',
+      transactionId: 'tx-1',
+      ttlSeconds: 900,
+      messageId: 'm',
+    });
+  }
+  removeArNSRecord(params: unknown) {
+    return this.record('removeArNSRecord', params, {
+      antId: 'ant-1',
+      undername: 'docs',
+      messageId: 'm',
+    });
+  }
+}
+
+const priceOptions = (o: Partial<ArNSPriceOptions>): ArNSPriceOptions =>
+  ({ token: 'arweave', ...o }) as ArNSPriceOptions;
+const purchaseOptions = (
+  o: Partial<ArNSPurchaseOptions>,
+): ArNSPurchaseOptions => ({ token: 'arweave', ...o }) as ArNSPurchaseOptions;
+
+describe('ArNS CLI commands', () => {
+  let turbo: FakeTurbo;
+  beforeEach(() => {
+    turbo = new FakeTurbo();
+  });
+
+  describe('arnsPriceParamsFromOptions (intent inference)', () => {
+    it('infers Buy-Name lease from --type lease (with years + processId)', () => {
+      assert.deepEqual(
+        arnsPriceParamsFromOptions(
+          priceOptions({
+            name: 'foo',
+            type: 'lease',
+            years: '2',
+            processId: 'ant-1',
+          }),
+        ),
+        {
+          intent: 'Buy-Name',
+          name: 'foo',
+          type: 'lease',
+          years: 2,
+          processId: 'ant-1',
+        },
+      );
+    });
+
+    it('infers Buy-Name permabuy from --type permabuy (no years)', () => {
+      assert.deepEqual(
+        arnsPriceParamsFromOptions(
+          priceOptions({ name: 'foo', type: 'permabuy', processId: 'ant-1' }),
+        ),
+        {
+          intent: 'Buy-Name',
+          name: 'foo',
+          type: 'permabuy',
+          processId: 'ant-1',
+        },
+      );
+    });
+
+    it('infers Increase-Undername-Limit from --increase-qty', () => {
+      assert.deepEqual(
+        arnsPriceParamsFromOptions(
+          priceOptions({ name: 'foo', increaseQty: '5' }),
+        ),
+        { intent: 'Increase-Undername-Limit', name: 'foo', increaseQty: 5 },
+      );
+    });
+
+    it('infers Extend-Lease from --years (no --type)', () => {
+      assert.deepEqual(
+        arnsPriceParamsFromOptions(priceOptions({ name: 'foo', years: '3' })),
+        { intent: 'Extend-Lease', name: 'foo', years: 3 },
+      );
+    });
+
+    it('infers Upgrade-Name when only --name is given', () => {
+      assert.deepEqual(
+        arnsPriceParamsFromOptions(priceOptions({ name: 'foo' })),
+        { intent: 'Upgrade-Name', name: 'foo' },
+      );
+    });
+
+    it('requires --name', () => {
+      assert.throws(() => arnsPriceParamsFromOptions(priceOptions({})), /name/);
+    });
+
+    it('rejects an invalid --type', () => {
+      assert.throws(
+        () =>
+          arnsPriceParamsFromOptions(
+            priceOptions({ name: 'foo', type: 'rental', processId: 'a' }),
+          ),
+        /type/,
+      );
+    });
+
+    it('does NOT require --process-id for pricing a Buy-Name (uses a placeholder)', () => {
+      const params = arnsPriceParamsFromOptions(
+        priceOptions({ name: 'foo', type: 'permabuy' }),
+      );
+      assert.equal(params.intent, 'Buy-Name');
+      assert.equal(params.name, 'foo');
+      // a non-empty processId is substituted so the SDK's Buy-Name validation passes
+      assert.ok(
+        (params as { processId: string }).processId.length > 0,
+        'a placeholder processId should be supplied for pricing',
+      );
+    });
+
+    it('requires a positive --years for a lease Buy-Name', () => {
+      assert.throws(
+        () =>
+          arnsPriceParamsFromOptions(
+            priceOptions({
+              name: 'foo',
+              type: 'lease',
+              years: '0',
+              processId: 'a',
+            }),
+          ),
+        /years/,
+      );
+    });
+  });
+
+  describe('arnsPrice', () => {
+    it('calls getArNSPriceForName with the inferred params', async () => {
+      await arnsPrice(
+        priceOptions({ name: 'foo', type: 'permabuy', processId: 'ant-1' }),
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'getArNSPriceForName');
+      assert.deepEqual(turbo.last.params, {
+        intent: 'Buy-Name',
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant-1',
+      });
+    });
+  });
+
+  describe('buyArNSName', () => {
+    it('buys a lease with the right params', async () => {
+      await buyArNSName(
+        purchaseOptions({
+          name: 'foo',
+          type: 'lease',
+          years: '1',
+          processId: 'ant-1',
+        }),
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'buyArNSName');
+      assert.deepEqual(turbo.last.params, {
+        name: 'foo',
+        type: 'lease',
+        years: 1,
+        processId: 'ant-1',
+        paidBy: undefined,
+      });
+    });
+
+    it('buys a permabuy (no years) and forwards paidBy', async () => {
+      await buyArNSName(
+        purchaseOptions({
+          name: 'foo',
+          type: 'permabuy',
+          processId: 'ant-1',
+          paidBy: ['payer-a', 'payer-b'],
+        }),
+        turbo,
+      );
+      assert.deepEqual(turbo.last.params, {
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant-1',
+        paidBy: ['payer-a', 'payer-b'],
+      });
+    });
+
+    it('requires --process-id', async () => {
+      await assert.rejects(
+        () =>
+          buyArNSName(
+            purchaseOptions({ name: 'foo', type: 'permabuy' }),
+            turbo,
+          ),
+        /process-id/,
+      );
+      assert.equal(turbo.calls.length, 0);
+    });
+
+    it('requires a valid --type', async () => {
+      await assert.rejects(
+        () => buyArNSName(purchaseOptions({ name: 'foo' }), turbo),
+        /type/,
+      );
+    });
+
+    it('maps a 402 to an actionable top-up error', async () => {
+      turbo.error = new InsufficientCreditsError();
+      await assert.rejects(
+        () =>
+          buyArNSName(
+            purchaseOptions({
+              name: 'foo',
+              type: 'permabuy',
+              processId: 'ant-1',
+            }),
+            turbo,
+          ),
+        /Top up your balance/,
+      );
+    });
+  });
+
+  describe('extendArNSLease', () => {
+    it('extends with the right params', async () => {
+      await extendArNSLease(
+        purchaseOptions({ name: 'foo', years: '2' }),
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'extendArNSLease');
+      assert.deepEqual(turbo.last.params, {
+        name: 'foo',
+        years: 2,
+        paidBy: undefined,
+      });
+    });
+
+    it('requires a positive --years', async () => {
+      await assert.rejects(
+        () => extendArNSLease(purchaseOptions({ name: 'foo' }), turbo),
+        /years/,
+      );
+    });
+  });
+
+  describe('increaseArNSUndernames', () => {
+    it('increases with the right params', async () => {
+      await increaseArNSUndernames(
+        purchaseOptions({ name: 'foo', increaseQty: '10' }),
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'increaseArNSUndernameLimit');
+      assert.deepEqual(turbo.last.params, {
+        name: 'foo',
+        increaseQty: 10,
+        paidBy: undefined,
+      });
+    });
+
+    it('requires a positive --increase-qty', async () => {
+      await assert.rejects(
+        () => increaseArNSUndernames(purchaseOptions({ name: 'foo' }), turbo),
+        /increase-qty/,
+      );
+    });
+  });
+
+  describe('upgradeArNSName', () => {
+    it('upgrades with the right params', async () => {
+      await upgradeArNSName(purchaseOptions({ name: 'foo' }), turbo);
+      assert.equal(turbo.last.method, 'upgradeArNSName');
+      assert.deepEqual(turbo.last.params, { name: 'foo', paidBy: undefined });
+    });
+  });
+
+  describe('arnsPurchaseStatus', () => {
+    it('looks up the status by nonce', async () => {
+      await arnsPurchaseStatus(
+        { token: 'arweave', nonce: 'nonce-123' } as ArNSPurchaseStatusOptions,
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'getArNSPurchaseStatus');
+      assert.deepEqual(turbo.last.params, { nonce: 'nonce-123' });
+    });
+
+    it('requires a --nonce', async () => {
+      await assert.rejects(
+        () =>
+          arnsPurchaseStatus(
+            { token: 'arweave' } as ArNSPurchaseStatusOptions,
+            turbo,
+          ),
+        /nonce/,
+      );
+    });
+  });
+
+  describe('transferArNSAnt', () => {
+    it('transfers with the right params', async () => {
+      await transferArNSAnt(
+        {
+          token: 'arweave',
+          antId: 'ant-1',
+          target: 'tgt-1',
+        } as TransferArNSAntOptions,
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'transferArNSAnt');
+      assert.deepEqual(turbo.last.params, { antId: 'ant-1', target: 'tgt-1' });
+    });
+
+    it('requires --ant-id and --target', async () => {
+      await assert.rejects(
+        () =>
+          transferArNSAnt(
+            { token: 'arweave', target: 'tgt-1' } as TransferArNSAntOptions,
+            turbo,
+          ),
+        /ant-id/,
+      );
+      await assert.rejects(
+        () =>
+          transferArNSAnt(
+            { token: 'arweave', antId: 'ant-1' } as TransferArNSAntOptions,
+            turbo,
+          ),
+        /target/,
+      );
+    });
+  });
+
+  describe('setArNSRecord', () => {
+    it('sets a record with the right params', async () => {
+      await setArNSRecord(
+        {
+          token: 'arweave',
+          antId: 'ant-1',
+          undername: 'docs',
+          transactionId: 'tx-1',
+          ttlSeconds: '900',
+        } as SetArNSRecordOptions,
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'setArNSRecord');
+      assert.deepEqual(turbo.last.params, {
+        antId: 'ant-1',
+        undername: 'docs',
+        transactionId: 'tx-1',
+        ttlSeconds: 900,
+      });
+    });
+
+    it("defaults --undername to '@'", async () => {
+      await setArNSRecord(
+        {
+          token: 'arweave',
+          antId: 'ant-1',
+          transactionId: 'tx-1',
+          ttlSeconds: '900',
+        } as SetArNSRecordOptions,
+        turbo,
+      );
+      assert.equal(
+        (turbo.last.params as { undername: string }).undername,
+        '@',
+      );
+    });
+
+    it('requires --transaction-id and a positive --ttl-seconds', async () => {
+      await assert.rejects(
+        () =>
+          setArNSRecord(
+            {
+              token: 'arweave',
+              antId: 'ant-1',
+              ttlSeconds: '900',
+            } as SetArNSRecordOptions,
+            turbo,
+          ),
+        /transaction-id/,
+      );
+      await assert.rejects(
+        () =>
+          setArNSRecord(
+            {
+              token: 'arweave',
+              antId: 'ant-1',
+              transactionId: 'tx-1',
+              ttlSeconds: '0',
+            } as SetArNSRecordOptions,
+            turbo,
+          ),
+        /ttl-seconds/,
+      );
+    });
+  });
+
+  describe('removeArNSRecord', () => {
+    it('removes a record with the right params', async () => {
+      await removeArNSRecord(
+        {
+          token: 'arweave',
+          antId: 'ant-1',
+          undername: 'docs',
+        } as RemoveArNSRecordOptions,
+        turbo,
+      );
+      assert.equal(turbo.last.method, 'removeArNSRecord');
+      assert.deepEqual(turbo.last.params, { antId: 'ant-1', undername: 'docs' });
+    });
+
+    it('requires --ant-id and --undername', async () => {
+      await assert.rejects(
+        () =>
+          removeArNSRecord(
+            { token: 'arweave', undername: 'docs' } as RemoveArNSRecordOptions,
+            turbo,
+          ),
+        /ant-id/,
+      );
+      await assert.rejects(
+        () =>
+          removeArNSRecord(
+            { token: 'arweave', antId: 'ant-1' } as RemoveArNSRecordOptions,
+            turbo,
+          ),
+        /undername/,
+      );
+    });
+  });
+});

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -474,10 +474,7 @@ describe('ArNS CLI commands', () => {
         } as SetArNSRecordOptions,
         turbo,
       );
-      assert.equal(
-        (turbo.last.params as { undername: string }).undername,
-        '@',
-      );
+      assert.equal((turbo.last.params as { undername: string }).undername, '@');
     });
 
     it('requires --transaction-id and a positive --ttl-seconds', async () => {
@@ -520,7 +517,10 @@ describe('ArNS CLI commands', () => {
         turbo,
       );
       assert.equal(turbo.last.method, 'removeArNSRecord');
-      assert.deepEqual(turbo.last.params, { antId: 'ant-1', undername: 'docs' });
+      assert.deepEqual(turbo.last.params, {
+        antId: 'ant-1',
+        undername: 'docs',
+      });
     });
 
     it('requires --ant-id and --undername', async () => {

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -299,16 +299,33 @@ describe('ArNS CLI commands', () => {
       });
     });
 
-    it('requires --process-id', async () => {
-      await assert.rejects(
-        () =>
-          buyArNSName(
-            purchaseOptions({ name: 'foo', type: 'permabuy' }),
-            turbo,
-          ),
-        /process-id/,
+    it('builds a custodial permabuy request when --process-id is omitted', async () => {
+      await buyArNSName(
+        purchaseOptions({ name: 'foo', type: 'permabuy' }),
+        turbo,
       );
-      assert.equal(turbo.calls.length, 0);
+      assert.equal(turbo.last.method, 'buyArNSName');
+      // No processId is forwarded -> the bundler custodially provisions the ANT.
+      assert.deepEqual(turbo.last.params, {
+        name: 'foo',
+        type: 'permabuy',
+        processId: undefined,
+        paidBy: undefined,
+      });
+    });
+
+    it('builds a custodial lease request when --process-id is omitted', async () => {
+      await buyArNSName(
+        purchaseOptions({ name: 'foo', type: 'lease', years: '1' }),
+        turbo,
+      );
+      assert.deepEqual(turbo.last.params, {
+        name: 'foo',
+        type: 'lease',
+        years: 1,
+        processId: undefined,
+        paidBy: undefined,
+      });
     });
 
     it('requires a valid --type', async () => {

--- a/packages/turbo-sdk/src/cli/commands/arns.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.ts
@@ -1,0 +1,417 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BigNumber } from 'bignumber.js';
+
+import { TurboFactory } from '../../node/factory.js';
+import {
+  ArNSNameType,
+  ArNSPriceParams,
+  ArNSPriceResponse,
+  ArNSPurchaseResponse,
+  ArNSPurchaseStatusResponse,
+} from '../../types.js';
+import { InsufficientCreditsError } from '../../utils/errors.js';
+import { wincPerCredit } from '../constants.js';
+import {
+  ArNSPriceOptions,
+  ArNSPurchaseOptions,
+  ArNSPurchaseStatusOptions,
+  RemoveArNSRecordOptions,
+  SetArNSRecordOptions,
+  TransferArNSAntOptions,
+} from '../types.js';
+import { configFromOptions, turboFromOptions } from '../utils.js';
+
+// Minimal structural client contracts. These are satisfied by the real
+// Turbo(Un)authenticatedClient and let tests inject a fake without touching the
+// network. The handlers accept an optional client (defaulting to the real one
+// built from CLI options) purely so the option->params mapping is unit testable.
+export type ArNSPriceClient = {
+  getArNSPriceForName(params: ArNSPriceParams): Promise<ArNSPriceResponse>;
+};
+export type ArNSStatusClient = {
+  getArNSPurchaseStatus(p: {
+    nonce: string;
+  }): Promise<ArNSPurchaseStatusResponse>;
+};
+export type ArNSPurchaseClient = {
+  buyArNSName(params: {
+    name: string;
+    type: ArNSNameType;
+    years?: number;
+    processId: string;
+    paidBy?: string[];
+  }): Promise<ArNSPurchaseResponse>;
+  extendArNSLease(params: {
+    name: string;
+    years: number;
+    paidBy?: string[];
+  }): Promise<ArNSPurchaseResponse>;
+  increaseArNSUndernameLimit(params: {
+    name: string;
+    increaseQty: number;
+    paidBy?: string[];
+  }): Promise<ArNSPurchaseResponse>;
+  upgradeArNSName(params: {
+    name: string;
+    paidBy?: string[];
+  }): Promise<ArNSPurchaseResponse>;
+};
+export type ArNSCustodyClient = {
+  transferArNSAnt(params: { antId: string; target: string }): Promise<{
+    antId: string;
+    target: string;
+    name?: string;
+    messageId: string;
+  }>;
+  setArNSRecord(params: {
+    antId: string;
+    undername?: string;
+    transactionId: string;
+    ttlSeconds: number;
+  }): Promise<{
+    antId: string;
+    undername: string;
+    transactionId: string;
+    ttlSeconds: number;
+    messageId: string;
+  }>;
+  removeArNSRecord(params: {
+    antId: string;
+    undername: string;
+  }): Promise<{ antId: string; undername: string; messageId: string }>;
+};
+
+export function requiredNameFromOptions(options: { name?: string }): string {
+  if (options.name === undefined || options.name.length === 0) {
+    throw new Error('Must provide an ArNS --name');
+  }
+  return options.name;
+}
+
+export function positiveIntFromOption(
+  value: string | undefined,
+  flag: string,
+): number {
+  if (value === undefined) {
+    throw new Error(`Must provide ${flag}`);
+  }
+  const num = +value;
+  if (!Number.isFinite(num) || !Number.isInteger(num) || num <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return num;
+}
+
+export function typeFromOptions(value: string | undefined): ArNSNameType {
+  if (value !== 'lease' && value !== 'permabuy') {
+    throw new Error("Must provide --type of 'lease' or 'permabuy'");
+  }
+  return value;
+}
+
+export function paidByFromArNSOptions(
+  paidBy: string[] | undefined,
+): string[] | undefined {
+  return paidBy !== undefined && paidBy.length > 0 ? paidBy : undefined;
+}
+
+// A price quote depends only on the name (length), type, and years — NOT on the
+// ANT the name will resolve to. The service ignores `processId` for pricing, but
+// the SDK's Buy-Name validation still requires a non-empty one, so we substitute
+// this obvious placeholder when the user omits `--process-id` from `arns-price`.
+// (`buy-arns-name` still requires a real `--process-id`.)
+const PRICING_PLACEHOLDER_PROCESS_ID = 'pricing-only-no-process-id';
+
+/**
+ * Infer the ArNS pricing intent from the provided flags:
+ * - `--type` present            -> Buy-Name (lease needs --years; --process-id optional for pricing)
+ * - `--increase-qty` present    -> Increase-Undername-Limit
+ * - `--years` present (no type) -> Extend-Lease
+ * - otherwise                   -> Upgrade-Name
+ */
+export function arnsPriceParamsFromOptions(
+  options: ArNSPriceOptions,
+): ArNSPriceParams {
+  const name = requiredNameFromOptions(options);
+
+  if (options.type !== undefined) {
+    const type = typeFromOptions(options.type);
+    const processId = options.processId ?? PRICING_PLACEHOLDER_PROCESS_ID;
+    if (type === 'lease') {
+      return {
+        intent: 'Buy-Name',
+        name,
+        type: 'lease',
+        years: positiveIntFromOption(options.years, '--years'),
+        processId,
+      };
+    }
+    return {
+      intent: 'Buy-Name',
+      name,
+      type: 'permabuy',
+      processId,
+    };
+  }
+
+  if (options.increaseQty !== undefined) {
+    return {
+      intent: 'Increase-Undername-Limit',
+      name,
+      increaseQty: positiveIntFromOption(options.increaseQty, '--increase-qty'),
+    };
+  }
+
+  if (options.years !== undefined) {
+    return {
+      intent: 'Extend-Lease',
+      name,
+      years: positiveIntFromOption(options.years, '--years'),
+    };
+  }
+
+  return { intent: 'Upgrade-Name', name };
+}
+
+function creditsFromWinc(winc: string): string {
+  return new BigNumber(winc).dividedBy(wincPerCredit).toFixed(12);
+}
+
+/** Rethrow a 402 as a clear, actionable "top up" message. */
+async function withCreditErrorMapping<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (error instanceof InsufficientCreditsError) {
+      throw new Error(
+        'Insufficient Turbo credits to complete this ArNS purchase. ' +
+          'Top up your balance (e.g. `turbo top-up` or `turbo crypto-fund`) and retry.',
+      );
+    }
+    throw error;
+  }
+}
+
+function logPurchaseResult(action: string, result: ArNSPurchaseResponse): void {
+  console.log(
+    JSON.stringify(
+      {
+        message: `${action} submitted!`,
+        nonce: result.nonce,
+        arioWriteId: result.arioWriteResult?.id,
+        purchaseReceipt: result.purchaseReceipt,
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(
+    `\nTrack this purchase with:\n  turbo arns-purchase-status --nonce ${result.nonce}`,
+  );
+}
+
+export async function arnsPrice(
+  options: ArNSPriceOptions,
+  turbo?: ArNSPriceClient,
+): Promise<void> {
+  const params = arnsPriceParamsFromOptions(options);
+  const client =
+    turbo ?? TurboFactory.unauthenticated(configFromOptions(options));
+  const { winc, mARIO } = await client.getArNSPriceForName(params);
+
+  console.log(
+    JSON.stringify(
+      {
+        name: params.name,
+        intent: params.intent,
+        winc,
+        credits: creditsFromWinc(winc),
+        mARIO,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+export async function buyArNSName(
+  options: ArNSPurchaseOptions,
+  turbo?: ArNSPurchaseClient,
+): Promise<void> {
+  const name = requiredNameFromOptions(options);
+  const type = typeFromOptions(options.type);
+  if (options.processId === undefined) {
+    throw new Error('Must provide a --process-id (the ANT ID) to buy a name');
+  }
+  const paidBy = paidByFromArNSOptions(options.paidBy);
+  const processId = options.processId;
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await withCreditErrorMapping(() =>
+    type === 'lease'
+      ? client.buyArNSName({
+          name,
+          type: 'lease',
+          years: positiveIntFromOption(options.years, '--years'),
+          processId,
+          paidBy,
+        })
+      : client.buyArNSName({ name, type: 'permabuy', processId, paidBy }),
+  );
+
+  logPurchaseResult('ArNS name purchase', result);
+}
+
+export async function extendArNSLease(
+  options: ArNSPurchaseOptions,
+  turbo?: ArNSPurchaseClient,
+): Promise<void> {
+  const name = requiredNameFromOptions(options);
+  const years = positiveIntFromOption(options.years, '--years');
+  const paidBy = paidByFromArNSOptions(options.paidBy);
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await withCreditErrorMapping(() =>
+    client.extendArNSLease({ name, years, paidBy }),
+  );
+
+  logPurchaseResult('ArNS lease extension', result);
+}
+
+export async function increaseArNSUndernames(
+  options: ArNSPurchaseOptions,
+  turbo?: ArNSPurchaseClient,
+): Promise<void> {
+  const name = requiredNameFromOptions(options);
+  const increaseQty = positiveIntFromOption(
+    options.increaseQty,
+    '--increase-qty',
+  );
+  const paidBy = paidByFromArNSOptions(options.paidBy);
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await withCreditErrorMapping(() =>
+    client.increaseArNSUndernameLimit({ name, increaseQty, paidBy }),
+  );
+
+  logPurchaseResult('ArNS undername limit increase', result);
+}
+
+export async function upgradeArNSName(
+  options: ArNSPurchaseOptions,
+  turbo?: ArNSPurchaseClient,
+): Promise<void> {
+  const name = requiredNameFromOptions(options);
+  const paidBy = paidByFromArNSOptions(options.paidBy);
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await withCreditErrorMapping(() =>
+    client.upgradeArNSName({ name, paidBy }),
+  );
+
+  logPurchaseResult('ArNS name upgrade (to permabuy)', result);
+}
+
+export async function arnsPurchaseStatus(
+  options: ArNSPurchaseStatusOptions,
+  turbo?: ArNSStatusClient,
+): Promise<void> {
+  if (options.nonce === undefined || options.nonce.length === 0) {
+    throw new Error('Must provide a --nonce to look up purchase status');
+  }
+  const client =
+    turbo ?? TurboFactory.unauthenticated(configFromOptions(options));
+  const status = await client.getArNSPurchaseStatus({ nonce: options.nonce });
+
+  const state =
+    status.failedDate !== undefined
+      ? 'failed'
+      : status.messageId
+      ? 'success'
+      : 'pending';
+
+  console.log(JSON.stringify({ state, ...status }, null, 2));
+}
+
+export async function transferArNSAnt(
+  options: TransferArNSAntOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to transfer');
+  }
+  if (options.target === undefined) {
+    throw new Error('Must provide a --target address to transfer the ANT to');
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.transferArNSAnt({
+    antId: options.antId,
+    target: options.target,
+  });
+
+  console.log(
+    JSON.stringify({ message: 'ANT transfer submitted!', ...result }, null, 2),
+  );
+}
+
+export async function setArNSRecord(
+  options: SetArNSRecordOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to set a record on');
+  }
+  if (options.transactionId === undefined) {
+    throw new Error('Must provide a --transaction-id for the record');
+  }
+  const ttlSeconds = positiveIntFromOption(options.ttlSeconds, '--ttl-seconds');
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.setArNSRecord({
+    antId: options.antId,
+    undername: options.undername ?? '@',
+    transactionId: options.transactionId,
+    ttlSeconds,
+  });
+
+  console.log(
+    JSON.stringify({ message: 'ArNS record set!', ...result }, null, 2),
+  );
+}
+
+export async function removeArNSRecord(
+  options: RemoveArNSRecordOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to remove a record from');
+  }
+  if (options.undername === undefined || options.undername.length === 0) {
+    throw new Error('Must provide an --undername to remove');
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.removeArNSRecord({
+    antId: options.antId,
+    undername: options.undername,
+  });
+
+  console.log(
+    JSON.stringify({ message: 'ArNS record removed!', ...result }, null, 2),
+  );
+}

--- a/packages/turbo-sdk/src/cli/commands/arns.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.ts
@@ -52,7 +52,7 @@ export type ArNSPurchaseClient = {
     name: string;
     type: ArNSNameType;
     years?: number;
-    processId: string;
+    processId?: string;
     paidBy?: string[];
   }): Promise<ArNSPurchaseResponse>;
   extendArNSLease(params: {
@@ -254,10 +254,10 @@ export async function buyArNSName(
 ): Promise<void> {
   const name = requiredNameFromOptions(options);
   const type = typeFromOptions(options.type);
-  if (options.processId === undefined) {
-    throw new Error('Must provide a --process-id (the ANT ID) to buy a name');
-  }
   const paidBy = paidByFromArNSOptions(options.paidBy);
+  // `--process-id` is OPTIONAL: omit it to have Turbo custodially provision the
+  // ANT (Turbo spawns + owns it — Model A); supply it to point the name at a
+  // user-owned ANT (Model B). When omitted, no `processId` is sent.
   const processId = options.processId;
 
   const client = turbo ?? (await turboFromOptions(options));

--- a/packages/turbo-sdk/src/cli/commands/index.ts
+++ b/packages/turbo-sdk/src/cli/commands/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from './arns.js';
 export * from './balance.js';
 export * from './cryptoFund.js';
 export * from './price.js';

--- a/packages/turbo-sdk/src/cli/options.ts
+++ b/packages/turbo-sdk/src/cli/options.ts
@@ -219,7 +219,8 @@ export const optionMap = {
   },
   arnsProcessId: {
     alias: '--process-id <processId>',
-    description: 'ANT process ID the ArNS name resolves to (Buy-Name)',
+    description:
+      'ANT process ID the ArNS name resolves to (Buy-Name). Optional: omit for Turbo custodial provisioning (Turbo owns the ANT); supply for a user-owned ANT',
   },
   arnsNonce: {
     alias: '--nonce <nonce>',

--- a/packages/turbo-sdk/src/cli/options.ts
+++ b/packages/turbo-sdk/src/cli/options.ts
@@ -200,6 +200,51 @@ export const optionMap = {
     description:
       'Maximum crypto top-up value to use for the upload. Defaults to no limit.',
   },
+  // ---- ArNS (paid with Turbo Credits) ----
+  arnsName: {
+    alias: '--name <name>',
+    description: 'ArNS name to price, buy, or manage',
+  },
+  arnsType: {
+    alias: '--type <type>',
+    description: "ArNS purchase type for Buy-Name: 'lease' or 'permabuy'",
+  },
+  arnsYears: {
+    alias: '--years <years>',
+    description: 'Lease duration in years (Buy-Name lease / Extend-Lease)',
+  },
+  arnsIncreaseQty: {
+    alias: '--increase-qty <qty>',
+    description: 'Number of additional undernames (Increase-Undername-Limit)',
+  },
+  arnsProcessId: {
+    alias: '--process-id <processId>',
+    description: 'ANT process ID the ArNS name resolves to (Buy-Name)',
+  },
+  arnsNonce: {
+    alias: '--nonce <nonce>',
+    description: 'ArNS purchase nonce to look up the status for',
+  },
+  arnsAntId: {
+    alias: '--ant-id <antId>',
+    description: 'ANT (Metaplex Core asset) ID to transfer or manage',
+  },
+  arnsTarget: {
+    alias: '--target <address>',
+    description: 'Target Solana pubkey to transfer the ANT to',
+  },
+  arnsUndername: {
+    alias: '--undername <undername>',
+    description: "ArNS undername record to set or remove (defaults to '@')",
+  },
+  arnsTransactionId: {
+    alias: '--transaction-id <transactionId>',
+    description: 'Arweave transaction ID the ArNS record resolves to',
+  },
+  arnsTtlSeconds: {
+    alias: '--ttl-seconds <ttlSeconds>',
+    description: 'TTL in seconds for the ArNS record',
+  },
 } as const;
 
 export const walletOptions = [
@@ -262,3 +307,64 @@ export const shareCreditsOptions = [
 export const revokeCreditsOptions = [...walletOptions, optionMap.address];
 
 export const listSharesOptions = revokeCreditsOptions;
+
+// ---- ArNS command option sets (token + --payment-url come from globalOptions) ----
+
+export const arnsPriceOptions = [
+  optionMap.arnsName,
+  optionMap.arnsType,
+  optionMap.arnsYears,
+  optionMap.arnsIncreaseQty,
+  optionMap.arnsProcessId,
+];
+
+export const buyArNSNameOptions = [
+  ...walletOptions,
+  optionMap.arnsName,
+  optionMap.arnsType,
+  optionMap.arnsYears,
+  optionMap.arnsProcessId,
+  optionMap.paidBy,
+];
+
+export const extendArNSLeaseOptions = [
+  ...walletOptions,
+  optionMap.arnsName,
+  optionMap.arnsYears,
+  optionMap.paidBy,
+];
+
+export const increaseArNSUndernamesOptions = [
+  ...walletOptions,
+  optionMap.arnsName,
+  optionMap.arnsIncreaseQty,
+  optionMap.paidBy,
+];
+
+export const upgradeArNSNameOptions = [
+  ...walletOptions,
+  optionMap.arnsName,
+  optionMap.paidBy,
+];
+
+export const arnsPurchaseStatusOptions = [optionMap.arnsNonce];
+
+export const transferArNSAntOptions = [
+  ...walletOptions,
+  optionMap.arnsAntId,
+  optionMap.arnsTarget,
+];
+
+export const setArNSRecordOptions = [
+  ...walletOptions,
+  optionMap.arnsAntId,
+  optionMap.arnsUndername,
+  optionMap.arnsTransactionId,
+  optionMap.arnsTtlSeconds,
+];
+
+export const removeArNSRecordOptions = [
+  ...walletOptions,
+  optionMap.arnsAntId,
+  optionMap.arnsUndername,
+];

--- a/packages/turbo-sdk/src/cli/types.ts
+++ b/packages/turbo-sdk/src/cli/types.ts
@@ -103,3 +103,39 @@ export type RevokeCreditsOptions = WalletOptions & {
 };
 
 export type ListSharesOptions = RevokeCreditsOptions;
+
+// ---- ArNS CLI options ----
+
+export type ArNSPriceOptions = GlobalOptions & {
+  name: string | undefined;
+  type: string | undefined;
+  years: string | undefined;
+  increaseQty: string | undefined;
+  processId: string | undefined;
+};
+
+export type ArNSPurchaseOptions = WalletOptions &
+  ArNSPriceOptions & {
+    paidBy: string[] | undefined;
+  };
+
+export type ArNSPurchaseStatusOptions = GlobalOptions & {
+  nonce: string | undefined;
+};
+
+export type TransferArNSAntOptions = WalletOptions & {
+  antId: string | undefined;
+  target: string | undefined;
+};
+
+export type SetArNSRecordOptions = WalletOptions & {
+  antId: string | undefined;
+  undername: string | undefined;
+  transactionId: string | undefined;
+  ttlSeconds: string | undefined;
+};
+
+export type RemoveArNSRecordOptions = WalletOptions & {
+  antId: string | undefined;
+  undername: string | undefined;
+};

--- a/packages/turbo-sdk/src/common/http.ts
+++ b/packages/turbo-sdk/src/common/http.ts
@@ -96,6 +96,7 @@ export class TurboHTTPService implements TurboHTTPServiceInterface {
     headers,
     data,
     x402Options,
+    retry = true,
   }: {
     endpoint: `/${string}`;
     signal?: AbortSignal;
@@ -103,6 +104,10 @@ export class TurboHTTPService implements TurboHTTPServiceInterface {
     headers?: Partial<TurboSignedRequestHeaders> & Record<string, string>;
     data: Readable | Buffer | ReadableStream | Uint8Array;
     x402Options?: X402RequestCredentials;
+    // See TurboHTTPServiceInterface.post — false disables auto-retry for
+    // non-idempotent signed writes (a retried-but-already-landed write would
+    // otherwise surface a false "already exists"/"nonce used" failure).
+    retry?: boolean;
   }): Promise<T> {
     if (x402Options !== undefined) {
       return this.x402Post({
@@ -117,11 +122,13 @@ export class TurboHTTPService implements TurboHTTPServiceInterface {
     // Convert all data types to fetch-compatible body
     const { body, duplex } = await toFetchBody(data);
 
-    // Use retry for Buffer/Uint8Array, tryRequest for streams
+    // Use retry for Buffer/Uint8Array, tryRequest for streams. Callers can opt
+    // out of retry for non-idempotent signed writes via `retry: false`.
     const isReusableData = data instanceof Buffer || data instanceof Uint8Array;
-    const requestFn = isReusableData
-      ? this.withRetry.bind(this)
-      : this.tryRequest.bind(this);
+    const requestFn =
+      isReusableData && retry
+        ? this.withRetry.bind(this)
+        : this.tryRequest.bind(this);
 
     return requestFn(
       () =>

--- a/packages/turbo-sdk/src/common/index.ts
+++ b/packages/turbo-sdk/src/common/index.ts
@@ -18,3 +18,6 @@ export * from './payment.js';
 export * from './turbo.js';
 export * from './currency.js';
 export * from './token/index.js';
+// Typed errors so consumers can `catch (e) { if (e instanceof InsufficientCreditsError) ... }`
+// e.g. to prompt a top-up on a 402 ArNS purchase.
+export * from '../utils/errors.js';

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ArweaveSigner } from '@dha-team/arbundles';
+import { ArweaveSigner, HexSolanaSigner } from '@dha-team/arbundles';
 import { strict as assert } from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
+import nacl from 'tweetnacl';
 
-import { testJwk } from '../../tests/helpers.js';
+import { testJwk, testSolWallet } from '../../tests/helpers.js';
 import { TurboNodeSigner } from '../node/signer.js';
+import { fromB64Url } from '../utils/base64.js';
+import {
+  FailedRequestError,
+  InsufficientCreditsError,
+  ProvidedInputError,
+} from '../utils/errors.js';
 import {
   TurboAuthenticatedPaymentService,
   TurboUnauthenticatedPaymentService,
@@ -27,7 +34,8 @@ import {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-// Records the last get/post call and returns a canned response.
+// Records the last get/post call and returns a canned response. Set `error` to
+// make the next call reject (used to exercise 402/401/503 handling).
 class FakeHttp {
   public calls: {
     method: string;
@@ -36,13 +44,31 @@ class FakeHttp {
     data?: any;
   }[] = [];
   public response: unknown = {};
+  public error: unknown = undefined;
   async get(args: { endpoint: string; headers?: any }) {
     this.calls.push({ method: 'GET', ...args });
+    if (this.error) throw this.error;
     return this.response;
   }
   async post(args: { endpoint: string; headers?: any; data?: any }) {
     this.calls.push({ method: 'POST', ...args });
+    if (this.error) throw this.error;
     return this.response;
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+// Wraps a real signer to capture the (nonce, additionalData) passed to
+// generateSignedRequestHeaders, so tests can assert the ACTION-BOUND custody
+// message is byte-exact without cracking real signatures open.
+class RecordingSigner {
+  public calls: { nonce: string; additionalData?: string }[] = [];
+  constructor(private readonly inner: TurboNodeSigner) {}
+  async generateSignedRequestHeaders(nonce: string, additionalData?: string) {
+    this.calls.push({ nonce, additionalData });
+    return this.inner.generateSignedRequestHeaders(nonce, additionalData);
   }
   get last() {
     return this.calls[this.calls.length - 1];
@@ -51,6 +77,12 @@ class FakeHttp {
 
 const newSigner = () =>
   new TurboNodeSigner({ signer: new ArweaveSigner(testJwk), token: 'arweave' });
+
+const newSolanaSigner = () =>
+  new TurboNodeSigner({
+    signer: new HexSolanaSigner(testSolWallet),
+    token: 'solana',
+  });
 
 describe('ArNS purchase client', () => {
   let http: FakeHttp;
@@ -66,7 +98,7 @@ describe('ArNS purchase client', () => {
       return s;
     };
 
-    it('getArNSPriceForName builds the price endpoint + query', async () => {
+    it('getArNSPriceForName builds the price endpoint + query (Buy-Name lease)', async () => {
       http.response = { winc: '5', mARIO: '10' };
       const res = await service().getArNSPriceForName({
         intent: 'Buy-Name',
@@ -83,9 +115,107 @@ describe('ArNS purchase client', () => {
       assert.deepEqual(res, { winc: '5', mARIO: '10' });
     });
 
+    it('getArNSPriceForName builds the permabuy price query', async () => {
+      await service().getArNSPriceForName({
+        intent: 'Buy-Name',
+        name: 'my-name',
+        type: 'permabuy',
+        processId: 'ant-123',
+      });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/price/buy-name/my-name?type=permabuy&processId=ant-123',
+      );
+    });
+
+    it('getArNSPriceForName builds the extend-lease price query', async () => {
+      await service().getArNSPriceForName({
+        intent: 'Extend-Lease',
+        name: 'my-name',
+        years: 3,
+      });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/price/extend-lease/my-name?years=3',
+      );
+    });
+
+    it('getArNSPriceForName builds the increase-undername-limit price query', async () => {
+      await service().getArNSPriceForName({
+        intent: 'Increase-Undername-Limit',
+        name: 'my-name',
+        increaseQty: 7,
+      });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/price/increase-undername-limit/my-name?increaseQty=7',
+      );
+    });
+
+    it('getArNSPriceForName builds the upgrade-name price query (no params)', async () => {
+      await service().getArNSPriceForName({
+        intent: 'Upgrade-Name',
+        name: 'my-name',
+      });
+      assert.equal(http.last.endpoint, '/arns/price/upgrade-name/my-name');
+    });
+
+    it('getArNSPriceForName validates required params before hitting the network', async () => {
+      await assert.rejects(
+        () =>
+          service().getArNSPriceForName({
+            // missing processId
+            intent: 'Buy-Name',
+            name: 'my-name',
+            type: 'lease',
+            years: 1,
+          } as never),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /processId/.test((err as Error).message),
+      );
+      assert.equal(http.calls.length, 0, 'no request should be issued');
+    });
+
     it('getArNSPurchaseStatus uses the nonce path', async () => {
       await service().getArNSPurchaseStatus({ nonce: 'abc-nonce' });
       assert.equal(http.last.endpoint, '/arns/purchase/abc-nonce');
+    });
+
+    it('getArNSPurchaseStatus surfaces a terminal SUCCESS (messageId, no failedDate)', async () => {
+      http.response = {
+        name: 'foo',
+        intent: 'Buy-Name',
+        nonce: 'abc-nonce',
+        owner: 'owner-1',
+        wincQty: '5',
+        mARIOQty: '10',
+        usdArRate: 1,
+        usdArioRate: 1,
+        paidBy: [],
+        messageId: 'sol-tx-success',
+      };
+      const res = await service().getArNSPurchaseStatus({ nonce: 'abc-nonce' });
+      assert.equal(res.messageId, 'sol-tx-success');
+      assert.equal(res.failedDate, undefined);
+    });
+
+    it('getArNSPurchaseStatus surfaces a terminal FAILURE (failedDate present)', async () => {
+      http.response = {
+        name: 'foo',
+        intent: 'Buy-Name',
+        nonce: 'abc-nonce',
+        owner: 'owner-1',
+        wincQty: '5',
+        mARIOQty: '10',
+        usdArRate: 1,
+        usdArioRate: 1,
+        paidBy: [],
+        messageId: '',
+        failedDate: '2026-07-14T00:00:00.000Z',
+      };
+      const res = await service().getArNSPurchaseStatus({ nonce: 'abc-nonce' });
+      assert.equal(res.failedDate, '2026-07-14T00:00:00.000Z');
     });
   });
 
@@ -128,6 +258,26 @@ describe('ArNS purchase client', () => {
       assert.equal(res.purchaseReceipt.nonce, res.nonce);
     });
 
+    it('every purchase mints a FRESH UUID nonce (no reuse across calls)', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'x' },
+      };
+      const a = await service().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant',
+      });
+      const b = await service().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant',
+      });
+      assert.notEqual(a.nonce, b.nonce);
+      assert.match(a.nonce, UUID_RE);
+      assert.match(b.nonce, UUID_RE);
+    });
+
     it('per-intent wrappers set the correct intent in the path', async () => {
       const s = service();
       await s.extendArNSLease({ name: 'foo', years: 2 });
@@ -150,6 +300,18 @@ describe('ArNS purchase client', () => {
       );
     });
 
+    it('buyArNSName supports a permabuy (no years, processId set)', async () => {
+      await service().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant-p',
+      });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/purchase/buy-name/foo?type=permabuy&processId=ant-p',
+      );
+    });
+
     it('appends paidBy delegated payers as repeated params', async () => {
       await service().buyArNSName({
         name: 'foo',
@@ -159,6 +321,142 @@ describe('ArNS purchase client', () => {
       });
       assert.ok(http.last.endpoint.includes('paidBy=payer-a'));
       assert.ok(http.last.endpoint.includes('paidBy=payer-b'));
+    });
+
+    it('appends a single paidBy payer', async () => {
+      await service().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant',
+        paidBy: 'solo-payer',
+      });
+      assert.ok(http.last.endpoint.includes('paidBy=solo-payer'));
+    });
+
+    // ---- per-intent required-param validation (fail fast, no network) ----
+
+    it('rejects an unknown intent', async () => {
+      await assert.rejects(
+        () =>
+          service().purchaseArNSName({
+            intent: 'Not-An-Intent',
+            name: 'foo',
+          } as never),
+        ProvidedInputError,
+      );
+      assert.equal(http.calls.length, 0);
+    });
+
+    it('rejects a missing/empty name', async () => {
+      await assert.rejects(
+        () =>
+          service().purchaseArNSName({
+            intent: 'Upgrade-Name',
+            name: '',
+          } as never),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /name/.test((err as Error).message),
+      );
+    });
+
+    it('rejects Buy-Name with a bad type', async () => {
+      await assert.rejects(
+        () =>
+          service().buyArNSName({
+            name: 'foo',
+            type: 'rental' as never,
+            processId: 'ant',
+          }),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /type/.test((err as Error).message),
+      );
+    });
+
+    it('rejects a lease Buy-Name without years', async () => {
+      await assert.rejects(
+        () =>
+          service().buyArNSName({
+            name: 'foo',
+            type: 'lease',
+            processId: 'ant',
+          } as never),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /years/.test((err as Error).message),
+      );
+    });
+
+    it('rejects Extend-Lease without a positive years', async () => {
+      await assert.rejects(
+        () => service().extendArNSLease({ name: 'foo', years: 0 }),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /years/.test((err as Error).message),
+      );
+    });
+
+    it('rejects Increase-Undername-Limit without a positive increaseQty', async () => {
+      await assert.rejects(
+        () =>
+          service().increaseArNSUndernameLimit({ name: 'foo', increaseQty: 0 }),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /increaseQty/.test((err as Error).message),
+      );
+    });
+
+    // ---- error semantics: 402 -> typed, others -> FailedRequestError ----
+
+    it('maps a 402 to a typed InsufficientCreditsError (prompt top-up)', async () => {
+      http.error = new FailedRequestError('insufficient balance', 402);
+      await assert.rejects(
+        () =>
+          service().buyArNSName({
+            name: 'foo',
+            type: 'permabuy',
+            processId: 'ant',
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof InsufficientCreditsError);
+          assert.equal((err as InsufficientCreditsError).status, 402);
+          return true;
+        },
+      );
+    });
+
+    it('propagates a 401 as a FailedRequestError (not insufficient-credits)', async () => {
+      http.error = new FailedRequestError('unauthorized', 401);
+      await assert.rejects(
+        () =>
+          service().buyArNSName({
+            name: 'foo',
+            type: 'permabuy',
+            processId: 'ant',
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof FailedRequestError);
+          assert.ok(!(err instanceof InsufficientCreditsError));
+          assert.equal((err as FailedRequestError).status, 401);
+          return true;
+        },
+      );
+    });
+
+    it('propagates a 503 as a FailedRequestError', async () => {
+      http.error = new FailedRequestError('service unavailable', 503);
+      await assert.rejects(
+        () =>
+          service().buyArNSName({
+            name: 'foo',
+            type: 'permabuy',
+            processId: 'ant',
+          }),
+        (err: unknown) =>
+          err instanceof FailedRequestError &&
+          (err as FailedRequestError).status === 503,
+      );
     });
 
     // The custody methods send a signed, UUID-nonced request to the bound
@@ -211,6 +509,170 @@ describe('ArNS purchase client', () => {
         '/arns/manage/ant-1/remove-record?undername=docs',
       );
       assertSignedHeaders();
+    });
+
+    // ---- ACTION-BOUND custody message is byte-exact ----
+    //
+    // The signature is taken over `<message>\n... + nonce` where <message> is the
+    // canonical `arns\n<action>\n<fields...>` string. This MUST match the bundler
+    // reconstruction byte-for-byte
+    // (ar-io-bundler packages/payment-service/src/utils/verifyArweaveSignature.ts
+    // -> verifySigAndGetNativeAddress, which verifies over `additionalData + nonce`)
+    // or every custody signature is rejected. We capture the `additionalData`
+    // handed to the signer and assert it exactly.
+    describe('custody message is byte-exact (buildArNSCustodyMessage)', () => {
+      const recordingService = () => {
+        const s = new TurboAuthenticatedPaymentService({ signer: newSigner() });
+        (s as unknown as { httpService: FakeHttp }).httpService = http;
+        const rec = new RecordingSigner(
+          (s as unknown as { signer: TurboNodeSigner }).signer,
+        );
+        (s as unknown as { signer: RecordingSigner }).signer = rec;
+        return { s, rec };
+      };
+
+      it('transfer -> "arns\\ntransfer\\n<antId>\\n<target>"', async () => {
+        const { s, rec } = recordingService();
+        await s.transferArNSAnt({ antId: 'ant-1', target: 'tgt-1' });
+        assert.equal(rec.last.additionalData, 'arns\ntransfer\nant-1\ntgt-1');
+      });
+
+      it('set-record -> "arns\\nset-record\\n<antId>\\n<undername>\\n<txId>\\n<ttl>"', async () => {
+        const { s, rec } = recordingService();
+        await s.setArNSRecord({
+          antId: 'ant-1',
+          undername: 'docs',
+          transactionId: 'tx-1',
+          ttlSeconds: 900,
+        });
+        assert.equal(
+          rec.last.additionalData,
+          'arns\nset-record\nant-1\ndocs\ntx-1\n900',
+        );
+      });
+
+      it('set-record binds the DEFAULT @ undername', async () => {
+        const { s, rec } = recordingService();
+        await s.setArNSRecord({
+          antId: 'ant-1',
+          transactionId: 'tx-1',
+          ttlSeconds: 900,
+        });
+        assert.equal(
+          rec.last.additionalData,
+          'arns\nset-record\nant-1\n@\ntx-1\n900',
+        );
+      });
+
+      it('remove-record -> "arns\\nremove-record\\n<antId>\\n<undername>"', async () => {
+        const { s, rec } = recordingService();
+        await s.removeArNSRecord({ antId: 'ant-1', undername: 'docs' });
+        assert.equal(
+          rec.last.additionalData,
+          'arns\nremove-record\nant-1\ndocs',
+        );
+      });
+    });
+  });
+
+  // =========================================================================
+  // SIGNED-BYTES CONTRACT REGRESSION GUARD (Solana / ed25519).
+  //
+  // This pins the canonical Solana signing convention that the SDK<->bundler
+  // contract depends on. arbundles' `HexSolanaSigner` HEX-ENCODES the message
+  // before ed25519-signing:  sign(m) == nacl.sign(utf8(hex(utf8(m)))).
+  //
+  // A recently-found launch-blocker was the bundler verifying over the RAW
+  // preimage (utf8(m)) instead of the hex preimage, so every Solana-signed ArNS
+  // request failed. The bundler verifier convention now lives in
+  //   ar-io-bundler packages/payment-service/src/utils/verifyArweaveSignature.ts
+  //   -> verifySolanaSignature  (must verify over the SAME preimage this asserts).
+  //
+  // If arbundles ever changes the hex-encoding (or someone swaps the Solana
+  // signer), these assertions fail LOUDLY instead of silently drifting.
+  // =========================================================================
+  describe('Solana signed-bytes contract (regression guard)', () => {
+    const solService = () => {
+      const s = new TurboAuthenticatedPaymentService({
+        signer: newSolanaSigner(),
+        token: 'solana',
+      });
+      (s as unknown as { httpService: FakeHttp }).httpService = http;
+      return s;
+    };
+
+    // ed25519 detached-verify helper mirroring the bundler's verifySolanaSignature.
+    const verifyOver = (
+      preimage: Buffer,
+      sigB64Url: string,
+      pubB64Url: string,
+    ): boolean =>
+      nacl.sign.detached.verify(
+        new Uint8Array(preimage),
+        new Uint8Array(fromB64Url(sigB64Url)),
+        new Uint8Array(fromB64Url(pubB64Url)),
+      );
+
+    it('a purchase signature verifies over the HEX preimage of the nonce, NOT the raw bytes', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'sol-tx' },
+      };
+      await solService().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant',
+      });
+
+      const { headers } = http.last;
+      assert.equal(headers['x-signature-type'], '4'); // solana/ed25519
+      const nonce: string = headers['x-nonce'];
+      assert.match(nonce, UUID_RE);
+
+      // The signed message is the bare nonce (no action-binding on purchase).
+      const message = Buffer.from(nonce);
+      const hexPreimage = Buffer.from(message.toString('hex')); // canonical
+      const rawPreimage = message; // the buggy convention
+
+      assert.ok(
+        verifyOver(hexPreimage, headers['x-signature'], headers['x-public-key']),
+        'signature MUST verify over the hex preimage (HexSolanaSigner convention)',
+      );
+      assert.ok(
+        !verifyOver(
+          rawPreimage,
+          headers['x-signature'],
+          headers['x-public-key'],
+        ),
+        'signature MUST NOT verify over the raw preimage (guards the launch-blocker)',
+      );
+    });
+
+    it('a custody signature verifies over the HEX preimage of (message + nonce)', async () => {
+      http.response = { antId: 'ant-1', target: 'tgt-1', messageId: 'm' };
+      await solService().transferArNSAnt({ antId: 'ant-1', target: 'tgt-1' });
+
+      const { headers } = http.last;
+      assert.equal(headers['x-signature-type'], '4');
+      const nonce: string = headers['x-nonce'];
+
+      // action-bound message + nonce, exactly what the bundler reconstructs
+      const signed = Buffer.from('arns\ntransfer\nant-1\ntgt-1' + nonce);
+      const hexPreimage = Buffer.from(signed.toString('hex'));
+
+      assert.ok(
+        verifyOver(hexPreimage, headers['x-signature'], headers['x-public-key']),
+        'custody signature MUST verify over hex(message + nonce)',
+      );
+      // A different action must NOT verify (proves the binding is real).
+      const wrong = Buffer.from(
+        Buffer.from('arns\nremove-record\nant-1\ntgt-1' + nonce).toString(
+          'hex',
+        ),
+      );
+      assert.ok(
+        !verifyOver(wrong, headers['x-signature'], headers['x-public-key']),
+      );
     });
   });
 });

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -170,17 +170,32 @@ describe('ArNS purchase client', () => {
       await assert.rejects(
         () =>
           service().getArNSPriceForName({
-            // missing processId
+            // lease missing `years`
             intent: 'Buy-Name',
             name: 'my-name',
             type: 'lease',
-            years: 1,
           } as never),
         (err: unknown) =>
           err instanceof ProvidedInputError &&
-          /processId/.test((err as Error).message),
+          /years/.test((err as Error).message),
       );
       assert.equal(http.calls.length, 0, 'no request should be issued');
+    });
+
+    it('getArNSPriceForName omits processId from the query when not supplied (custodial)', async () => {
+      await service().getArNSPriceForName({
+        intent: 'Buy-Name',
+        name: 'my-name',
+        type: 'permabuy',
+      });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/price/buy-name/my-name?type=permabuy',
+      );
+      assert.ok(
+        !http.last.endpoint.includes('processId'),
+        'no processId query param should be sent',
+      );
     });
 
     it('getArNSPurchaseStatus uses the nonce path', async () => {
@@ -342,6 +357,74 @@ describe('ArNS purchase client', () => {
       assert.equal(
         http.last.endpoint,
         '/arns/purchase/buy-name/foo?type=permabuy&processId=ant-p',
+      );
+    });
+
+    // Custodial provisioning (Model A): omitting processId must send NO
+    // processId query param so the bundler spawns + owns the ANT.
+    it('buyArNSName WITHOUT processId omits it from the query (custodial permabuy)', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'x' },
+      };
+      await service().buyArNSName({ name: 'foo', type: 'permabuy' });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/purchase/buy-name/foo?type=permabuy',
+      );
+      assert.ok(
+        !http.last.endpoint.includes('processId'),
+        'no processId query param should be sent for a custodial buy',
+      );
+    });
+
+    it('buyArNSName WITHOUT processId omits it from the query (custodial lease)', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'x' },
+      };
+      await service().buyArNSName({ name: 'foo', type: 'lease', years: 2 });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/purchase/buy-name/foo?type=lease&years=2',
+      );
+      assert.ok(!http.last.endpoint.includes('processId'));
+    });
+
+    it('buyArNSName WITH processId still includes it in the query (user-owned ANT)', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'x' },
+      };
+      await service().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant',
+      });
+      assert.ok(http.last.endpoint.includes('processId=ant'));
+    });
+
+    it('validateArNSPurchaseParams no longer rejects a Buy-Name missing processId', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'x' },
+      };
+      // Must NOT throw a ProvidedInputError; a request should be issued.
+      await service().buyArNSName({ name: 'foo', type: 'permabuy' });
+      assert.equal(http.last.method, 'POST');
+    });
+
+    it('rejects a Buy-Name with an explicit empty-string processId', async () => {
+      await assert.rejects(
+        () =>
+          service().buyArNSName({
+            name: 'foo',
+            type: 'permabuy',
+            processId: '',
+          }),
+        (err: unknown) =>
+          err instanceof ProvidedInputError &&
+          /processId/.test((err as Error).message),
       );
     });
 

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -160,5 +160,57 @@ describe('ArNS purchase client', () => {
       assert.ok(http.last.endpoint.includes('paidBy=payer-a'));
       assert.ok(http.last.endpoint.includes('paidBy=payer-b'));
     });
+
+    // The custody methods send a signed, UUID-nonced request to the bound
+    // endpoint. (Cross-system binding correctness — that the signed message
+    // equals the bundler's canonical string — is enforced by both sides using
+    // the identical newline-delimited builder + the bundler's binding tests.)
+    const assertSignedHeaders = () => {
+      assert.match(http.last.headers['x-nonce'], UUID_RE);
+      assert.ok(http.last.headers['x-public-key']?.length > 0);
+      assert.ok(http.last.headers['x-signature']?.length > 0);
+      assert.equal(http.last.headers['x-signature-type'], '1'); // arweave
+      assert.ok(Buffer.isBuffer(http.last.data));
+    };
+
+    it('transferArNSAnt posts to the transfer endpoint with a signed request', async () => {
+      http.response = { antId: 'ant-1', target: 'tgt-1', messageId: 'm' };
+      await service().transferArNSAnt({ antId: 'ant-1', target: 'tgt-1' });
+      assert.equal(http.last.method, 'POST');
+      assert.equal(http.last.endpoint, '/arns/transfer/ant-1?target=tgt-1');
+      assertSignedHeaders();
+    });
+
+    it('setArNSRecord posts the record op with a signed request', async () => {
+      await service().setArNSRecord({
+        antId: 'ant-1',
+        undername: 'docs',
+        transactionId: 'tx-1',
+        ttlSeconds: 900,
+      });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/manage/ant-1/set-record?undername=docs&transactionId=tx-1&ttlSeconds=900',
+      );
+      assertSignedHeaders();
+    });
+
+    it('setArNSRecord defaults undername to @', async () => {
+      await service().setArNSRecord({
+        antId: 'ant-1',
+        transactionId: 'tx-1',
+        ttlSeconds: 900,
+      });
+      assert.ok(http.last.endpoint.includes('undername=%40'));
+    });
+
+    it('removeArNSRecord posts the remove op with a signed request', async () => {
+      await service().removeArNSRecord({ antId: 'ant-1', undername: 'docs' });
+      assert.equal(
+        http.last.endpoint,
+        '/arns/manage/ant-1/remove-record?undername=docs',
+      );
+      assertSignedHeaders();
+    });
   });
 });

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -42,6 +42,7 @@ class FakeHttp {
     endpoint: string;
     headers?: any;
     data?: any;
+    retry?: boolean;
   }[] = [];
   public response: unknown = {};
   public error: unknown = undefined;
@@ -50,7 +51,12 @@ class FakeHttp {
     if (this.error) throw this.error;
     return this.response;
   }
-  async post(args: { endpoint: string; headers?: any; data?: any }) {
+  async post(args: {
+    endpoint: string;
+    headers?: any;
+    data?: any;
+    retry?: boolean;
+  }) {
     this.calls.push({ method: 'POST', ...args });
     if (this.error) throw this.error;
     return this.response;
@@ -225,6 +231,33 @@ describe('ArNS purchase client', () => {
       (s as unknown as { httpService: FakeHttp }).httpService = http;
       return s;
     };
+
+    // Regression: non-idempotent signed writes must NOT auto-retry — the nonce
+    // is single-use, so a retried-but-already-landed write 4xxs as
+    // "already exists"/"nonce used" and surfaces a false failure.
+    it('non-idempotent ArNS writes disable HTTP auto-retry (retry:false)', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo' },
+        arioWriteResult: { id: 'x' },
+      };
+      const s = service();
+      await s.buyArNSName({ name: 'foo', type: 'permabuy', processId: 'ant' });
+      assert.equal(http.last.method, 'POST');
+      assert.equal(http.last.retry, false);
+
+      await s.transferArNSAnt({ antId: 'ant-1', target: 'tgt-1' });
+      assert.equal(http.last.retry, false);
+
+      await s.setArNSRecord({
+        antId: 'ant-1',
+        transactionId: 'tx-1',
+        ttlSeconds: 900,
+      });
+      assert.equal(http.last.retry, false);
+
+      await s.removeArNSRecord({ antId: 'ant-1', undername: 'docs' });
+      assert.equal(http.last.retry, false);
+    });
 
     it('purchaseArNSName signs a UUID nonce + sends signature-type, returns the nonce', async () => {
       http.response = {

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -635,7 +635,11 @@ describe('ArNS purchase client', () => {
       const rawPreimage = message; // the buggy convention
 
       assert.ok(
-        verifyOver(hexPreimage, headers['x-signature'], headers['x-public-key']),
+        verifyOver(
+          hexPreimage,
+          headers['x-signature'],
+          headers['x-public-key'],
+        ),
         'signature MUST verify over the hex preimage (HexSolanaSigner convention)',
       );
       assert.ok(
@@ -661,7 +665,11 @@ describe('ArNS purchase client', () => {
       const hexPreimage = Buffer.from(signed.toString('hex'));
 
       assert.ok(
-        verifyOver(hexPreimage, headers['x-signature'], headers['x-public-key']),
+        verifyOver(
+          hexPreimage,
+          headers['x-signature'],
+          headers['x-public-key'],
+        ),
         'custody signature MUST verify over hex(message + nonce)',
       );
       // A different action must NOT verify (proves the binding is real).

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -123,6 +123,9 @@ describe('ArNS purchase client', () => {
       // returned nonce is the one that was signed/sent
       assert.equal(res.nonce, http.last.headers['x-nonce']);
       assert.match(res.nonce, UUID_RE);
+      // both the top-level and nested receipt nonce are normalized to the
+      // signed nonce (the service echo of `purchaseReceipt.nonce` is ignored)
+      assert.equal(res.purchaseReceipt.nonce, res.nonce);
     });
 
     it('per-intent wrappers set the correct intent in the path', async () => {

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ArweaveSigner } from '@dha-team/arbundles';
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { testJwk } from '../../tests/helpers.js';
+import { TurboNodeSigner } from '../node/signer.js';
+import {
+  TurboAuthenticatedPaymentService,
+  TurboUnauthenticatedPaymentService,
+} from './payment.js';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// Records the last get/post call and returns a canned response.
+class FakeHttp {
+  public calls: {
+    method: string;
+    endpoint: string;
+    headers?: any;
+    data?: any;
+  }[] = [];
+  public response: unknown = {};
+  async get(args: { endpoint: string; headers?: any }) {
+    this.calls.push({ method: 'GET', ...args });
+    return this.response;
+  }
+  async post(args: { endpoint: string; headers?: any; data?: any }) {
+    this.calls.push({ method: 'POST', ...args });
+    return this.response;
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+const newSigner = () =>
+  new TurboNodeSigner({ signer: new ArweaveSigner(testJwk), token: 'arweave' });
+
+describe('ArNS purchase client', () => {
+  let http: FakeHttp;
+
+  beforeEach(() => {
+    http = new FakeHttp();
+  });
+
+  describe('unauthenticated', () => {
+    const service = () => {
+      const s = new TurboUnauthenticatedPaymentService({});
+      (s as unknown as { httpService: FakeHttp }).httpService = http;
+      return s;
+    };
+
+    it('getArNSPriceForName builds the price endpoint + query', async () => {
+      http.response = { winc: '5', mARIO: '10' };
+      const res = await service().getArNSPriceForName({
+        intent: 'Buy-Name',
+        name: 'my-name',
+        type: 'lease',
+        years: 1,
+        processId: 'ant-123',
+      });
+      assert.equal(http.last.method, 'GET');
+      assert.equal(
+        http.last.endpoint,
+        '/arns/price/buy-name/my-name?type=lease&years=1&processId=ant-123',
+      );
+      assert.deepEqual(res, { winc: '5', mARIO: '10' });
+    });
+
+    it('getArNSPurchaseStatus uses the nonce path', async () => {
+      await service().getArNSPurchaseStatus({ nonce: 'abc-nonce' });
+      assert.equal(http.last.endpoint, '/arns/purchase/abc-nonce');
+    });
+  });
+
+  describe('authenticated', () => {
+    const service = () => {
+      const s = new TurboAuthenticatedPaymentService({ signer: newSigner() });
+      (s as unknown as { httpService: FakeHttp }).httpService = http;
+      return s;
+    };
+
+    it('purchaseArNSName signs a UUID nonce + sends signature-type, returns the nonce', async () => {
+      http.response = {
+        purchaseReceipt: { name: 'foo', nonce: 'ignored' },
+        arioWriteResult: { id: 'sol-tx' },
+      };
+      const res = await service().purchaseArNSName({
+        intent: 'Buy-Name',
+        name: 'foo',
+        type: 'lease',
+        years: 1,
+        processId: 'ant-xyz',
+      });
+
+      assert.equal(http.last.method, 'POST');
+      assert.equal(
+        http.last.endpoint,
+        '/arns/purchase/buy-name/foo?type=lease&years=1&processId=ant-xyz',
+      );
+      // UUID nonce, signed, with signature type advertised
+      assert.match(http.last.headers['x-nonce'], UUID_RE);
+      assert.equal(http.last.headers['x-signature-type'], '1'); // arweave
+      assert.ok(http.last.headers['x-public-key']?.length > 0);
+      assert.ok(http.last.headers['x-signature']?.length > 0);
+      assert.ok(Buffer.isBuffer(http.last.data));
+      // returned nonce is the one that was signed/sent
+      assert.equal(res.nonce, http.last.headers['x-nonce']);
+      assert.match(res.nonce, UUID_RE);
+    });
+
+    it('per-intent wrappers set the correct intent in the path', async () => {
+      const s = service();
+      await s.extendArNSLease({ name: 'foo', years: 2 });
+      assert.ok(
+        http.last.endpoint.startsWith('/arns/purchase/extend-lease/foo'),
+      );
+      assert.ok(http.last.endpoint.includes('years=2'));
+
+      await s.increaseArNSUndernameLimit({ name: 'foo', increaseQty: 5 });
+      assert.ok(
+        http.last.endpoint.startsWith(
+          '/arns/purchase/increase-undername-limit/foo',
+        ),
+      );
+      assert.ok(http.last.endpoint.includes('increaseQty=5'));
+
+      await s.upgradeArNSName({ name: 'foo' });
+      assert.ok(
+        http.last.endpoint.startsWith('/arns/purchase/upgrade-name/foo'),
+      );
+    });
+
+    it('appends paidBy delegated payers as repeated params', async () => {
+      await service().buyArNSName({
+        name: 'foo',
+        type: 'permabuy',
+        processId: 'ant',
+        paidBy: ['payer-a', 'payer-b'],
+      });
+      assert.ok(http.last.endpoint.includes('paidBy=payer-a'));
+      assert.ok(http.last.endpoint.includes('paidBy=payer-b'));
+    });
+  });
+});

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -62,8 +62,14 @@ import {
   TurboWincForTokenParams,
   TurboWincForTokenResponse,
   UserAddress,
+  arNSPurchaseIntents,
 } from '../types.js';
 import { isAnyValidUserAddress } from '../utils/common.js';
+import {
+  FailedRequestError,
+  InsufficientCreditsError,
+  ProvidedInputError,
+} from '../utils/errors.js';
 import { uuidV4 } from '../utils/uuid.js';
 import { defaultRetryConfig } from './http.js';
 import { TurboHTTPService } from './http.js';
@@ -187,14 +193,84 @@ export class TurboUnauthenticatedPaymentService
     };
   }
 
-  public getArNSPriceForName(
+  public async getArNSPriceForName(
     params: ArNSPriceParams,
   ): Promise<ArNSPriceResponse> {
+    // `async` so a validation failure surfaces as a rejected promise (consistent
+    // with `purchaseArNSName`) rather than a synchronous throw.
+    this.validateArNSPurchaseParams(params);
     return this.httpService.get<ArNSPriceResponse>({
       endpoint: `/arns/price/${params.intent.toLowerCase()}/${
         params.name
       }${this.buildArNSPurchaseQuery(params)}`,
     });
+  }
+
+  /**
+   * Fail fast (client-side) on malformed ArNS requests so JS callers that bypass
+   * the compile-time intent unions get a clear `ProvidedInputError` instead of an
+   * opaque service 4xx. Enforces the required fields per intent:
+   *  - `Buy-Name`: `type` ('lease' | 'permabuy') + `processId`; leases also need `years`
+   *  - `Extend-Lease`: positive `years`
+   *  - `Increase-Undername-Limit`: positive `increaseQty`
+   *  - `Upgrade-Name`: just `name`
+   */
+  protected validateArNSPurchaseParams(params: ArNSPriceParams): void {
+    const p = params as {
+      intent?: string;
+      name?: string;
+      type?: string;
+      years?: number;
+      increaseQty?: number;
+      processId?: string;
+    };
+    if (!arNSPurchaseIntents.includes(p.intent as never)) {
+      throw new ProvidedInputError(
+        `Invalid ArNS intent '${
+          p.intent
+        }'. Expected one of: ${arNSPurchaseIntents.join(', ')}.`,
+      );
+    }
+    if (typeof p.name !== 'string' || p.name.length === 0) {
+      throw new ProvidedInputError('An ArNS `name` is required.');
+    }
+    const isPositiveNumber = (v: unknown): boolean =>
+      typeof v === 'number' && Number.isFinite(v) && v > 0;
+    switch (p.intent) {
+      case 'Buy-Name':
+        if (p.type !== 'lease' && p.type !== 'permabuy') {
+          throw new ProvidedInputError(
+            "Buy-Name requires a `type` of 'lease' or 'permabuy'.",
+          );
+        }
+        if (typeof p.processId !== 'string' || p.processId.length === 0) {
+          throw new ProvidedInputError(
+            'Buy-Name requires a `processId` (the ANT the name resolves to).',
+          );
+        }
+        if (p.type === 'lease' && !isPositiveNumber(p.years)) {
+          throw new ProvidedInputError(
+            'A lease `Buy-Name` requires a positive `years`.',
+          );
+        }
+        break;
+      case 'Extend-Lease':
+        if (!isPositiveNumber(p.years)) {
+          throw new ProvidedInputError(
+            'Extend-Lease requires a positive `years`.',
+          );
+        }
+        break;
+      case 'Increase-Undername-Limit':
+        if (!isPositiveNumber(p.increaseQty)) {
+          throw new ProvidedInputError(
+            'Increase-Undername-Limit requires a positive `increaseQty`.',
+          );
+        }
+        break;
+      case 'Upgrade-Name':
+        break;
+    }
   }
 
   public getArNSPurchaseStatus({
@@ -487,21 +563,34 @@ export class TurboAuthenticatedPaymentService
   public async purchaseArNSName(
     params: ArNSPurchaseParams,
   ): Promise<ArNSPurchaseResponse> {
+    this.validateArNSPurchaseParams(params);
     // The bundler requires the signed nonce to be a UUID; it also doubles as
     // the idempotency + status-lookup key (`getArNSPurchaseStatus`).
     const nonce = uuidV4();
     const headers = await this.signer.generateSignedRequestHeaders(nonce);
-    const response = await this.httpService.post<
-      Omit<ArNSPurchaseResponse, 'nonce'>
-    >({
-      endpoint: `/arns/purchase/${params.intent.toLowerCase()}/${
-        params.name
-      }${this.buildArNSPurchaseQuery(params)}`,
-      headers,
-      // Params travel in the query string + signed headers; the service reads no
-      // body, but the HTTP layer requires a `data` field.
-      data: Buffer.from([]),
-    });
+    let response: Omit<ArNSPurchaseResponse, 'nonce'>;
+    try {
+      response = await this.httpService.post<
+        Omit<ArNSPurchaseResponse, 'nonce'>
+      >({
+        endpoint: `/arns/purchase/${params.intent.toLowerCase()}/${
+          params.name
+        }${this.buildArNSPurchaseQuery(params)}`,
+        headers,
+        // Params travel in the query string + signed headers; the service reads
+        // no body, but the HTTP layer requires a `data` field.
+        data: Buffer.from([]),
+      });
+    } catch (error) {
+      // Surface a credit shortfall as a typed, catchable error so callers can
+      // prompt a top-up. The `nonce` is the idempotency key: after topping up,
+      // retry the same purchase (a fresh nonce is fine — the service dedupes by
+      // the on-chain effect, and a captured nonce lets you poll status).
+      if (error instanceof FailedRequestError && error.status === 402) {
+        throw new InsufficientCreditsError(error.message);
+      }
+      throw error;
+    }
     // Normalize both nonce fields to the one we signed so callers can poll with
     // either `response.nonce` or `response.purchaseReceipt.nonce`.
     return {

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -541,6 +541,108 @@ export class TurboAuthenticatedPaymentService
     return this.purchaseArNSName({ ...params, intent: 'Upgrade-Name' });
   }
 
+  // ---- ArNS ANT custody: self-custody exit + manage records ----
+
+  // Canonical ACTION-BOUND message. MUST match the bundler's
+  // buildArNSCustodyMessage byte-for-byte (newline-delimited) or every signature
+  // is rejected. The bundler reconstructs this from the request and verifies the
+  // signature over `message + nonce`, so a captured signature can't be replayed
+  // against a different operation/params.
+  private buildArNSCustodyMessage(
+    action: 'transfer' | 'set-record' | 'remove-record',
+    fields: string[],
+  ): string {
+    return ['arns', action, ...fields].join('\n');
+  }
+
+  /**
+   * Self-custody exit: move a Turbo-custodied ANT to a Solana pubkey you control.
+   * Authenticated with an action-bound, single-use signature.
+   */
+  public async transferArNSAnt({
+    antId,
+    target,
+  }: {
+    antId: string;
+    target: string;
+  }): Promise<{
+    antId: string;
+    target: string;
+    name?: string;
+    messageId: string;
+  }> {
+    const nonce = uuidV4();
+    const headers = await this.signer.generateSignedRequestHeaders(
+      nonce,
+      this.buildArNSCustodyMessage('transfer', [antId, target]),
+    );
+    return this.httpService.post({
+      endpoint: `/arns/transfer/${antId}?target=${encodeURIComponent(target)}`,
+      headers,
+      data: Buffer.from([]),
+    });
+  }
+
+  /** Set a resolution record on a custodied ANT (undername defaults to '@'). */
+  public async setArNSRecord({
+    antId,
+    undername = '@',
+    transactionId,
+    ttlSeconds,
+  }: {
+    antId: string;
+    undername?: string;
+    transactionId: string;
+    ttlSeconds: number;
+  }): Promise<{
+    antId: string;
+    undername: string;
+    transactionId: string;
+    ttlSeconds: number;
+    messageId: string;
+  }> {
+    const nonce = uuidV4();
+    const headers = await this.signer.generateSignedRequestHeaders(
+      nonce,
+      this.buildArNSCustodyMessage('set-record', [
+        antId,
+        undername,
+        transactionId,
+        String(ttlSeconds),
+      ]),
+    );
+    const query = `?undername=${encodeURIComponent(
+      undername,
+    )}&transactionId=${transactionId}&ttlSeconds=${ttlSeconds}`;
+    return this.httpService.post({
+      endpoint: `/arns/manage/${antId}/set-record${query}`,
+      headers,
+      data: Buffer.from([]),
+    });
+  }
+
+  /** Remove a resolution record (an undername) from a custodied ANT. */
+  public async removeArNSRecord({
+    antId,
+    undername,
+  }: {
+    antId: string;
+    undername: string;
+  }): Promise<{ antId: string; undername: string; messageId: string }> {
+    const nonce = uuidV4();
+    const headers = await this.signer.generateSignedRequestHeaders(
+      nonce,
+      this.buildArNSCustodyMessage('remove-record', [antId, undername]),
+    );
+    return this.httpService.post({
+      endpoint: `/arns/manage/${antId}/remove-record?undername=${encodeURIComponent(
+        undername,
+      )}`,
+      headers,
+      data: Buffer.from([]),
+    });
+  }
+
   public async getCreditShareApprovals({
     userAddress,
   }: {

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -16,6 +16,12 @@
 import { BigNumber } from 'bignumber.js';
 
 import {
+  ArNSNameType,
+  ArNSPriceParams,
+  ArNSPriceResponse,
+  ArNSPurchaseParams,
+  ArNSPurchaseResponse,
+  ArNSPurchaseStatusResponse,
   Currency,
   GetCreditShareApprovalsResponse,
   RawWincForTokenResponse,
@@ -53,6 +59,7 @@ import {
   UserAddress,
 } from '../types.js';
 import { isAnyValidUserAddress } from '../utils/common.js';
+import { uuidV4 } from '../utils/uuid.js';
 import { defaultRetryConfig } from './http.js';
 import { TurboHTTPService } from './http.js';
 import { Logger } from './logger.js';
@@ -173,6 +180,58 @@ export class TurboUnauthenticatedPaymentService
       actualTokenAmount: tokenAmount.toString(),
       equivalentWincTokenAmount: actualPaymentAmount.toString(),
     };
+  }
+
+  public getArNSPriceForName({
+    intent,
+    name,
+    type,
+    years,
+    increaseQty,
+    processId,
+  }: ArNSPriceParams): Promise<ArNSPriceResponse> {
+    return this.httpService.get<ArNSPriceResponse>({
+      endpoint: `/arns/price/${intent.toLowerCase()}/${name}${this.buildArNSPurchaseQuery(
+        { type, years, increaseQty, processId },
+      )}`,
+    });
+  }
+
+  public getArNSPurchaseStatus({
+    nonce,
+  }: {
+    nonce: string;
+  }): Promise<ArNSPurchaseStatusResponse> {
+    return this.httpService.get<ArNSPurchaseStatusResponse>({
+      endpoint: `/arns/purchase/${nonce}`,
+    });
+  }
+
+  protected buildArNSPurchaseQuery({
+    type,
+    years,
+    increaseQty,
+    processId,
+    paidBy,
+  }: {
+    type?: ArNSNameType;
+    years?: number;
+    increaseQty?: number;
+    processId?: string;
+    paidBy?: UserAddress | UserAddress[];
+  }): string {
+    const params = new URLSearchParams();
+    if (type !== undefined) params.set('type', type);
+    if (years !== undefined) params.set('years', `${years}`);
+    if (increaseQty !== undefined) params.set('increaseQty', `${increaseQty}`);
+    if (processId !== undefined) params.set('processId', processId);
+    if (paidBy !== undefined) {
+      for (const payer of Array.isArray(paidBy) ? paidBy : [paidBy]) {
+        params.append('paidBy', payer);
+      }
+    }
+    const query = params.toString();
+    return query.length > 0 ? `?${query}` : '';
   }
 
   protected appendPromoCodesToQuery(promoCodes: string[]): string {
@@ -422,6 +481,72 @@ export class TurboAuthenticatedPaymentService
   public async getBalance(userAddress?: string): Promise<TurboBalanceResponse> {
     userAddress ??= await this.signer.getNativeAddress();
     return super.getBalance(userAddress);
+  }
+
+  /**
+   * Buy / extend / upgrade an ArNS name, paying with the signer's Turbo credit
+   * balance. The bundler performs the on-chain ARIO purchase and debits credits;
+   * a `402` (FailedRequestError.status === 402) indicates insufficient credits.
+   */
+  public async purchaseArNSName({
+    intent,
+    name,
+    type,
+    years,
+    increaseQty,
+    processId,
+    paidBy,
+  }: ArNSPurchaseParams): Promise<ArNSPurchaseResponse> {
+    // The bundler requires the signed nonce to be a UUID; it also doubles as
+    // the idempotency + status-lookup key (`getArNSPurchaseStatus`).
+    const nonce = uuidV4();
+    const headers = await this.signer.generateSignedRequestHeaders(nonce);
+    const response = await this.httpService.post<
+      Omit<ArNSPurchaseResponse, 'nonce'>
+    >({
+      endpoint: `/arns/purchase/${intent.toLowerCase()}/${name}${this.buildArNSPurchaseQuery(
+        { type, years, increaseQty, processId, paidBy },
+      )}`,
+      headers,
+      // Params travel in the query string + signed headers; the service reads no
+      // body, but the HTTP layer requires a `data` field.
+      data: Buffer.from([]),
+    });
+    return { ...response, nonce };
+  }
+
+  public buyArNSName(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'increaseQty'>,
+  ): Promise<ArNSPurchaseResponse> {
+    return this.purchaseArNSName({ ...params, intent: 'Buy-Name' });
+  }
+
+  public extendArNSLease(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'increaseQty'> & {
+      years: number;
+    },
+  ): Promise<ArNSPurchaseResponse> {
+    return this.purchaseArNSName({ ...params, intent: 'Extend-Lease' });
+  }
+
+  public increaseArNSUndernameLimit(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'years'> & {
+      increaseQty: number;
+    },
+  ): Promise<ArNSPurchaseResponse> {
+    return this.purchaseArNSName({
+      ...params,
+      intent: 'Increase-Undername-Limit',
+    });
+  }
+
+  public upgradeArNSName(
+    params: Omit<
+      ArNSPurchaseParams,
+      'intent' | 'type' | 'years' | 'increaseQty'
+    >,
+  ): Promise<ArNSPurchaseResponse> {
+    return this.purchaseArNSName({ ...params, intent: 'Upgrade-Name' });
   }
 
   public async getCreditShareApprovals({

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -580,6 +580,10 @@ export class TurboAuthenticatedPaymentService
         // Params travel in the query string + signed headers; the service reads
         // no body, but the HTTP layer requires a `data` field.
         data: Buffer.from([]),
+        // Non-idempotent signed write: the nonce is single-use, so a retried
+        // (but already-landed) purchase would 4xx as "already exists". Poll
+        // status by nonce instead of retrying.
+        retry: false,
       });
     } catch (error) {
       // Surface a credit shortfall as a typed, catchable error so callers can
@@ -669,6 +673,7 @@ export class TurboAuthenticatedPaymentService
       endpoint: `/arns/transfer/${antId}?target=${encodeURIComponent(target)}`,
       headers,
       data: Buffer.from([]),
+      retry: false, // single-use action-bound nonce; don't re-POST on 5xx
     });
   }
 
@@ -707,6 +712,7 @@ export class TurboAuthenticatedPaymentService
       endpoint: `/arns/manage/${antId}/set-record${query}`,
       headers,
       data: Buffer.from([]),
+      retry: false, // single-use action-bound nonce; don't re-POST on 5xx
     });
   }
 
@@ -729,6 +735,7 @@ export class TurboAuthenticatedPaymentService
       )}`,
       headers,
       data: Buffer.from([]),
+      retry: false, // single-use action-bound nonce; don't re-POST on 5xx
     });
   }
 

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -16,7 +16,7 @@
 import { BigNumber } from 'bignumber.js';
 
 import {
-  ArNSBuyNameParams,
+  ArNSBuyNameArgs,
   ArNSExtendLeaseParams,
   ArNSIncreaseUndernameLimitParams,
   ArNSNameType,
@@ -210,7 +210,9 @@ export class TurboUnauthenticatedPaymentService
    * Fail fast (client-side) on malformed ArNS requests so JS callers that bypass
    * the compile-time intent unions get a clear `ProvidedInputError` instead of an
    * opaque service 4xx. Enforces the required fields per intent:
-   *  - `Buy-Name`: `type` ('lease' | 'permabuy') + `processId`; leases also need `years`
+   *  - `Buy-Name`: `type` ('lease' | 'permabuy'); leases also need `years`.
+   *    `processId` is OPTIONAL — omit it to have the bundler custodially
+   *    provision the ANT (Turbo owns it), supply it for a user-owned ANT.
    *  - `Extend-Lease`: positive `years`
    *  - `Increase-Undername-Limit`: positive `increaseQty`
    *  - `Upgrade-Name`: just `name`
@@ -243,9 +245,15 @@ export class TurboUnauthenticatedPaymentService
             "Buy-Name requires a `type` of 'lease' or 'permabuy'.",
           );
         }
-        if (typeof p.processId !== 'string' || p.processId.length === 0) {
+        // `processId` is optional for Buy-Name: omitting it drives the
+        // bundler's custodial provisioning path (Turbo spawns + owns the ANT).
+        // If supplied it must be a non-empty string (user-owned ANT).
+        if (
+          p.processId !== undefined &&
+          (typeof p.processId !== 'string' || p.processId.length === 0)
+        ) {
           throw new ProvidedInputError(
-            'Buy-Name requires a `processId` (the ANT the name resolves to).',
+            'Buy-Name `processId`, when provided, must be a non-empty string (the ANT the name resolves to).',
           );
         }
         if (p.type === 'lease' && !isPositiveNumber(p.years)) {
@@ -604,9 +612,7 @@ export class TurboAuthenticatedPaymentService
     };
   }
 
-  public buyArNSName(
-    params: Omit<ArNSBuyNameParams, 'intent'> & ArNSPaidByParams,
-  ): Promise<ArNSPurchaseResponse> {
+  public buyArNSName(params: ArNSBuyNameArgs): Promise<ArNSPurchaseResponse> {
     return this.purchaseArNSName({
       ...params,
       intent: 'Buy-Name',

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -16,12 +16,17 @@
 import { BigNumber } from 'bignumber.js';
 
 import {
+  ArNSBuyNameParams,
+  ArNSExtendLeaseParams,
+  ArNSIncreaseUndernameLimitParams,
   ArNSNameType,
+  ArNSPaidByParams,
   ArNSPriceParams,
   ArNSPriceResponse,
   ArNSPurchaseParams,
   ArNSPurchaseResponse,
   ArNSPurchaseStatusResponse,
+  ArNSUpgradeNameParams,
   Currency,
   GetCreditShareApprovalsResponse,
   RawWincForTokenResponse,
@@ -182,18 +187,13 @@ export class TurboUnauthenticatedPaymentService
     };
   }
 
-  public getArNSPriceForName({
-    intent,
-    name,
-    type,
-    years,
-    increaseQty,
-    processId,
-  }: ArNSPriceParams): Promise<ArNSPriceResponse> {
+  public getArNSPriceForName(
+    params: ArNSPriceParams,
+  ): Promise<ArNSPriceResponse> {
     return this.httpService.get<ArNSPriceResponse>({
-      endpoint: `/arns/price/${intent.toLowerCase()}/${name}${this.buildArNSPurchaseQuery(
-        { type, years, increaseQty, processId },
-      )}`,
+      endpoint: `/arns/price/${params.intent.toLowerCase()}/${
+        params.name
+      }${this.buildArNSPurchaseQuery(params)}`,
     });
   }
 
@@ -207,19 +207,15 @@ export class TurboUnauthenticatedPaymentService
     });
   }
 
-  protected buildArNSPurchaseQuery({
-    type,
-    years,
-    increaseQty,
-    processId,
-    paidBy,
-  }: {
-    type?: ArNSNameType;
-    years?: number;
-    increaseQty?: number;
-    processId?: string;
-    paidBy?: UserAddress | UserAddress[];
-  }): string {
+  protected buildArNSPurchaseQuery(input: ArNSPurchaseParams): string {
+    // The intent-specific union members each carry only their own fields; read
+    // them through a single widened view rather than narrowing per intent.
+    const { type, years, increaseQty, processId, paidBy } = input as {
+      type?: ArNSNameType;
+      years?: number;
+      increaseQty?: number;
+      processId?: string;
+    } & ArNSPaidByParams;
     const params = new URLSearchParams();
     if (type !== undefined) params.set('type', type);
     if (years !== undefined) params.set('years', `${years}`);
@@ -488,15 +484,9 @@ export class TurboAuthenticatedPaymentService
    * balance. The bundler performs the on-chain ARIO purchase and debits credits;
    * a `402` (FailedRequestError.status === 402) indicates insufficient credits.
    */
-  public async purchaseArNSName({
-    intent,
-    name,
-    type,
-    years,
-    increaseQty,
-    processId,
-    paidBy,
-  }: ArNSPurchaseParams): Promise<ArNSPurchaseResponse> {
+  public async purchaseArNSName(
+    params: ArNSPurchaseParams,
+  ): Promise<ArNSPurchaseResponse> {
     // The bundler requires the signed nonce to be a UUID; it also doubles as
     // the idempotency + status-lookup key (`getArNSPurchaseStatus`).
     const nonce = uuidV4();
@@ -504,35 +494,40 @@ export class TurboAuthenticatedPaymentService
     const response = await this.httpService.post<
       Omit<ArNSPurchaseResponse, 'nonce'>
     >({
-      endpoint: `/arns/purchase/${intent.toLowerCase()}/${name}${this.buildArNSPurchaseQuery(
-        { type, years, increaseQty, processId, paidBy },
-      )}`,
+      endpoint: `/arns/purchase/${params.intent.toLowerCase()}/${
+        params.name
+      }${this.buildArNSPurchaseQuery(params)}`,
       headers,
       // Params travel in the query string + signed headers; the service reads no
       // body, but the HTTP layer requires a `data` field.
       data: Buffer.from([]),
     });
-    return { ...response, nonce };
+    // Normalize both nonce fields to the one we signed so callers can poll with
+    // either `response.nonce` or `response.purchaseReceipt.nonce`.
+    return {
+      ...response,
+      nonce,
+      purchaseReceipt: { ...response.purchaseReceipt, nonce },
+    };
   }
 
   public buyArNSName(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'increaseQty'>,
+    params: Omit<ArNSBuyNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
-    return this.purchaseArNSName({ ...params, intent: 'Buy-Name' });
+    return this.purchaseArNSName({
+      ...params,
+      intent: 'Buy-Name',
+    } as ArNSPurchaseParams);
   }
 
   public extendArNSLease(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'increaseQty'> & {
-      years: number;
-    },
+    params: Omit<ArNSExtendLeaseParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.purchaseArNSName({ ...params, intent: 'Extend-Lease' });
   }
 
   public increaseArNSUndernameLimit(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'years'> & {
-      increaseQty: number;
-    },
+    params: Omit<ArNSIncreaseUndernameLimitParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.purchaseArNSName({
       ...params,
@@ -541,10 +536,7 @@ export class TurboAuthenticatedPaymentService
   }
 
   public upgradeArNSName(
-    params: Omit<
-      ArNSPurchaseParams,
-      'intent' | 'type' | 'years' | 'increaseQty'
-    >,
+    params: Omit<ArNSUpgradeNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.purchaseArNSName({ ...params, intent: 'Upgrade-Name' });
   }

--- a/packages/turbo-sdk/src/common/signer.ts
+++ b/packages/turbo-sdk/src/common/signer.ts
@@ -127,11 +127,16 @@ export abstract class TurboDataItemAbstractSigner
 
   public async generateSignedRequestHeaders(
     // Callers may supply the nonce (e.g. a UUID required by some routes); the
-    // signed payload is this nonce string, so the value must round-trip to the
-    // service unchanged.
+    // nonce round-trips to the service in `x-nonce` unchanged.
     nonce: string = randomBytes(16).toString('hex'),
+    // Optional ACTION-BINDING data prepended to the nonce for SIGNING only (not
+    // sent): the service reconstructs the same string from the request and
+    // verifies the signature over `additionalData + nonce`. This binds the
+    // signature to a specific operation + params so it can't be replayed against
+    // a different request. Omitted → signs the bare nonce (unchanged behavior).
+    additionalData?: string,
   ): Promise<TurboSignedRequestHeaders> {
-    const buffer = Buffer.from(nonce);
+    const buffer = Buffer.from((additionalData ?? '') + nonce);
     const signature = await this.signer.sign(Uint8Array.from(buffer));
     const publicKey = toB64Url(this.signer.publicKey);
     return {

--- a/packages/turbo-sdk/src/common/signer.ts
+++ b/packages/turbo-sdk/src/common/signer.ts
@@ -125,8 +125,12 @@ export abstract class TurboDataItemAbstractSigner
     }
   }
 
-  public async generateSignedRequestHeaders(): Promise<TurboSignedRequestHeaders> {
-    const nonce = randomBytes(16).toString('hex');
+  public async generateSignedRequestHeaders(
+    // Callers may supply the nonce (e.g. a UUID required by some routes); the
+    // signed payload is this nonce string, so the value must round-trip to the
+    // service unchanged.
+    nonce: string = randomBytes(16).toString('hex'),
+  ): Promise<TurboSignedRequestHeaders> {
     const buffer = Buffer.from(nonce);
     const signature = await this.signer.sign(Uint8Array.from(buffer));
     const publicKey = toB64Url(this.signer.publicKey);

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -383,6 +383,37 @@ export class TurboAuthenticatedClient
     return this.paymentService.upgradeArNSName(params);
   }
 
+  transferArNSAnt(params: { antId: string; target: string }): Promise<{
+    antId: string;
+    target: string;
+    name?: string;
+    messageId: string;
+  }> {
+    return this.paymentService.transferArNSAnt(params);
+  }
+
+  setArNSRecord(params: {
+    antId: string;
+    undername?: string;
+    transactionId: string;
+    ttlSeconds: number;
+  }): Promise<{
+    antId: string;
+    undername: string;
+    transactionId: string;
+    ttlSeconds: number;
+    messageId: string;
+  }> {
+    return this.paymentService.setArNSRecord(params);
+  }
+
+  removeArNSRecord(params: {
+    antId: string;
+    undername: string;
+  }): Promise<{ antId: string; undername: string; messageId: string }> {
+    return this.paymentService.removeArNSRecord(params);
+  }
+
   /**
    * Returns a list of all credit share approvals for the user.
    */

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -16,7 +16,7 @@
 import { BigNumber } from 'bignumber.js';
 
 import {
-  ArNSBuyNameParams,
+  ArNSBuyNameArgs,
   ArNSExtendLeaseParams,
   ArNSIncreaseUndernameLimitParams,
   ArNSPaidByParams,
@@ -356,9 +356,7 @@ export class TurboAuthenticatedClient
   }
 
   /** Buys a new ArNS name (lease or permabuy). */
-  buyArNSName(
-    params: Omit<ArNSBuyNameParams, 'intent'> & ArNSPaidByParams,
-  ): Promise<ArNSPurchaseResponse> {
+  buyArNSName(params: ArNSBuyNameArgs): Promise<ArNSPurchaseResponse> {
     return this.paymentService.buyArNSName(params);
   }
 

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -16,6 +16,11 @@
 import { BigNumber } from 'bignumber.js';
 
 import {
+  ArNSPriceParams,
+  ArNSPriceResponse,
+  ArNSPurchaseParams,
+  ArNSPurchaseResponse,
+  ArNSPurchaseStatusResponse,
   CreditShareApproval,
   Currency,
   FundingOptions,
@@ -145,6 +150,22 @@ export class TurboUnauthenticatedClient
 
   getBalance(address: NativeAddress): Promise<TurboBalanceResponse> {
     return this.paymentService.getBalance(address);
+  }
+
+  /**
+   * Returns the price in 'winc' (and mARIO) to buy/extend/upgrade an ArNS name.
+   */
+  getArNSPriceForName(params: ArNSPriceParams): Promise<ArNSPriceResponse> {
+    return this.paymentService.getArNSPriceForName(params);
+  }
+
+  /**
+   * Returns the status of an ArNS purchase by its nonce.
+   */
+  getArNSPurchaseStatus(p: {
+    nonce: string;
+  }): Promise<ArNSPurchaseStatusResponse> {
+    return this.paymentService.getArNSPurchaseStatus(p);
   }
 
   /**
@@ -319,6 +340,49 @@ export class TurboAuthenticatedClient
    */
   getBalance(userAddress?: NativeAddress): Promise<TurboBalanceResponse> {
     return this.paymentService.getBalance(userAddress);
+  }
+
+  /**
+   * Buys, extends, or upgrades an ArNS name, paying with the signer's Turbo
+   * credit balance. Poll {@link getArNSPurchaseStatus} with the returned nonce.
+   */
+  purchaseArNSName(params: ArNSPurchaseParams): Promise<ArNSPurchaseResponse> {
+    return this.paymentService.purchaseArNSName(params);
+  }
+
+  /** Buys a new ArNS name (lease or permabuy). */
+  buyArNSName(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'increaseQty'>,
+  ): Promise<ArNSPurchaseResponse> {
+    return this.paymentService.buyArNSName(params);
+  }
+
+  /** Extends the lease on an existing ArNS name. */
+  extendArNSLease(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'increaseQty'> & {
+      years: number;
+    },
+  ): Promise<ArNSPurchaseResponse> {
+    return this.paymentService.extendArNSLease(params);
+  }
+
+  /** Increases the undername limit on an existing ArNS name. */
+  increaseArNSUndernameLimit(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'years'> & {
+      increaseQty: number;
+    },
+  ): Promise<ArNSPurchaseResponse> {
+    return this.paymentService.increaseArNSUndernameLimit(params);
+  }
+
+  /** Upgrades an ArNS lease to a permabuy. */
+  upgradeArNSName(
+    params: Omit<
+      ArNSPurchaseParams,
+      'intent' | 'type' | 'years' | 'increaseQty'
+    >,
+  ): Promise<ArNSPurchaseResponse> {
+    return this.paymentService.upgradeArNSName(params);
   }
 
   /**

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -16,11 +16,16 @@
 import { BigNumber } from 'bignumber.js';
 
 import {
+  ArNSBuyNameParams,
+  ArNSExtendLeaseParams,
+  ArNSIncreaseUndernameLimitParams,
+  ArNSPaidByParams,
   ArNSPriceParams,
   ArNSPriceResponse,
   ArNSPurchaseParams,
   ArNSPurchaseResponse,
   ArNSPurchaseStatusResponse,
+  ArNSUpgradeNameParams,
   CreditShareApproval,
   Currency,
   FundingOptions,
@@ -352,35 +357,28 @@ export class TurboAuthenticatedClient
 
   /** Buys a new ArNS name (lease or permabuy). */
   buyArNSName(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'increaseQty'>,
+    params: Omit<ArNSBuyNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.paymentService.buyArNSName(params);
   }
 
   /** Extends the lease on an existing ArNS name. */
   extendArNSLease(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'increaseQty'> & {
-      years: number;
-    },
+    params: Omit<ArNSExtendLeaseParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.paymentService.extendArNSLease(params);
   }
 
   /** Increases the undername limit on an existing ArNS name. */
   increaseArNSUndernameLimit(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'years'> & {
-      increaseQty: number;
-    },
+    params: Omit<ArNSIncreaseUndernameLimitParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.paymentService.increaseArNSUndernameLimit(params);
   }
 
   /** Upgrades an ArNS lease to a permabuy. */
   upgradeArNSName(
-    params: Omit<
-      ArNSPurchaseParams,
-      'intent' | 'type' | 'years' | 'increaseQty'
-    >,
+    params: Omit<ArNSUpgradeNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse> {
     return this.paymentService.upgradeArNSName(params);
   }

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -892,7 +892,9 @@ export interface TurboDataItemSigner {
   }: TurboFileFactory & {
     emitter?: TurboEventEmitter;
   }): Promise<TurboSignedDataItemFactory>;
-  generateSignedRequestHeaders(): Promise<TurboSignedRequestHeaders>;
+  generateSignedRequestHeaders(
+    nonce?: string,
+  ): Promise<TurboSignedRequestHeaders>;
   signData(dataToSign: Uint8Array): Promise<Uint8Array>;
   sendTransaction(p: SendTxWithSignerParams): Promise<string>;
   getPublicKey(): Promise<Buffer>;
@@ -901,8 +903,80 @@ export interface TurboDataItemSigner {
   walletAdapter?: WalletAdapter;
 }
 
+// ===== ArNS purchases paid with Turbo credits (via the bundler REST API) =====
+
+export const arNSPurchaseIntents = [
+  'Buy-Name',
+  'Extend-Lease',
+  'Increase-Undername-Limit',
+  'Upgrade-Name',
+] as const;
+export type ArNSPurchaseIntent = (typeof arNSPurchaseIntents)[number];
+export type ArNSNameType = 'lease' | 'permabuy';
+
+export type ArNSPriceParams = {
+  intent: ArNSPurchaseIntent;
+  name: string;
+  /** Required for `Buy-Name` */
+  type?: ArNSNameType;
+  /** Required for `Buy-Name` leases and `Extend-Lease` */
+  years?: number;
+  /** Required for `Increase-Undername-Limit` */
+  increaseQty?: number;
+  /** ANT (Metaplex Core asset) the name points at — required for `Buy-Name` */
+  processId?: string;
+};
+
+export type ArNSPriceResponse = {
+  /** Price in Winston credits */
+  winc: string;
+  /** Equivalent price in mARIO */
+  mARIO: string;
+  [key: string]: unknown;
+};
+
+export type ArNSPurchaseParams = ArNSPriceParams & {
+  /** Optional delegated payer address(es) whose credits cover the purchase */
+  paidBy?: UserAddress | UserAddress[];
+};
+
+export type ArNSPurchaseReceipt = {
+  name: string;
+  intent: ArNSPurchaseIntent;
+  type?: ArNSNameType;
+  years?: number;
+  increaseQty?: number;
+  processId?: string;
+  owner: UserAddress;
+  /** UUID that identifies this purchase (also the status-lookup key) */
+  nonce: string;
+  wincQty: string;
+  mARIOQty: string;
+  usdArRate: number;
+  usdArioRate: number;
+  paidBy: UserAddress[];
+  /** Solana transaction id of the on-chain ArNS write */
+  messageId: string;
+};
+
+export type ArNSPurchaseResponse = {
+  purchaseReceipt: ArNSPurchaseReceipt;
+  arioWriteResult: { id: string };
+  /** UUID nonce used for the purchase — poll `getArNSPurchaseStatus({ nonce })` with it */
+  nonce: string;
+};
+
+export type ArNSPurchaseStatusResponse = ArNSPurchaseReceipt & {
+  /** Present once the purchase has terminally failed */
+  failedDate?: string;
+};
+
 export interface TurboUnauthenticatedPaymentServiceInterface {
   getBalance: (address: string) => Promise<TurboBalanceResponse>;
+  getArNSPriceForName(params: ArNSPriceParams): Promise<ArNSPriceResponse>;
+  getArNSPurchaseStatus(p: {
+    nonce: string;
+  }): Promise<ArNSPurchaseStatusResponse>;
   getSupportedCurrencies(): Promise<TurboCurrenciesResponse>;
   getSupportedCountries(): Promise<TurboCountriesResponse>;
   getTurboCryptoWallets(): Promise<Record<TokenType, string>>;
@@ -963,6 +1037,28 @@ export interface TurboAuthenticatedPaymentServiceInterface
   topUpWithTokens(
     p: TurboFundWithTokensParams,
   ): Promise<TurboCryptoFundResponse>;
+
+  /** Buy / extend / upgrade an ArNS name, debiting the signer's credit balance. */
+  purchaseArNSName(params: ArNSPurchaseParams): Promise<ArNSPurchaseResponse>;
+  buyArNSName(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'increaseQty'>,
+  ): Promise<ArNSPurchaseResponse>;
+  extendArNSLease(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'increaseQty'> & {
+      years: number;
+    },
+  ): Promise<ArNSPurchaseResponse>;
+  increaseArNSUndernameLimit(
+    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'years'> & {
+      increaseQty: number;
+    },
+  ): Promise<ArNSPurchaseResponse>;
+  upgradeArNSName(
+    params: Omit<
+      ArNSPurchaseParams,
+      'intent' | 'type' | 'years' | 'increaseQty'
+    >,
+  ): Promise<ArNSPurchaseResponse>;
 }
 
 export interface TurboUnauthenticatedUploadServiceInterface {

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -854,12 +854,18 @@ export interface TurboHTTPServiceInterface {
     headers,
     allowedStatuses,
     data,
+    retry,
   }: {
     endpoint: `/${string}`;
     signal?: AbortSignal;
     headers?: Partial<TurboSignedRequestHeaders> & Record<string, string>;
     allowedStatuses?: number[];
     data: Readable | ReadableStream | Buffer;
+    // Set false for NON-IDEMPOTENT signed writes (e.g. ArNS purchase/custody):
+    // the server treats the nonce as single-use, so an auto-retry after a slow
+    // (but landed) write is rejected as "already exists"/"nonce used" and
+    // surfaces a false failure. Callers poll status by nonce instead.
+    retry?: boolean;
   }): Promise<T>;
 }
 

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -894,6 +894,7 @@ export interface TurboDataItemSigner {
   }): Promise<TurboSignedDataItemFactory>;
   generateSignedRequestHeaders(
     nonce?: string,
+    additionalData?: string,
   ): Promise<TurboSignedRequestHeaders>;
   signData(dataToSign: Uint8Array): Promise<Uint8Array>;
   sendTransaction(p: SendTxWithSignerParams): Promise<string>;
@@ -1081,6 +1082,28 @@ export interface TurboAuthenticatedPaymentServiceInterface
   upgradeArNSName(
     params: Omit<ArNSUpgradeNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse>;
+  transferArNSAnt(params: { antId: string; target: string }): Promise<{
+    antId: string;
+    target: string;
+    name?: string;
+    messageId: string;
+  }>;
+  setArNSRecord(params: {
+    antId: string;
+    undername?: string;
+    transactionId: string;
+    ttlSeconds: number;
+  }): Promise<{
+    antId: string;
+    undername: string;
+    transactionId: string;
+    ttlSeconds: number;
+    messageId: string;
+  }>;
+  removeArNSRecord(params: {
+    antId: string;
+    undername: string;
+  }): Promise<{ antId: string; undername: string; messageId: string }>;
 }
 
 export interface TurboUnauthenticatedUploadServiceInterface {

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -914,18 +914,50 @@ export const arNSPurchaseIntents = [
 export type ArNSPurchaseIntent = (typeof arNSPurchaseIntents)[number];
 export type ArNSNameType = 'lease' | 'permabuy';
 
-export type ArNSPriceParams = {
-  intent: ArNSPurchaseIntent;
+// Intent-specific shapes so the required fields per intent are enforced at
+// compile time rather than surfacing as runtime 4xxs from the service.
+export type ArNSBuyNameLeaseParams = {
+  intent: 'Buy-Name';
   name: string;
-  /** Required for `Buy-Name` */
-  type?: ArNSNameType;
-  /** Required for `Buy-Name` leases and `Extend-Lease` */
-  years?: number;
-  /** Required for `Increase-Undername-Limit` */
-  increaseQty?: number;
-  /** ANT (Metaplex Core asset) the name points at — required for `Buy-Name` */
-  processId?: string;
+  type: 'lease';
+  /** Lease duration in years */
+  years: number;
+  /** ANT (Metaplex Core asset) the name resolves to */
+  processId: string;
 };
+export type ArNSBuyNamePermabuyParams = {
+  intent: 'Buy-Name';
+  name: string;
+  type: 'permabuy';
+  /** ANT (Metaplex Core asset) the name resolves to */
+  processId: string;
+};
+export type ArNSBuyNameParams =
+  | ArNSBuyNameLeaseParams
+  | ArNSBuyNamePermabuyParams;
+export type ArNSExtendLeaseParams = {
+  intent: 'Extend-Lease';
+  name: string;
+  years: number;
+};
+export type ArNSIncreaseUndernameLimitParams = {
+  intent: 'Increase-Undername-Limit';
+  name: string;
+  increaseQty: number;
+};
+export type ArNSUpgradeNameParams = {
+  intent: 'Upgrade-Name';
+  name: string;
+};
+
+export type ArNSPriceParams =
+  | ArNSBuyNameParams
+  | ArNSExtendLeaseParams
+  | ArNSIncreaseUndernameLimitParams
+  | ArNSUpgradeNameParams;
+
+/** Optional delegated payer address(es) whose credits cover a purchase */
+export type ArNSPaidByParams = { paidBy?: UserAddress | UserAddress[] };
 
 export type ArNSPriceResponse = {
   /** Price in Winston credits */
@@ -935,10 +967,7 @@ export type ArNSPriceResponse = {
   [key: string]: unknown;
 };
 
-export type ArNSPurchaseParams = ArNSPriceParams & {
-  /** Optional delegated payer address(es) whose credits cover the purchase */
-  paidBy?: UserAddress | UserAddress[];
-};
+export type ArNSPurchaseParams = ArNSPriceParams & ArNSPaidByParams;
 
 export type ArNSPurchaseReceipt = {
   name: string;
@@ -1041,23 +1070,16 @@ export interface TurboAuthenticatedPaymentServiceInterface
   /** Buy / extend / upgrade an ArNS name, debiting the signer's credit balance. */
   purchaseArNSName(params: ArNSPurchaseParams): Promise<ArNSPurchaseResponse>;
   buyArNSName(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'increaseQty'>,
+    params: Omit<ArNSBuyNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse>;
   extendArNSLease(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'increaseQty'> & {
-      years: number;
-    },
+    params: Omit<ArNSExtendLeaseParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse>;
   increaseArNSUndernameLimit(
-    params: Omit<ArNSPurchaseParams, 'intent' | 'type' | 'years'> & {
-      increaseQty: number;
-    },
+    params: Omit<ArNSIncreaseUndernameLimitParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse>;
   upgradeArNSName(
-    params: Omit<
-      ArNSPurchaseParams,
-      'intent' | 'type' | 'years' | 'increaseQty'
-    >,
+    params: Omit<ArNSUpgradeNameParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse>;
 }
 

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -929,15 +929,23 @@ export type ArNSBuyNameLeaseParams = {
   type: 'lease';
   /** Lease duration in years */
   years: number;
-  /** ANT (Metaplex Core asset) the name resolves to */
-  processId: string;
+  /**
+   * ANT (Metaplex Core asset) the name resolves to. Optional: omit to have
+   * Turbo custodially provision the ANT (Turbo spawns + owns it — Model A);
+   * supply to point the name at a user-owned ANT (Model B).
+   */
+  processId?: string;
 };
 export type ArNSBuyNamePermabuyParams = {
   intent: 'Buy-Name';
   name: string;
   type: 'permabuy';
-  /** ANT (Metaplex Core asset) the name resolves to */
-  processId: string;
+  /**
+   * ANT (Metaplex Core asset) the name resolves to. Optional: omit to have
+   * Turbo custodially provision the ANT (Turbo spawns + owns it — Model A);
+   * supply to point the name at a user-owned ANT (Model B).
+   */
+  processId?: string;
 };
 export type ArNSBuyNameParams =
   | ArNSBuyNameLeaseParams
@@ -975,6 +983,19 @@ export type ArNSPriceResponse = {
 };
 
 export type ArNSPurchaseParams = ArNSPriceParams & ArNSPaidByParams;
+
+/**
+ * Distributive `Omit` so a discriminated union keeps its per-branch fields.
+ * The built-in `Omit<A | B, K>` collapses to only the keys common to every
+ * member (dropping e.g. a lease's `years`); this maps over each member instead.
+ */
+export type DistributiveOmit<T, K extends keyof never> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/** `buyArNSName` params: any Buy-Name variant minus the (implied) `intent`. */
+export type ArNSBuyNameArgs = DistributiveOmit<ArNSBuyNameParams, 'intent'> &
+  ArNSPaidByParams;
 
 export type ArNSPurchaseReceipt = {
   name: string;
@@ -1076,9 +1097,7 @@ export interface TurboAuthenticatedPaymentServiceInterface
 
   /** Buy / extend / upgrade an ArNS name, debiting the signer's credit balance. */
   purchaseArNSName(params: ArNSPurchaseParams): Promise<ArNSPurchaseResponse>;
-  buyArNSName(
-    params: Omit<ArNSBuyNameParams, 'intent'> & ArNSPaidByParams,
-  ): Promise<ArNSPurchaseResponse>;
+  buyArNSName(params: ArNSBuyNameArgs): Promise<ArNSPurchaseResponse>;
   extendArNSLease(
     params: Omit<ArNSExtendLeaseParams, 'intent'> & ArNSPaidByParams,
   ): Promise<ArNSPurchaseResponse>;

--- a/packages/turbo-sdk/src/utils/errors.ts
+++ b/packages/turbo-sdk/src/utils/errors.ts
@@ -44,6 +44,26 @@ export class ProvidedInputError extends BaseError {
   }
 }
 
+/**
+ * Raised when a credit-paid operation (e.g. an ArNS purchase) is rejected by the
+ * service because the paying wallet does not hold enough Turbo credits. Maps the
+ * bundler's HTTP `402 Payment Required` response to a typed, catchable error so
+ * callers can prompt a top-up without string-matching on messages.
+ *
+ * Recovery: top up the balance, then retry the SAME operation reusing the
+ * captured `nonce` (the nonce is the idempotency key), or mint a fresh request.
+ */
+export class InsufficientCreditsError extends BaseError {
+  /** Always the HTTP status that produced this error. */
+  public readonly status = 402;
+  constructor(message?: string) {
+    super(
+      message ??
+        'Insufficient Turbo credits to complete this purchase. Top up your balance and retry.',
+    );
+  }
+}
+
 export class AbortError extends BaseError {
   constructor(message = 'Request was aborted') {
     super(message);

--- a/packages/turbo-sdk/src/utils/uuid.ts
+++ b/packages/turbo-sdk/src/utils/uuid.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { randomBytes } from 'crypto';
+
+/**
+ * RFC 4122 version 4 UUID, derived from `randomBytes` (already used across the
+ * SDK in both the node and web builds). Avoids depending on
+ * `crypto.randomUUID`, whose availability varies by runtime/polyfill.
+ */
+export function uuidV4(): string {
+  const bytes = randomBytes(16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16,
+  )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/turbo-sdk/src/web/signer.ts
+++ b/packages/turbo-sdk/src/web/signer.ts
@@ -98,9 +98,14 @@ export class TurboWebArweaveSigner extends TurboDataItemAbstractSigner {
     };
   }
 
-  public async generateSignedRequestHeaders(): Promise<TurboSignedRequestHeaders> {
+  public async generateSignedRequestHeaders(
+    nonce?: string,
+    additionalData?: string,
+  ): Promise<TurboSignedRequestHeaders> {
     await this.setPublicKey();
-    return super.generateSignedRequestHeaders();
+    // Pass through the caller's nonce + action-binding data (previously dropped,
+    // which would override a route-required UUID nonce and the H-2 binding).
+    return super.generateSignedRequestHeaders(nonce, additionalData);
   }
 
   public async signData(dataToSign: Uint8Array): Promise<Uint8Array> {


### PR DESCRIPTION
## Summary

Adds a **credit-paid ArNS purchase client** to the SDK, backed by the bundler's `/v1/arns/*` REST API. The bundler performs the on-chain ARIO purchase and **debits the signer's Turbo credit balance**, so callers need no ARIO/SOL (or even a Solana wallet) of their own — an Arweave/Ethereum/Solana credit account is enough.

This is the client counterpart to the `x-signature-type` work in #434 (which lets non-Arweave wallets authenticate signed requests).

## What's added

**Unauthenticated (`TurboUnauthenticatedPaymentService` + top-level client):**
- `getArNSPriceForName({ intent, name, type?, years?, increaseQty?, processId? })` → `{ winc, mARIO, … }`
- `getArNSPurchaseStatus({ nonce })` → purchase status (poll to terminal state)

**Authenticated (`TurboAuthenticatedPaymentService` + top-level client):**
- `purchaseArNSName({ intent, name, … , paidBy? })` (signed)
- Thin per-intent wrappers: `buyArNSName`, `extendArNSLease`, `increaseArNSUndernameLimit`, `upgradeArNSName`

**Signing:**
- `generateSignedRequestHeaders(nonce?)` now accepts a caller-supplied nonce. ArNS purchases sign a **UUID** nonce — the bundler requires a UUID (it also serves as the idempotency + status-lookup key). Back-compatible: the default still generates the prior random hex nonce.
- New `uuidV4` util derived from `randomBytes` (no dependency on `crypto.randomUUID`, whose availability varies by runtime/polyfill).

## Errors

A `402` (`FailedRequestError.status === 402`) indicates **insufficient credits**.

## Test plan

- New `src/common/payment.arns.test.ts`: asserts endpoint construction + query params, that purchases send a **valid UUID** `x-nonce` plus `x-signature-type` / `x-public-key` / `x-signature`, that the returned `nonce` matches the signed one, per-intent path mapping, and repeated `paidBy` params.
- Full suite: **55/55 unit tests pass**, `tsc --noEmit` clean, eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mqXHvaS8MdXvuWXCvDcnn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArNS pricing lookup and purchase-status checks for name orders.
  * Added authenticated ArNS purchase flows, including buying, extending leases, increasing undername limits, and upgrading names.
  * Purchase requests now include signed nonces and return the nonce with the response for tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->