### PR TITLE
feat(payment): add getFreeStatus for free-tier upload allowance

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,20 @@ Issues a signed request to get the credit balance of a wallet measured in AR (me
 const { winc: balance } = await turbo.getBalance();
 ```
 
+#### `getFreeStatus()`
+
+Returns the wallet's remaining free-tier upload allowance in bytes as `{ bytesRemaining }`, so you can tell up front whether an upload will be free. `bytesRemaining` is `null` for a wallet with an unlimited allowance (an exempt/partner wallet), and `0` when the free tier is disabled on the target Turbo deployment. It is advisory — the authoritative free/charge decision is made at upload time — and is a wallet-side figure (a per-network cap may also apply). Deployment-wide free-tier limits are on the service's `/info` endpoint.
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus();
+```
+
+It is also available on the `TurboUnauthenticatedClient` for any wallet by address:
+
+```typescript
+const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
+```
+
 #### `signer.getNativeAddress()`
 
 Returns the [native address][docs/native-address] of the connected signer.
@@ -1570,6 +1584,24 @@ turbo balance --address 'crypto-wallet-public-native-address' --token solana
 
 ```shell
 turbo balance --wallet-file '../path/to/my/wallet.json' --token arweave
+```
+
+##### `free-status`
+
+Get the remaining free-tier upload allowance (in bytes) for a connected wallet or native address. Prints `unlimited` for an exempt/partner wallet.
+
+Command Options:
+
+- `-a, --address <nativeAddress>` - Native address to check the free-tier allowance of
+
+e.g:
+
+```shell
+turbo free-status --address 'crypto-wallet-public-native-address' --token arweave
+```
+
+```shell
+turbo free-status --wallet-file '../path/to/my/wallet.json' --token arweave
 ```
 
 ##### `top-up`

--- a/packages/turbo-sdk/src/cli/cli.ts
+++ b/packages/turbo-sdk/src/cli/cli.ts
@@ -37,6 +37,7 @@ import { fiatEstimate } from './commands/fiatEstimate.js';
 import {
   balance,
   cryptoFund,
+  freeStatus,
   price,
   topUp,
   uploadFile,
@@ -83,6 +84,17 @@ applyOptions(
   [optionMap.address, ...walletOptions],
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, balance);
+});
+
+applyOptions(
+  program
+    .command('free-status')
+    .description(
+      'Get the free-tier upload allowance remaining for a Turbo address',
+    ),
+  [optionMap.address, ...walletOptions],
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, freeStatus);
 });
 
 applyOptions(

--- a/packages/turbo-sdk/src/cli/commands/freeStatus.ts
+++ b/packages/turbo-sdk/src/cli/commands/freeStatus.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TurboFactory } from '../../node/factory.js';
+import { AddressOptions } from '../types.js';
+import { addressOrPrivateKeyFromOptions, configFromOptions } from '../utils.js';
+
+export async function freeStatus(options: AddressOptions) {
+  const config = configFromOptions(options);
+  const { address, privateKey } = await addressOrPrivateKeyFromOptions(options);
+
+  const { bytesRemaining, nativeAddress } = await (async () => {
+    if (address !== undefined) {
+      return {
+        ...(await TurboFactory.unauthenticated(config).getFreeStatus(address)),
+        nativeAddress: address,
+      };
+    }
+    if (privateKey === undefined) {
+      throw new Error('Must provide an (--address) or use a valid wallet');
+    }
+    const turbo = TurboFactory.authenticated({
+      ...config,
+      privateKey,
+    });
+    return {
+      ...(await turbo.getFreeStatus()),
+      nativeAddress: await turbo.signer.getNativeAddress(),
+    };
+  })();
+
+  console.log(
+    `Turbo free-tier allowance for Native Address "${nativeAddress}"\n` +
+      (bytesRemaining === null
+        ? 'Free bytes remaining: unlimited (exempt/partner wallet)'
+        : `Free bytes remaining: ${bytesRemaining}`),
+  );
+}

--- a/packages/turbo-sdk/src/cli/commands/index.ts
+++ b/packages/turbo-sdk/src/cli/commands/index.ts
@@ -17,6 +17,7 @@
 export * from './arns.js';
 export * from './balance.js';
 export * from './cryptoFund.js';
+export * from './freeStatus.js';
 export * from './price.js';
 export * from './topUp.js';
 export * from './uploadFile.js';

--- a/packages/turbo-sdk/src/common/payment.freeStatus.test.ts
+++ b/packages/turbo-sdk/src/common/payment.freeStatus.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ArweaveSigner } from '@dha-team/arbundles';
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { testJwk } from '../../tests/helpers.js';
+import { TurboNodeSigner } from '../node/signer.js';
+import {
+  TurboAuthenticatedPaymentService,
+  TurboUnauthenticatedPaymentService,
+} from './payment.js';
+
+// Records the last GET and returns a canned response.
+class FakeHttp {
+  public calls: { endpoint: string; allowedStatuses?: number[] }[] = [];
+  public response: unknown = {};
+  async get(args: { endpoint: string; allowedStatuses?: number[] }) {
+    this.calls.push(args);
+    return this.response;
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+const newSigner = () =>
+  new TurboNodeSigner({ signer: new ArweaveSigner(testJwk), token: 'arweave' });
+
+describe('getFreeStatus', () => {
+  let http: FakeHttp;
+  beforeEach(() => {
+    http = new FakeHttp();
+  });
+
+  describe('unauthenticated', () => {
+    const service = () => {
+      const s = new TurboUnauthenticatedPaymentService({});
+      (s as unknown as { httpService: FakeHttp }).httpService = http;
+      return s;
+    };
+
+    it('builds /account/free?address= and returns bytesRemaining', async () => {
+      http.response = { bytesRemaining: 7340032 };
+      const res = await service().getFreeStatus('wallet-abc');
+      assert.equal(http.last.endpoint, '/account/free?address=wallet-abc');
+      assert.deepEqual(res, { bytesRemaining: 7340032 });
+    });
+
+    it('preserves 0 (free tier disabled) and null (unlimited/exempt)', async () => {
+      http.response = { bytesRemaining: 0 };
+      assert.deepEqual(await service().getFreeStatus('w'), {
+        bytesRemaining: 0,
+      });
+      http.response = { bytesRemaining: null };
+      assert.deepEqual(await service().getFreeStatus('w'), {
+        bytesRemaining: null,
+      });
+    });
+
+    it('coerces a missing field (e.g. a 404 body) to null', async () => {
+      http.response = 'Not Found';
+      assert.deepEqual(await service().getFreeStatus('w'), {
+        bytesRemaining: null,
+      });
+    });
+
+    it('tolerates a 404 via allowedStatuses', async () => {
+      http.response = { bytesRemaining: 10485760 };
+      await service().getFreeStatus('w');
+      assert.deepEqual(http.last.allowedStatuses, [200, 404]);
+    });
+  });
+
+  describe('authenticated', () => {
+    const service = () => {
+      const s = new TurboAuthenticatedPaymentService({ signer: newSigner() });
+      (s as unknown as { httpService: FakeHttp }).httpService = http;
+      return s;
+    };
+
+    it('defaults the address from the signer when none is given', async () => {
+      http.response = { bytesRemaining: 5 };
+      const nativeAddress = await newSigner().getNativeAddress();
+      const res = await service().getFreeStatus();
+      assert.equal(
+        http.last.endpoint,
+        `/account/free?address=${nativeAddress}`,
+      );
+      assert.deepEqual(res, { bytesRemaining: 5 });
+    });
+  });
+});

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -44,6 +44,7 @@ import {
   TurboDataItemSigner,
   TurboFiatEstimateForBytesResponse,
   TurboFiatToArResponse,
+  TurboFreeStatusResponse,
   TurboFundWithTokensParams,
   TurboInfoResponse,
   TurboLogger,
@@ -118,6 +119,18 @@ export class TurboUnauthenticatedPaymentService
           givenApprovals: [],
           receivedApprovals: [],
         };
+  }
+
+  public async getFreeStatus(
+    address: string,
+  ): Promise<TurboFreeStatusResponse> {
+    const status = await this.httpService.get<TurboFreeStatusResponse>({
+      endpoint: `/account/free?address=${address}`,
+      allowedStatuses: [200, 404],
+    });
+    // Normalize: preserve a legitimate `0` (free tier off) or `null` (unlimited),
+    // and coerce a missing field (e.g. a 404 body) to `null`.
+    return { bytesRemaining: status?.bytesRemaining ?? null };
   }
 
   public getFiatRates(): Promise<TurboRatesResponse> {
@@ -561,6 +574,13 @@ export class TurboAuthenticatedPaymentService
   public async getBalance(userAddress?: string): Promise<TurboBalanceResponse> {
     userAddress ??= await this.signer.getNativeAddress();
     return super.getBalance(userAddress);
+  }
+
+  public async getFreeStatus(
+    userAddress?: string,
+  ): Promise<TurboFreeStatusResponse> {
+    userAddress ??= await this.signer.getNativeAddress();
+    return super.getFreeStatus(userAddress);
   }
 
   /**

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -48,6 +48,7 @@ import {
   TurboDataItemSigner,
   TurboFiatEstimateForBytesResponse,
   TurboFiatToArResponse,
+  TurboFreeStatusResponse,
   TurboFundWithTokensParams,
   TurboPaymentIntentParams,
   TurboPaymentIntentResponse,
@@ -155,6 +156,10 @@ export class TurboUnauthenticatedClient
 
   getBalance(address: NativeAddress): Promise<TurboBalanceResponse> {
     return this.paymentService.getBalance(address);
+  }
+
+  getFreeStatus(address: NativeAddress): Promise<TurboFreeStatusResponse> {
+    return this.paymentService.getFreeStatus(address);
   }
 
   /**
@@ -345,6 +350,14 @@ export class TurboAuthenticatedClient
    */
   getBalance(userAddress?: NativeAddress): Promise<TurboBalanceResponse> {
     return this.paymentService.getBalance(userAddress);
+  }
+
+  /**
+   * Returns how many free-tier bytes the wallet can still upload for free
+   * (`bytesRemaining`), or `null` for an unlimited (exempt/partner) wallet.
+   */
+  getFreeStatus(userAddress?: NativeAddress): Promise<TurboFreeStatusResponse> {
+    return this.paymentService.getFreeStatus(userAddress);
   }
 
   /**

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -242,6 +242,18 @@ export type TurboBalanceResponse = {
   givenApprovals: CreditShareApproval[];
 };
 
+export type TurboFreeStatusResponse = {
+  /**
+   * Free-tier bytes this wallet can still upload for free, or `null` when the
+   * wallet has an unlimited allowance (an exempt/partner wallet). `0` when the
+   * free tier is disabled on the target Turbo deployment. Advisory — the
+   * authoritative free/charge decision is made at upload time, and the value is
+   * a wallet-side figure (a per-network cap may also apply). Deployment-wide
+   * free-tier config lives on the service's `/info` endpoint.
+   */
+  bytesRemaining: number | null;
+};
+
 export type TurboFiatToArResponse = {
   currency: Currency;
   rate: number;
@@ -1030,6 +1042,7 @@ export type ArNSPurchaseStatusResponse = ArNSPurchaseReceipt & {
 
 export interface TurboUnauthenticatedPaymentServiceInterface {
   getBalance: (address: string) => Promise<TurboBalanceResponse>;
+  getFreeStatus: (address: string) => Promise<TurboFreeStatusResponse>;
   getArNSPriceForName(params: ArNSPriceParams): Promise<ArNSPriceResponse>;
   getArNSPurchaseStatus(p: {
     nonce: string;
@@ -1086,6 +1099,9 @@ export type TurboFundWithTokensParams = {
 export interface TurboAuthenticatedPaymentServiceInterface
   extends TurboUnauthenticatedPaymentServiceInterface {
   getBalance: (userAddress?: UserAddress) => Promise<TurboBalanceResponse>;
+  getFreeStatus: (
+    userAddress?: UserAddress,
+  ) => Promise<TurboFreeStatusResponse>;
 
   getCreditShareApprovals(p: {
     userAddress?: UserAddress;


### PR DESCRIPTION
## What

Adds **`getFreeStatus`** to the payment-service client, wrapping the AR.IO Bundler's new **`GET /v1/account/free`** endpoint — so a caller can tell up front how much of the free tier a wallet has left.

```typescript
// authenticated (signer's own wallet)
const { bytesRemaining } = await turbo.getFreeStatus();

// unauthenticated, any wallet by address
const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
```

`bytesRemaining` is the wallet's remaining free-tier upload bytes; **`null`** = unlimited (exempt/partner wallet), **`0`** = free tier disabled on the target deployment. Advisory — the authoritative free/charge decision happens at upload time.

## Shape

Mirrors `getBalance` exactly (public, open-by-address, 404-tolerant), threaded through all four layers:
- **Interface** (`types.ts`): `TurboFreeStatusResponse`; `getFreeStatus(address)` on the unauthenticated interface + an optional-address override on the authenticated interface.
- **Impl** (`common/payment.ts`): `GET /account/free?address=…` with `allowedStatuses: [200, 404]`; normalizes a missing field to `null` while preserving a legitimate `0`/`null`. Authenticated variant defaults the address from the signer.
- **Facade** (`common/turbo.ts`): delegation on both clients.
- **CLI**: `turbo free-status [--address <a> | --wallet-file <f>]`.

## Tests / docs

- Unit tests (mocked HTTP): endpoint + query, preserves `0` and `null`, coerces a missing field to `null`, and the authenticated signer-address default. Full unit suite green (96 tests).
- README API + CLI docs + regenerated TOC. `yarn build`, `tsc`, and `eslint` all clean.

## Scope

This is the free-status method only. **Payment history (`getPaymentHistory`) ships as a separate PR** (it introduces a signed-GET pattern and is tracked independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)