### PR TITLE
feat(payment): add getPaymentHistory for a wallet's own top-up history

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,23 @@ It is also available on the `TurboUnauthenticatedClient` for any wallet by addre
 const { bytesRemaining } = await turbo.getFreeStatus('a-native-address');
 ```
 
+#### `getPaymentHistory({ limit, cursor })`
+
+Issues a signed request for the signing wallet's own completed top-up (payment) history — both cryptocurrency and fiat top-ups — merged newest-first and keyset-paginated. This is self-scoped: it returns **only** the signing wallet's rows (the service reads the address from the signature, never a query parameter), so it is available on the `TurboAuthenticatedClient` only. `limit` is the page size (1-100, default 50). To page, pass the previous response's `cursor` while `hasMore` is `true`.
+
+Each item is discriminated by `type`: a `'crypto'` item includes `wincCredited`, `tokenType`, `tokenQuantity`, `usdEquivalent`, `senderAddress`, `transactionId`, and `blockHeight`; a `'fiat'` item includes `wincCredited`, `paymentAmount`, `currencyType`, `paymentProvider`, `receiptId`, and `giftMessage`. Every item has an ISO-8601 UTC `date`.
+
+```typescript
+const { payments, hasMore, cursor } = await turbo.getPaymentHistory({
+  limit: 25,
+});
+
+// Fetch the next page while more results remain
+if (hasMore) {
+  const next = await turbo.getPaymentHistory({ limit: 25, cursor });
+}
+```
+
 #### `signer.getNativeAddress()`
 
 Returns the [native address][docs/native-address] of the connected signer.
@@ -1602,6 +1619,26 @@ turbo free-status --address 'crypto-wallet-public-native-address' --token arweav
 
 ```shell
 turbo free-status --wallet-file '../path/to/my/wallet.json' --token arweave
+```
+
+##### `payment-history`
+
+Get the signing wallet's own top-up (payment) history — both crypto and fiat top-ups, newest first. Requires a wallet (it is signature-scoped to that wallet). Prints a JSON page of `{ payments, hasMore, cursor }`; when `hasMore` is `true`, pass the printed `cursor` back with `--cursor` to fetch the next page.
+
+Command Options:
+
+- `--limit <limit>` - Max number of rows to return (1-100, default 50)
+- `--cursor <cursor>` - Opaque pagination cursor from a prior response
+
+e.g:
+
+```shell
+turbo payment-history --wallet-file '../path/to/my/wallet.json' --token arweave --limit 25
+```
+
+```shell
+# Fetch the next page using the cursor printed by the previous call
+turbo payment-history --wallet-file '../path/to/my/wallet.json' --token arweave --cursor '<cursor-from-previous-page>'
 ```
 
 ##### `top-up`

--- a/packages/turbo-sdk/src/cli/cli.ts
+++ b/packages/turbo-sdk/src/cli/cli.ts
@@ -38,6 +38,7 @@ import {
   balance,
   cryptoFund,
   freeStatus,
+  paymentHistory,
   price,
   topUp,
   uploadFile,
@@ -95,6 +96,15 @@ applyOptions(
   [optionMap.address, ...walletOptions],
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, freeStatus);
+});
+
+applyOptions(
+  program
+    .command('payment-history')
+    .description("Get the signing wallet's own top-up (payment) history"),
+  [...walletOptions, optionMap.limit, optionMap.cursor],
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, paymentHistory);
 });
 
 applyOptions(

--- a/packages/turbo-sdk/src/cli/commands/index.ts
+++ b/packages/turbo-sdk/src/cli/commands/index.ts
@@ -18,6 +18,7 @@ export * from './arns.js';
 export * from './balance.js';
 export * from './cryptoFund.js';
 export * from './freeStatus.js';
+export * from './paymentHistory.js';
 export * from './price.js';
 export * from './topUp.js';
 export * from './uploadFile.js';

--- a/packages/turbo-sdk/src/cli/commands/paymentHistory.ts
+++ b/packages/turbo-sdk/src/cli/commands/paymentHistory.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PaymentHistoryOptions } from '../types.js';
+import { turboFromOptions } from '../utils.js';
+
+export async function paymentHistory(options: PaymentHistoryOptions) {
+  // Signature-required and self-scoped: a wallet is mandatory (there is no
+  // --address form), and the service returns only this signer's own top-ups.
+  const turbo = await turboFromOptions(options);
+
+  const limit = options.limit !== undefined ? +options.limit : undefined;
+  if (
+    limit !== undefined &&
+    (!Number.isInteger(limit) || limit < 1 || limit > 100)
+  ) {
+    throw new Error('--limit must be an integer between 1 and 100');
+  }
+
+  const { payments, hasMore, cursor } = await turbo.getPaymentHistory({
+    limit,
+    cursor: options.cursor,
+  });
+
+  // stdout is exactly the documented page shape so `... | jq` stays valid JSON;
+  // the human-facing next-page hint goes to stderr.
+  console.log(JSON.stringify({ payments, hasMore, cursor }, null, 2));
+
+  if (hasMore) {
+    console.error(
+      `\nMore results available — fetch the next page with --cursor ${cursor}`,
+    );
+  }
+}

--- a/packages/turbo-sdk/src/cli/commands/paymentHistory.ts
+++ b/packages/turbo-sdk/src/cli/commands/paymentHistory.ts
@@ -34,8 +34,9 @@ export async function paymentHistory(options: PaymentHistoryOptions) {
     cursor: options.cursor,
   });
 
-  // stdout is exactly the documented page shape so `... | jq` stays valid JSON;
-  // the human-facing next-page hint goes to stderr.
+  // stdout carries only the JSON page and the next-page hint goes to stderr, so
+  // `... | jq` works at the default log level. (--debug intentionally routes SDK
+  // logs to stdout and will interleave — expected when you ask for debug output.)
   console.log(JSON.stringify({ payments, hasMore, cursor }, null, 2));
 
   if (hasMore) {

--- a/packages/turbo-sdk/src/cli/options.ts
+++ b/packages/turbo-sdk/src/cli/options.ts
@@ -246,6 +246,17 @@ export const optionMap = {
     alias: '--ttl-seconds <ttlSeconds>',
     description: 'TTL in seconds for the ArNS record',
   },
+  // ---- Payment history ----
+  limit: {
+    alias: '--limit <limit>',
+    description:
+      'Max number of payment-history rows to return (1-100, default 50)',
+  },
+  cursor: {
+    alias: '--cursor <cursor>',
+    description:
+      'Opaque pagination cursor from a prior payment-history response',
+  },
 } as const;
 
 export const walletOptions = [

--- a/packages/turbo-sdk/src/cli/types.ts
+++ b/packages/turbo-sdk/src/cli/types.ts
@@ -37,6 +37,11 @@ export type AddressOptions = WalletOptions & {
   address: string | undefined;
 };
 
+export type PaymentHistoryOptions = WalletOptions & {
+  limit: string | undefined;
+  cursor: string | undefined;
+};
+
 export type TopUpOptions = AddressOptions & {
   value: string | undefined;
   currency: string | undefined;

--- a/packages/turbo-sdk/src/common/payment.paymentHistory.test.ts
+++ b/packages/turbo-sdk/src/common/payment.paymentHistory.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ArweaveSigner } from '@dha-team/arbundles';
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { testJwk } from '../../tests/helpers.js';
+import { TurboNodeSigner } from '../node/signer.js';
+import { FailedRequestError } from '../utils/errors.js';
+import { TurboAuthenticatedPaymentService } from './payment.js';
+
+// getPaymentHistory signs the bare nonce, which defaults to randomBytes(16) hex.
+const HEX_NONCE_RE = /^[0-9a-f]{32}$/i;
+
+// Records the last get() call (including allowedStatuses) and returns a canned
+// response, or throws `error` to exercise failure handling.
+class FakeHttp {
+  public calls: {
+    endpoint: string;
+    headers?: Record<string, string>;
+    allowedStatuses?: number[];
+  }[] = [];
+  public response: unknown = {};
+  public error: unknown = undefined;
+  async get(args: {
+    endpoint: string;
+    headers?: Record<string, string>;
+    allowedStatuses?: number[];
+  }) {
+    this.calls.push(args);
+    if (this.error) throw this.error;
+    return this.response;
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+// Wraps a real signer to capture (nonce, additionalData) so we can prove the
+// request signs the BARE nonce (no action-binding) as the service expects.
+class RecordingSigner {
+  public calls: { nonce?: string; additionalData?: string }[] = [];
+  constructor(private readonly inner: TurboNodeSigner) {}
+  async generateSignedRequestHeaders(nonce?: string, additionalData?: string) {
+    this.calls.push({ nonce, additionalData });
+    return this.inner.generateSignedRequestHeaders(nonce, additionalData);
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+const newSigner = () =>
+  new TurboNodeSigner({ signer: new ArweaveSigner(testJwk), token: 'arweave' });
+
+describe('getPaymentHistory', () => {
+  let http: FakeHttp;
+
+  const service = () => {
+    const s = new TurboAuthenticatedPaymentService({ signer: newSigner() });
+    (s as unknown as { httpService: FakeHttp }).httpService = http;
+    return s;
+  };
+
+  beforeEach(() => {
+    http = new FakeHttp();
+    http.response = { payments: [], hasMore: false, cursor: null };
+  });
+
+  it('GETs /account/payments with signed headers and allowedStatuses [200]', async () => {
+    await service().getPaymentHistory();
+    assert.equal(http.last.endpoint, '/account/payments');
+    assert.deepEqual(http.last.allowedStatuses, [200]);
+    // Real signature headers must be attached (proof-of-ownership).
+    assert.match(http.last.headers?.['x-nonce'] ?? '', HEX_NONCE_RE);
+    assert.equal(http.last.headers?.['x-signature-type'], '1'); // arweave
+    assert.ok((http.last.headers?.['x-public-key']?.length ?? 0) > 0);
+    assert.ok((http.last.headers?.['x-signature']?.length ?? 0) > 0);
+  });
+
+  it('signs the BARE nonce (no limit/cursor action-binding) to match the service', async () => {
+    const s = service();
+    const rec = new RecordingSigner(
+      (s as unknown as { signer: TurboNodeSigner }).signer,
+    );
+    (s as unknown as { signer: RecordingSigner }).signer = rec;
+
+    await s.getPaymentHistory({ limit: 10, cursor: 'abc' });
+    // Called with no args → inner signer generates the nonce, additionalData undefined.
+    assert.equal(rec.last.nonce, undefined);
+    assert.equal(rec.last.additionalData, undefined);
+  });
+
+  it('puts limit and cursor in the query string', async () => {
+    await service().getPaymentHistory({ limit: 25, cursor: 'CURSOR123' });
+    assert.equal(
+      http.last.endpoint,
+      '/account/payments?limit=25&cursor=CURSOR123',
+    );
+  });
+
+  it('includes only the params provided', async () => {
+    await service().getPaymentHistory({ limit: 5 });
+    assert.equal(http.last.endpoint, '/account/payments?limit=5');
+
+    await service().getPaymentHistory({ cursor: 'onlyCursor' });
+    assert.equal(http.last.endpoint, '/account/payments?cursor=onlyCursor');
+  });
+
+  it('URL-encodes an opaque cursor', async () => {
+    // Cursors are base64url so they never contain '+//=', but a defensive check
+    // that URLSearchParams encoding is in effect (no raw injection into the path).
+    await service().getPaymentHistory({ cursor: 'a b&c=d' });
+    assert.equal(http.last.endpoint, '/account/payments?cursor=a+b%26c%3Dd');
+  });
+
+  it('returns the service response unchanged', async () => {
+    const page = {
+      payments: [
+        {
+          type: 'crypto',
+          date: '2026-01-02T00:00:00.000Z',
+          wincCredited: '1000',
+          tokenType: 'ethereum',
+          tokenQuantity: '5793434082931',
+          usdEquivalent: '0.010000',
+          senderAddress: '0xSENDER',
+          transactionId: 'tx-1',
+          blockHeight: '25576712',
+        },
+        {
+          type: 'fiat',
+          date: '2026-01-01T00:00:00.000Z',
+          wincCredited: '2000',
+          paymentAmount: '1000',
+          currencyType: 'usd',
+          paymentProvider: 'stripe',
+          receiptId: 'r-1',
+          giftMessage: null,
+        },
+      ],
+      hasMore: true,
+      cursor: 'NEXT',
+    };
+    http.response = page;
+    const res = await service().getPaymentHistory({ limit: 2 });
+    assert.deepEqual(res, page);
+  });
+
+  it('propagates a service error (e.g. 401 unsigned/invalid)', async () => {
+    http.error = new FailedRequestError('Signature required', 401);
+    await assert.rejects(
+      () => service().getPaymentHistory(),
+      /Signature required/,
+    );
+  });
+});

--- a/packages/turbo-sdk/src/common/payment.paymentHistory.test.ts
+++ b/packages/turbo-sdk/src/common/payment.paymentHistory.test.ts
@@ -127,6 +127,36 @@ describe('getPaymentHistory', () => {
     assert.equal(http.last.endpoint, '/account/payments?cursor=a+b%26c%3Dd');
   });
 
+  it('forwards a real base64url cursor byte-for-byte (- and _ not percent-encoded)', async () => {
+    // The service issues cursors via Buffer.toString('base64url'); its alphabet
+    // is [A-Za-z0-9-_]. URLSearchParams must leave '-' and '_' untouched or a
+    // round-tripped cursor would decode differently server-side and mis-paginate.
+    const serverCursor = Buffer.from(
+      JSON.stringify({
+        d: '2026-01-02T03:04:05.678901Z',
+        t: 'crypto',
+        i: 'tx-1',
+      }),
+    ).toString('base64url');
+    assert.ok(!/[+/=]/.test(serverCursor)); // sanity: genuinely base64url
+    await service().getPaymentHistory({ cursor: serverCursor });
+    assert.equal(
+      http.last.endpoint,
+      `/account/payments?cursor=${serverCursor}`,
+    );
+  });
+
+  it('replays a prior page cursor unchanged (page-2 fetch)', async () => {
+    http.response = { payments: [], hasMore: true, cursor: 'PAGE2CURSOR-_x' };
+    const page1 = await service().getPaymentHistory({ limit: 2 });
+    assert.equal(page1.hasMore, true);
+    await service().getPaymentHistory({ limit: 2, cursor: page1.cursor ?? '' });
+    assert.equal(
+      http.last.endpoint,
+      '/account/payments?limit=2&cursor=PAGE2CURSOR-_x',
+    );
+  });
+
   it('returns the service response unchanged', async () => {
     const page = {
       payments: [

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -48,6 +48,8 @@ import {
   TurboFundWithTokensParams,
   TurboInfoResponse,
   TurboLogger,
+  TurboPaymentHistoryParams,
+  TurboPaymentHistoryResponse,
   TurboPaymentIntentParams,
   TurboPaymentIntentResponse,
   TurboPostBalanceResponse,
@@ -581,6 +583,37 @@ export class TurboAuthenticatedPaymentService
   ): Promise<TurboFreeStatusResponse> {
     userAddress ??= await this.signer.getNativeAddress();
     return super.getFreeStatus(userAddress);
+  }
+
+  /**
+   * The signer's OWN completed top-up history (crypto + fiat), merged newest
+   * first and keyset-paginated. This is a SIGNED GET: unlike `getBalance` /
+   * `getFreeStatus` (which name a wallet by `?address=`), payment history is
+   * self-scoped and returns only the rows belonging to the signing wallet — the
+   * service reads the address from the signature, never a query param.
+   *
+   * We sign the bare nonce (no action-binding of `limit`/`cursor`) to match the
+   * service's `verifySignature` middleware; the pagination params ride in the
+   * query string. Pass `cursor` from a prior response to fetch the next page.
+   */
+  public async getPaymentHistory({
+    limit,
+    cursor,
+  }: TurboPaymentHistoryParams = {}): Promise<TurboPaymentHistoryResponse> {
+    const headers = await this.signer.generateSignedRequestHeaders();
+    const query = new URLSearchParams();
+    if (limit !== undefined) {
+      query.set('limit', `${limit}`);
+    }
+    if (cursor !== undefined) {
+      query.set('cursor', cursor);
+    }
+    const queryString = query.toString();
+    return this.httpService.get<TurboPaymentHistoryResponse>({
+      endpoint: `/account/payments${queryString ? `?${queryString}` : ''}`,
+      headers,
+      allowedStatuses: [200],
+    });
   }
 
   /**

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -50,6 +50,8 @@ import {
   TurboFiatToArResponse,
   TurboFreeStatusResponse,
   TurboFundWithTokensParams,
+  TurboPaymentHistoryParams,
+  TurboPaymentHistoryResponse,
   TurboPaymentIntentParams,
   TurboPaymentIntentResponse,
   TurboPriceResponse,
@@ -358,6 +360,18 @@ export class TurboAuthenticatedClient
    */
   getFreeStatus(userAddress?: NativeAddress): Promise<TurboFreeStatusResponse> {
     return this.paymentService.getFreeStatus(userAddress);
+  }
+
+  /**
+   * Returns the signer's OWN completed top-up history (crypto + fiat), newest
+   * first and keyset-paginated. Signature-required and self-scoped: it only ever
+   * returns the signing wallet's rows. Pass `cursor` from a prior response's
+   * `cursor` field (with `hasMore === true`) to fetch the next page.
+   */
+  getPaymentHistory(
+    params?: TurboPaymentHistoryParams,
+  ): Promise<TurboPaymentHistoryResponse> {
+    return this.paymentService.getPaymentHistory(params);
   }
 
   /**

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -254,6 +254,58 @@ export type TurboFreeStatusResponse = {
   bytesRemaining: number | null;
 };
 
+/** A single credited top-up settled with cryptocurrency. */
+export type TurboCryptoPaymentHistoryItem = {
+  type: 'crypto';
+  /** ISO-8601 UTC timestamp of when the credits landed. */
+  date: string;
+  /** Winston Credits credited by this top-up. */
+  wincCredited: string;
+  tokenType: string;
+  /** On-chain token amount paid, in the token's smallest unit. */
+  tokenQuantity: string;
+  /** USD value captured at credit time (historical; not a live quote). */
+  usdEquivalent: string;
+  /** On-chain sender address; empty string on rows predating the column. */
+  senderAddress: string;
+  transactionId: string;
+  blockHeight: string;
+};
+
+/** A single credited top-up settled with fiat (e.g. a Stripe card payment). */
+export type TurboFiatPaymentHistoryItem = {
+  type: 'fiat';
+  /** ISO-8601 UTC timestamp of when the receipt was recorded. */
+  date: string;
+  /** Winston Credits credited by this top-up. */
+  wincCredited: string;
+  paymentAmount: string;
+  currencyType: string;
+  paymentProvider: string;
+  receiptId: string;
+  giftMessage: string | null;
+};
+
+export type TurboPaymentHistoryItem =
+  | TurboCryptoPaymentHistoryItem
+  | TurboFiatPaymentHistoryItem;
+
+export type TurboPaymentHistoryResponse = {
+  /** One page of the signer's own top-ups, newest first. */
+  payments: TurboPaymentHistoryItem[];
+  /** True when more rows exist beyond this page (fetch again with `cursor`). */
+  hasMore: boolean;
+  /** Opaque cursor for the next page, or `null` on the last page. */
+  cursor: string | null;
+};
+
+export type TurboPaymentHistoryParams = {
+  /** Page size, 1-100 (default 50 on the service). */
+  limit?: number;
+  /** Opaque cursor from a prior response's `cursor` field. */
+  cursor?: string;
+};
+
 export type TurboFiatToArResponse = {
   currency: Currency;
   rate: number;
@@ -1102,6 +1154,14 @@ export interface TurboAuthenticatedPaymentServiceInterface
   getFreeStatus: (
     userAddress?: UserAddress,
   ) => Promise<TurboFreeStatusResponse>;
+
+  /**
+   * The signer's OWN completed top-up history (crypto + fiat), newest first.
+   * Signature-required and self-scoped — there is no by-address form.
+   */
+  getPaymentHistory(
+    params?: TurboPaymentHistoryParams,
+  ): Promise<TurboPaymentHistoryResponse>;
 
   getCreditShareApprovals(p: {
     userAddress?: UserAddress;


### PR DESCRIPTION
## Summary

Adds `getPaymentHistory({ limit, cursor })` to the authenticated Turbo client — a wallet's **own** completed top-up (payment) history, crypto + fiat, merged newest-first and keyset-paginated.

```ts
const { payments, hasMore, cursor } = await turbo.getPaymentHistory({ limit: 25 });
if (hasMore) {
  const next = await turbo.getPaymentHistory({ limit: 25, cursor });
}
```

Response: `{ payments, hasMore, cursor }` where each `payment` is discriminated by `type`:
- `'crypto'` → `wincCredited, tokenType, tokenQuantity, usdEquivalent, senderAddress, transactionId, blockHeight`
- `'fiat'` → `wincCredited, paymentAmount, currencyType, paymentProvider, receiptId, giftMessage`

Every item carries an ISO-8601 UTC `date`.

## Design notes

- **Signed GET (a new shape for this SDK).** Every existing GET (`getBalance`, `getFreeStatus`) is unsigned and names a wallet by `?address=`. Payment history is materially more sensitive (fiat amounts, providers, gift messages, cadence) and the wallet address is a public identifier — so it is **self-scoped**: the service reads the address from the signature and returns only that wallet's rows. There is deliberately **no** by-address/unauthenticated form; the method lives on the authenticated client only, enforced at the type level.
- **Signs the bare nonce.** Matches the payment service's `verifySignature` middleware (verifies over the nonce with no additional data). `limit`/`cursor` are not action-bound into the signature; they ride in the query string. This is the identical auth posture to `GET /v1/balance`.
- **Endpoint** is `/account/payments` — the HTTP client already prefixes `/v1`, exactly as `getBalance`/`getFreeStatus` do.

## Changes

Mirrors the `getFreeStatus` PR's file-set:
- `src/types.ts` — `TurboCrypto/FiatPaymentHistoryItem`, `TurboPaymentHistoryItem`, `TurboPaymentHistoryResponse`, `TurboPaymentHistoryParams`; method on the authenticated interface only.
- `src/common/payment.ts` — implementation on `TurboAuthenticatedPaymentService` (sign → `httpService.get` with signed headers, `allowedStatuses: [200]`).
- `src/common/turbo.ts` — exposed on `TurboAuthenticatedClient`.
- CLI: new `payment-history` command (`--limit`/`--cursor`, wallet required) + `optionMap`/types/barrel/registration.
- `README.md` — SDK method + CLI docs.
- New unit tests (`payment.paymentHistory.test.ts`): signed headers, bare-nonce signing, query building, cursor URL-encoding, response pass-through, error propagation.

## Testing

- `tsc --noEmit` clean; `eslint` clean (prettier/import-sort gate).
- New suite (7 tests) + all payment suites (53 tests) green.
- Full `yarn build` (web/esm/cjs/types) clean.

Targets **`alpha`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API method to retrieve the signing wallet’s crypto and fiat payment history.
  * Added cursor-based pagination with configurable result limits.
  * Added a `payment-history` CLI command with `--limit` and `--cursor` options.
  * Payment history responses include payment records, pagination status, and a continuation cursor.

* **Documentation**
  * Documented the new API method, response formats, pagination behavior, and CLI usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->