### PR TITLE
fix(docs): point testnet config at the ar.io testnet + fix broken Ethereum Sepolia example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1991,7 +1991,7 @@ The Turbo CLI provides the following commands to manage Credit Share Approvals:
 
 ### Testing
 
-- `yarn test` - runs integration tests against dev environment (e.g. `https://payment.services.ar-io.dev` and `https://upload.services.ar-io.dev`)
+- `yarn test` - runs integration tests using the configured environment (localhost by default); set `PAYMENT_SERVICE_URL` and `UPLOAD_SERVICE_URL` to target the ar.io Testnet Sandbox
 - `yarn test:docker` - runs integration tests against locally running docker containers (recommended)
 - `yarn example:web` - opens up the example web page
 - `yarn example:cjs` - runs example CJS node script

--- a/README.md
+++ b/README.md
@@ -254,10 +254,10 @@ const turbo = TurboFactory.authenticated({
   token: 'base-eth',
   gatewayUrl: 'https://sepolia.base.org', // Required for testnet
   paymentServiceConfig: {
-    url: 'https://payment.ardrive.dev', // Dev payment service
+    url: 'https://payment.services.ar-io.dev', // ar.io testnet sandbox
   },
   uploadServiceConfig: {
-    url: 'https://upload.ardrive.dev', // Dev upload service
+    url: 'https://upload.services.ar-io.dev', // ar.io testnet sandbox
   }
 });
 
@@ -267,10 +267,10 @@ const turbo = TurboFactory.authenticated({
   token: 'solana',
   gatewayUrl: 'https://api.devnet.solana.com',
   paymentServiceConfig: {
-    url: 'https://payment.ardrive.dev',
+    url: 'https://payment.services.ar-io.dev',
   },
   uploadServiceConfig: {
-    url: 'https://upload.ardrive.dev',
+    url: 'https://upload.services.ar-io.dev',
   }
 });
 
@@ -280,16 +280,23 @@ const turbo = TurboFactory.authenticated({
   token: 'ethereum',
   gatewayUrl: 'https://sepolia.gateway.tenderly.co',
   paymentServiceConfig: {
-    url: 'https://payment.ardrive.dev',
+    url: 'https://payment.services.ar-io.dev',
   },
   uploadServiceConfig: {
-    url: 'https://upload.ardrive.dev',
-
+    url: 'https://upload.services.ar-io.dev',
+  },
 });
 ```
 
+These endpoints are the **ar.io Testnet Sandbox** — the full ar.io stack (upload, payment, ArNS,
+and gateway) running on testnet, with a faucet so nothing costs real money. Uploaded data is
+served from the sandbox gateway at `https://ar-io.dev` and is **ephemeral** (purged after ~3
+days); it is never posted to mainnet Arweave. See
+[the ar.io Testnet Sandbox docs](https://docs.ar.io/build/testnet).
+
 **Supported Testnets**:
 
+- **ARIO staging** (`ario`) - Staging ARIO on Solana devnet; fee-free funding, claim from the [ar.io faucet](https://faucet.services.ar-io.dev)
 - **Base Sepolia** (`base-eth`) - Supports on-demand funding
 - **Solana Devnet** (`solana`) - Supports on-demand funding
 - **Ethereum Sepolia** (`ethereum`) - Manual top-up only
@@ -1984,7 +1991,7 @@ The Turbo CLI provides the following commands to manage Credit Share Approvals:
 
 ### Testing
 
-- `yarn test` - runs integration tests against dev environment (e.g. `https://payment.ardrive.dev` and `https://upload.ardrive.dev`)
+- `yarn test` - runs integration tests against dev environment (e.g. `https://payment.services.ar-io.dev` and `https://upload.services.ar-io.dev`)
 - `yarn test:docker` - runs integration tests against locally running docker containers (recommended)
 - `yarn example:web` - opens up the example web page
 - `yarn example:cjs` - runs example CJS node script


### PR DESCRIPTION
`ardrive.dev` is now `ar-io.dev` — the ar.io testnet — served by `upload.services.ar-io.dev` and `payment.services.ar-io.dev`. The **Testnet Configuration** section still pointed at the old hosts.

## 1. Repoint the testnet endpoints (7 references)

```diff
-    url: 'https://payment.ardrive.dev', // Dev payment service
+    url: 'https://payment.services.ar-io.dev', // ar.io testnet sandbox
-    url: 'https://upload.ardrive.dev', // Dev upload service
+    url: 'https://upload.services.ar-io.dev', // ar.io testnet sandbox
```

Applied to all three examples, plus the `yarn test` line under **Testing**.

## 2. Fix a genuinely broken example 🐛

The Ethereum Sepolia snippet is **invalid JavaScript** — `uploadServiceConfig` is never closed, so copy-pasting it is a syntax error:

```diff
   uploadServiceConfig: {
     url: 'https://upload.services.ar-io.dev',
-
+  },
 });
```

## 3. Document ARIO staging as a funding token

The sandbox accepts `ario` (fee-free), which wasn't listed:

```diff
 **Supported Testnets**:
 
+- **ARIO staging** (`ario`) - Staging ARIO on Solana devnet; fee-free funding, claim from the [ar.io faucet](https://faucet.services.ar-io.dev)
 - **Base Sepolia** (`base-eth`) - Supports on-demand funding
```

## 4. Set expectations about the sandbox

Added a short note that these endpoints are the ar.io Testnet Sandbox, that data is served from `https://ar-io.dev`, and that it's **ephemeral** (~3 days, never posted to mainnet Arweave) — with a link to https://docs.ar.io/build/testnet.

> [!NOTE]
> The **Ethereum Sepolia** and **Polygon Amoy** entries were intentionally left in place. The sandbox's current `ACCEPTED_FUNDING_TOKENS` is `ario,solana,base-eth`, so those two will return `Token not supported` until the ar.io team enables them — which they've confirmed is planned.

## Why it matters beyond this repo

This README is the source for [docs.ar.io/sdks/turbo-sdk](https://docs.ar.io/sdks/turbo-sdk) (generated by `generate-sdk-docs`), so the stale endpoints and the broken snippet are currently published there and can't be fixed downstream.

Companion docs work: ar-io/docs#124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUArqiyP9GbfJrqNFVkUBr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testnet configuration examples to use the ar.io Testnet Sandbox endpoints.
  * Clarified that the sandbox is ephemeral and documented support for ARIO staging and other listed testnets.
  * Updated testing instructions with the current development environment URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->