### PR TITLE
fix(x402): post uploads to /x402/upload/* and sign on Base mainnet

### DIFF
--- a/packages/turbo-sdk/src/common/http.ts
+++ b/packages/turbo-sdk/src/common/http.ts
@@ -48,6 +48,19 @@ const defaultHeaders = {
   'x-turbo-source-identifier': 'turbo-sdk',
 };
 
+/**
+ * Canonical x402 upload routes on the upload service.
+ *
+ * These were previously `/x402/data-item/{signed,unsigned}`. The service
+ * renamed them to `/x402/upload/*` and kept a `data-item/signed` alias, but not
+ * a `data-item/unsigned` one — so every unsigned x402 upload 404ed. Both
+ * canonical paths are served by all released upload-service versions.
+ */
+export const x402UploadEndpoints = {
+  signed: '/x402/upload/signed',
+  unsigned: '/x402/upload/unsigned',
+} as const;
+
 export class TurboHTTPService implements TurboHTTPServiceInterface {
   protected baseURL: string;
   protected logger: TurboLogger;
@@ -223,8 +236,9 @@ export class TurboHTTPService implements TurboHTTPServiceInterface {
     data: Readable | Buffer | ReadableStream | Uint8Array;
     x402Options: X402RequestCredentials;
   }): Promise<T> {
-    const endpoint =
-      '/x402/data-item/' + (x402Options.unsignedData ? 'unsigned' : 'signed');
+    const endpoint = x402Options.unsignedData
+      ? x402UploadEndpoints.unsigned
+      : x402UploadEndpoints.signed;
 
     this.logger.debug('Using X402 options for POST request', {
       endpoint,

--- a/packages/turbo-sdk/src/common/signer.ts
+++ b/packages/turbo-sdk/src/common/signer.ts
@@ -34,7 +34,7 @@ import { computeAddress } from 'ethers';
 import nacl from 'tweetnacl';
 import { type EIP1193Provider, createWalletClient, custom, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { baseSepolia } from 'viem/chains';
+import { base } from 'viem/chains';
 import { Signer as x402Signer } from 'x402-fetch';
 
 import {
@@ -272,6 +272,16 @@ export abstract class TurboDataItemAbstractSigner
   }
 }
 
+/**
+ * Builds the wallet client x402-fetch signs payment authorizations with.
+ *
+ * The chain matters because `wrapFetchWithPayment` maps `walletClient.chain.id`
+ * to a network name and prefers the matching entry in the service's `accepts`
+ * list. The upload service advertises Base mainnet (`base`), and x402 support
+ * here is limited to `base-usdc`, so mainnet is the correct default. Callers
+ * needing another network can supply their own signer via
+ * `X402Funding({ signer })`.
+ */
 export async function makeX402Signer(
   arbundlesSigner: ArbundleSigner,
 ): Promise<x402Signer> {
@@ -282,7 +292,7 @@ export async function makeX402Signer(
         ('0x' +
           Buffer.from(arbundlesSigner.key).toString('hex')) as `0x${string}`,
       ),
-      chain: baseSepolia,
+      chain: base,
       transport: http(),
     }) as unknown as x402Signer;
   }
@@ -306,7 +316,7 @@ export async function makeX402Signer(
 
     return createWalletClient({
       account,
-      chain: baseSepolia,
+      chain: base,
       transport: custom(provider),
     }) as unknown as x402Signer;
   }

--- a/packages/turbo-sdk/src/common/upload.ts
+++ b/packages/turbo-sdk/src/common/upload.ts
@@ -56,7 +56,7 @@ import { FailedRequestError } from '../utils/errors.js';
 import { ChunkedUploader } from './chunked.js';
 import { TurboEventEmitter, createStreamWithUploadEvents } from './events.js';
 import { RetryConfig, defaultRetryConfig } from './http.js';
-import { TurboHTTPService } from './http.js';
+import { TurboHTTPService, x402UploadEndpoints } from './http.js';
 import { exponentMap, tokenToBaseMap } from './index.js';
 import { Logger } from './logger.js';
 import { TurboAuthenticatedPaymentService } from './payment.js';
@@ -213,7 +213,9 @@ export class TurboUnauthenticatedUploadService
 
     return this.httpService.post({
       data: dataBuffer,
-      endpoint: '/x402/data-item/unsigned',
+      // Only reached when no signer was supplied; the x402 path recomputes this
+      // from `unsignedData`. Both must name the same route.
+      endpoint: x402UploadEndpoints.unsigned,
       signal,
       headers:
         tags !== undefined

--- a/packages/turbo-sdk/src/common/x402.test.ts
+++ b/packages/turbo-sdk/src/common/x402.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EthereumSigner } from '@dha-team/arbundles';
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { testEthWallet } from '../../tests/helpers.js';
+import { TurboHTTPService, x402UploadEndpoints } from './http.js';
+import { Logger } from './logger.js';
+import { makeX402Signer } from './signer.js';
+
+/**
+ * Base mainnet. The upload service advertises `network: "base"` with USDC
+ * `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, and x402-fetch picks the entry
+ * in `accepts` matching the wallet client's chain id — so a signer on any other
+ * chain either mis-selects or fails to match at all.
+ */
+const baseMainnetChainId = 8453;
+
+describe('x402 upload endpoints', () => {
+  const originalFetch = globalThis.fetch;
+  let requestedUrls: string[];
+
+  beforeEach(() => {
+    requestedUrls = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requestedUrls.push(typeof input === 'string' ? input : input.toString());
+      return new Response(JSON.stringify({ id: 'stub-id' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const httpService = () =>
+    new TurboHTTPService({
+      url: 'https://upload.example.com/v1',
+      logger: Logger.default,
+      retryConfig: {
+        retries: 1,
+        retryDelay: () => 0,
+        onRetry: () => undefined,
+      },
+    });
+
+  // Regression for #440: these posted to `/x402/data-item/*`, but the upload
+  // service renamed the routes to `/x402/upload/*` and only kept a
+  // `data-item/signed` alias — so every unsigned x402 upload 404ed.
+  it('posts signed x402 uploads to /v1/x402/upload/signed', async () => {
+    await httpService().post({
+      endpoint: '/ignored-when-x402',
+      data: Buffer.from('hello'),
+      x402Options: { signer: {} as never, unsignedData: false },
+    });
+
+    assert.deepEqual(requestedUrls, [
+      'https://upload.example.com/v1/x402/upload/signed',
+    ]);
+  });
+
+  it('posts unsigned x402 uploads to /v1/x402/upload/unsigned', async () => {
+    await httpService().post({
+      endpoint: '/ignored-when-x402',
+      data: Buffer.from('hello'),
+      x402Options: { signer: {} as never, unsignedData: true },
+    });
+
+    assert.deepEqual(requestedUrls, [
+      'https://upload.example.com/v1/x402/upload/unsigned',
+    ]);
+  });
+
+  it('never references the retired /x402/data-item/* routes', () => {
+    assert.equal(x402UploadEndpoints.signed, '/x402/upload/signed');
+    assert.equal(x402UploadEndpoints.unsigned, '/x402/upload/unsigned');
+  });
+});
+
+describe('makeX402Signer', () => {
+  // Regression for #441: both branches hardcoded `chain: baseSepolia` (84532)
+  // while the deployed service settles on Base mainnet.
+  it('builds a wallet client on the chain the upload service settles on', async () => {
+    const signer = (await makeX402Signer(
+      new EthereumSigner(testEthWallet),
+    )) as unknown as { chain?: { id: number } };
+
+    assert.equal(signer.chain?.id, baseMainnetChainId);
+  });
+});

--- a/packages/turbo-sdk/src/common/x402.test.ts
+++ b/packages/turbo-sdk/src/common/x402.test.ts
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { EthereumSigner } from '@dha-team/arbundles';
+import { ArweaveSigner, EthereumSigner } from '@dha-team/arbundles';
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
-import { testEthWallet } from '../../tests/helpers.js';
+import { testEthWallet, testJwk } from '../../tests/helpers.js';
 import { TurboHTTPService, x402UploadEndpoints } from './http.js';
+// Via the barrel, not './upload.js': entering the upload -> index -> turbo ->
+// upload cycle at upload.ts leaves `developmentUploadServiceURL` uninitialized.
+import { TurboUnauthenticatedUploadService } from './index.js';
 import { Logger } from './logger.js';
 import { makeX402Signer } from './signer.js';
 
@@ -91,16 +94,101 @@ describe('x402 upload endpoints', () => {
     assert.equal(x402UploadEndpoints.signed, '/x402/upload/signed');
     assert.equal(x402UploadEndpoints.unsigned, '/x402/upload/unsigned');
   });
+
+  // `uploadRawX402Data` names the route a second time, independently of the one
+  // `x402Post` computes, and that copy is the live one when no signer is passed
+  // (no signer -> no x402Options -> the plain POST path). It carried the same
+  // retired path, so #440 reproduced through this function specifically.
+  it('sends uploadRawX402Data to /v1/x402/upload/unsigned without a signer', async () => {
+    const service = new TurboUnauthenticatedUploadService({
+      url: 'https://upload.example.com',
+      token: 'base-usdc',
+      logger: Logger.default,
+    });
+
+    await service.uploadRawX402Data({
+      data: Buffer.from('hello'),
+      tags: [{ name: 'Content-Type', value: 'text/plain' }],
+    });
+
+    assert.deepEqual(requestedUrls, [
+      'https://upload.example.com/v1/x402/upload/unsigned',
+    ]);
+  });
+
+  it('rejects uploadRawX402Data for tokens without x402 support', async () => {
+    const service = new TurboUnauthenticatedUploadService({
+      url: 'https://upload.example.com',
+      token: 'arweave',
+      logger: Logger.default,
+    });
+
+    await assert.rejects(
+      () => service.uploadRawX402Data({ data: Buffer.from('hello') }),
+      /x402 uploads are not supported for token: arweave/,
+    );
+    assert.deepEqual(requestedUrls, []);
+  });
 });
 
 describe('makeX402Signer', () => {
-  // Regression for #441: both branches hardcoded `chain: baseSepolia` (84532)
-  // while the deployed service settles on Base mainnet.
+  // Regression for #441: BOTH branches hardcoded `chain: baseSepolia` (84532)
+  // while the deployed service settles on Base mainnet, so both are asserted.
   it('builds a wallet client on the chain the upload service settles on', async () => {
     const signer = (await makeX402Signer(
       new EthereumSigner(testEthWallet),
     )) as unknown as { chain?: { id: number } };
 
     assert.equal(signer.chain?.id, baseMainnetChainId);
+  });
+
+  describe('browser branch', () => {
+    const account = '0x1234567890123456789012345678901234567890';
+    let requests: string[];
+
+    beforeEach(() => {
+      requests = [];
+      (globalThis as Record<string, unknown>).window = {
+        document: {},
+        ethereum: {
+          request: async ({ method }: { method: string }) => {
+            requests.push(method);
+            if (method === 'eth_requestAccounts') return [account];
+            return null;
+          },
+        },
+      };
+    });
+
+    afterEach(() => {
+      delete (globalThis as Record<string, unknown>).window;
+    });
+
+    it('also builds the injected-wallet client on Base mainnet', async () => {
+      // A non-Ethereum arbundles signer falls through to the injected-wallet
+      // branch, which is the path browser consumers take.
+      const signer = (await makeX402Signer(
+        new ArweaveSigner(testJwk),
+      )) as unknown as {
+        chain?: { id: number };
+        account?: { address: string };
+      };
+
+      assert.equal(signer.chain?.id, baseMainnetChainId);
+      assert.deepEqual(requests, ['eth_requestAccounts']);
+    });
+
+    it('throws when the wallet returns no accounts', async () => {
+      (
+        (globalThis as Record<string, unknown>).window as {
+          ethereum: { request: () => Promise<unknown> };
+        }
+      ).ethereum.request = async () => [];
+
+      await assert.rejects(
+        () => makeX402Signer(new ArweaveSigner(testJwk)),
+        /No accounts returned from wallet/,
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #440. Refs #441.

Both issues were reproduced against `alpha` and the live upload service before changing anything.

## #440 — unsigned x402 uploads 404 (real bug)

The upload service renamed its x402 routes from `/x402/data-item/*` to `/x402/upload/*`, then restored only a `data-item/signed` alias. We still post to `/x402/data-item/*`, so signed uploads survive on that alias while every unsigned upload 404s.

Probed against production:

| endpoint | upload.ardrive.io | upload.services.ar.io |
|---|---|---|
| `/v1/x402/data-item/signed` | 402 | 402 |
| `/v1/x402/data-item/unsigned` | **404** | **404** |
| `/v1/x402/upload/unsigned` | 402 | 402 |

Two corrections to the issue as filed, for the record:

- The reporter's probe table omitted the `/v1` prefix, since `baseURL` is already `${url}/v1`. The SDK never requests the paths they listed.
- `/v1/tx` is not the intended route. The challenge body's `resource` field is hardcoded server-side to `.../v1/tx` regardless of which route served it, which is what pointed them there.

The unsigned route has only ever existed under the `upload` spelling, and every released upload-service version serves both canonical paths, so this moves to the canonical names. It also gives them a single definition — `uploadRawX402Data` was naming the route a **second** time, independently of the one `x402Post` computes, and that copy is the live one when no signer is passed. Same bug, twice.

Blast radius was narrower than the title suggests: `unsignedData: true` is set in exactly one place, so this affected `uploadRawX402Data()` and the `x402-upload-unsigned-data` CLI command, not x402 uploads generally. The signed path has been working in production throughout.

## #441 — hardcoded `baseSepolia` (correct reading, not the reported failure)

`makeX402Signer` did pin both branches to Base Sepolia. But it was **not** causing a failure, and the issue should not be closed as the live bug it was filed as.

Verified by driving the real flow with a throwaway key and intercepting the `X-PAYMENT` header before it was sent (no USDC spent):

```
makeX402Signer -> chain: Base Sepolia 84532
server asked for network : base | asset 0x8335...2913
payment payload network  : base
  domain chainId 8453  (base mainnet): VALID — signature matches signer
  domain chainId 84532 (base sepolia): invalid
```

`signAuthorization` builds the EIP-712 domain from `paymentRequirements.network`, not from `walletClient.chain`, and `selectPaymentRequirements` falls back to `paymentRequirements[0]` when no network matches. So signatures were already valid for mainnet. Same logic in x402-fetch 1.2.0, the version in the report.

It is still worth fixing as a latent bug: x402-fetch maps `walletClient.chain.id` to a network and *prefers* the matching entry in `accepts`, and the service builds `accepts` from every enabled network. Production enables only `base` today, so the fallback always lands correctly — but enabling base-sepolia alongside it would make the Sepolia-pinned client actively select testnet for a production upload. Defaults to mainnet; callers needing another network can still pass their own signer via `X402Funding({ signer })`.

## Tests

New `src/common/x402.test.ts` covers both. Confirmed they fail on the prior code rather than merely passing on the new:

```
✖ posts signed x402 uploads to /v1/x402/upload/signed
    actual:   [ '.../v1/x402/data-item/signed' ]
    expected: [ '.../v1/x402/upload/signed' ]
✖ posts unsigned x402 uploads to /v1/x402/upload/unsigned
    actual:   [ '.../v1/x402/data-item/unsigned' ]
    expected: [ '.../v1/x402/upload/unsigned' ]
✖ builds a wallet client on the chain the upload service settles on
    actual: 84532, expected: 8453
```

The integration suite does not exercise x402, so `test:docker` is unaffected by the endpoint change.

## Depends on

The service-side half is ar-io/ar-io-bundler#246, which restores the `/x402/data-item/unsigned` alias. That is what repairs 1.40.x–1.42.x, which are already published and cannot be fixed from here. This PR is the forward-looking fix; the two are complementary and neither makes the other redundant.