### PR TITLE
fix(token): drop base-ario, no longer supported by the payment service

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,15 +909,6 @@ const turbo = TurboFactory.authenticated({ signer, token: 'ario' });
 const { winc, status, id, ...fundResult } = await turbo.topUpWithTokens({
   tokenAmount: ARIOToTokenAmount(100), // 100 $ARIO
 });
-
-
-// ARIO on Base Network
-const { winc, status, id, ...fundResult } = await TurboFactory.authenticated({
-  signer,
-  token: 'base-ario',
-}).topUpWithTokens({
-  tokenAmount: ARIOToTokenAmount(100), // 100 $ARIO
-});
 ```
 
 ##### USDC Crypto Top Up
@@ -1323,15 +1314,6 @@ const turbo = TurboFactory.authenticated({
 const turbo = TurboFactory.authenticated({
   privateKey: ethHexadecimalPrivateKey,
   token: 'base-usdc',
-});
-```
-
-#### Base ARIO Private Key
-
-```typescript
-const turbo = TurboFactory.authenticated({
-  privateKey: ethHexadecimalPrivateKey,
-  token: 'base-ario',
 });
 ```
 

--- a/packages/turbo-sdk/src/common/signer.ts
+++ b/packages/turbo-sdk/src/common/signer.ts
@@ -104,7 +104,6 @@ export abstract class TurboDataItemAbstractSigner
       case 'base-eth':
       case 'usdc':
       case 'base-usdc':
-      case 'base-ario':
       case 'polygon-usdc':
         return computeAddress(computePublicKey(fromB64Url(owner)));
 

--- a/packages/turbo-sdk/src/common/token/index.ts
+++ b/packages/turbo-sdk/src/common/token/index.ts
@@ -21,18 +21,14 @@ import {
   TokenType,
   tokenTypes,
 } from '../../types.js';
-import { defaultProdGatewayUrls } from '../../utils/common.js';
 import { ARIOToTokenAmount, ARIOToken } from './ario.js';
 import { ARToTokenAmount, ArweaveToken } from './arweave.js';
-import { BaseEthToken, defaultBaseNetworkPollingOptions } from './baseEth.js';
-import { ERC20Token } from './erc20.js';
+import { BaseEthToken } from './baseEth.js';
 import { ETHToTokenAmount, EthereumToken } from './ethereum.js';
 import { KYVEToTokenAmount, KyveToken } from './kyve.js';
 import { POLToTokenAmount, PolygonToken } from './polygon.js';
 import { SOLToTokenAmount, SolanaToken } from './solana.js';
 import { USDCToTokenAmount, USDCToken } from './usdc.js';
-
-const baseARIOContractAddress = '0x138746adfA52909E5920def027f5a8dc1C7EfFb6';
 
 export const defaultTokenMap: TokenFactory = {
   arweave: (config: TokenConfig) => new ArweaveToken(config),
@@ -49,13 +45,6 @@ export const defaultTokenMap: TokenFactory = {
     new USDCToken({ network: 'base', ...config }),
   'polygon-usdc': (config: TokenConfig) =>
     new USDCToken({ network: 'polygon', ...config }),
-  'base-ario': (config: TokenConfig) =>
-    new ERC20Token({
-      ...config,
-      pollingOptions: config.pollingOptions ?? defaultBaseNetworkPollingOptions,
-      tokenContractAddress: baseARIOContractAddress,
-      gatewayUrl: config.gatewayUrl ?? defaultProdGatewayUrls['base-ario'],
-    }),
 } as const;
 
 const ethExponent = 18;
@@ -65,7 +54,6 @@ const arioExponent = 6;
 export const exponentMap: Record<TokenType, number> = {
   arweave: 12,
   ario: arioExponent,
-  'base-ario': arioExponent,
   solana: 9,
   ethereum: ethExponent,
   'base-eth': ethExponent,
@@ -83,7 +71,6 @@ export const tokenToBaseMap: Record<
 > = {
   arweave: (a: BigNumber.Value) => ARToTokenAmount(a),
   ario: (a: BigNumber.Value) => ARIOToTokenAmount(a),
-  'base-ario': (a: BigNumber.Value) => USDCToTokenAmount(a),
   solana: (a: BigNumber.Value) => SOLToTokenAmount(a),
   ethereum: (a: BigNumber.Value) => ETHToTokenAmount(a),
   'base-eth': (a: BigNumber.Value) => ETHToTokenAmount(a),

--- a/packages/turbo-sdk/src/common/upload.ts
+++ b/packages/turbo-sdk/src/common/upload.ts
@@ -873,7 +873,6 @@ export abstract class TurboAuthenticatedBaseUploadService
     'solana',
     'base-eth',
     'base-usdc',
-    'base-ario',
   ];
 
   /**

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -64,7 +64,6 @@ export type Country = 'United States' | 'United Kingdom' | 'Canada'; // TODO: ad
 export const tokenTypes = [
   'arweave',
   'ario',
-  'base-ario',
   'solana',
   'ethereum',
   'kyve',
@@ -85,7 +84,6 @@ export const supportedEvmSignerTokens = new Set([
   'polygon-usdc',
   'usdc',
   'base-usdc',
-  'base-ario',
 ]);
 
 export type Adjustment = {

--- a/packages/turbo-sdk/src/utils/common.ts
+++ b/packages/turbo-sdk/src/utils/common.ts
@@ -53,7 +53,6 @@ const baseMainnetRpc = 'https://mainnet.base.org';
 export const tokenToDevGatewayMap: Record<TokenType, string> = {
   arweave: 'https://turbo-gateway.com', // No arweave test net
   ario: 'https://api.devnet.solana.com',
-  'base-ario': baseMainnetRpc, // No base-ario test net contract deployed
   solana: 'https://api.devnet.solana.com',
   ethereum: ethTestnetRpc,
   'base-eth': baseTestnetRpc,
@@ -68,7 +67,6 @@ export const tokenToDevGatewayMap: Record<TokenType, string> = {
 export const defaultProdGatewayUrls: Record<TokenType, string> = {
   arweave: 'https://turbo-gateway.com',
   ario: 'https://api.mainnet-beta.solana.com',
-  'base-ario': baseMainnetRpc,
   solana: 'https://api.mainnet-beta.solana.com',
   ethereum: 'https://cloudflare-eth.com/',
   'base-eth': baseMainnetRpc,
@@ -118,7 +116,6 @@ export function createTurboSigner({
     case 'base-eth':
     case 'usdc':
     case 'base-usdc':
-    case 'base-ario':
     case 'polygon-usdc':
       if (!isEthPrivateKey(clientProvidedPrivateKey)) {
         throw new Error(
@@ -204,7 +201,6 @@ export function isValidUserAddress(address: string, type: TokenType): boolean {
     case 'matic':
     case 'pol':
     case 'base-usdc':
-    case 'base-ario':
     case 'usdc':
     case 'polygon-usdc':
       return isValidECDSAAddress(address);

--- a/packages/turbo-sdk/tests/turbo.node.test.ts
+++ b/packages/turbo-sdk/tests/turbo.node.test.ts
@@ -97,7 +97,6 @@ describe('Node environment', () => {
       matic: [new EthereumSigner(testEthWallet), testEthNativeAddress],
       pol: [new EthereumSigner(testEthWallet), testEthNativeAddress],
       'base-usdc': [new EthereumSigner(testEthWallet), testEthNativeAddress],
-      'base-ario': [new EthereumSigner(testEthWallet), testEthNativeAddress],
       usdc: [new EthereumSigner(testEthWallet), testEthNativeAddress],
       'polygon-usdc': [new EthereumSigner(testEthWallet), testEthNativeAddress],
     };


### PR DESCRIPTION
## Why

The payment service rejects `base-ario` outright:

```
GET https://payment.ardrive.io/v1/price/base-ario/1000000
-> 400  "The currency type 'base-ario' is currently not supported by this API!"

GET .../v1/price/ario/1000000       -> 200
GET .../v1/price/base-usdc/1000000  -> 200
```

So every `base-ario` path in the SDK fails at runtime today. This is also one of the genuine (non-infra) failures in the integration suite — `should return the correct token price for the given bytes for base-ario` — which contributed to the failed Release run on the #442 merge.

## What

Removed from `tokenTypes` (and therefore the exported `TokenType`), `supportedEvmSignerTokens`, `defaultTokenMap`, `exponentMap`, `tokenToBaseMap`, `defaultProdGatewayUrls`, the native-address and private-key switches in `utils/common.ts`, `enabledOnDemandTokens`, the node signer-matrix test fixture, and both README sections.

`ERC20Token` and `defaultBaseNetworkPollingOptions` are kept — `usdc.ts` still extends/uses them. Only their now-unused imports in `token/index.ts` are dropped, along with the `baseARIOContractAddress` constant.

Because `exponentMap`, `tokenToBaseMap`, and `defaultProdGatewayUrls` are all typed `Record<TokenType, ...>`, the compiler enforces that no map was left half-updated.

## Versioning

Deliberately released as a **fix**, not a breaking change. Removing a union member is a type-level break, but no working consumer can regress: any code passing `token: 'base-ario'` is already failing against the live service with a 400. The only change is that it now fails at compile time rather than at runtime. Flagging it explicitly so the choice is visible rather than implied.

## Verification

- `yarn build` — passes
- `yarn lint` / `prettier --check` — clean
- unit suite — **143/143 pass**

The `base-ario` entry is gone from every one of the parallel token records, verified by a repo-wide sweep turning up no remaining references outside `CHANGELOG.md`.