### PR TITLE
fix(release): run semantic-release from the repo root so .releaserc applies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,18 @@ jobs:
       - name: Build
         run: yarn workspace @ardrive/turbo-sdk build
 
+      # Run from the repo ROOT, not the workspace. `.releaserc` lives at the
+      # root and every path in it is root-relative (`pkgRoot`, the exec
+      # prepareCmd, the release assets). Running this via
+      # `yarn workspace @ardrive/turbo-sdk` sets cwd to packages/turbo-sdk,
+      # where semantic-release finds no config and silently falls back to its
+      # DEFAULT plugins -- dropping @semantic-release/changelog, /exec and
+      # /git. That is why no release since 1.40.0 updated CHANGELOG.md,
+      # stamped src/version.ts, or produced a `chore(release)` commit.
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn workspace @ardrive/turbo-sdk semantic-release
+        run: yarn semantic-release
 
       - name: Publish Dist Tag
         run: |

--- a/packages/turbo-sdk/update-version.sh
+++ b/packages/turbo-sdk/update-version.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+set -euo pipefail
 
 # The version to be released is passed as the first argument to the script
 nextRelease_version=$1
+
+# semantic-release runs prepareCmd from the repo root, but every path below is
+# relative to this package. Resolve them against the script's own location so
+# the stamping works regardless of the caller's cwd.
+cd "$(dirname "$0")"
 
 # Update the version in src/version.ts
 sed -i.bak -e "s/export const version = '.*';/export const version = '${nextRelease_version}';/" ./src/version.ts && rm ./src/version.ts.bak


### PR DESCRIPTION
Found while smoke-testing `1.42.0-alpha.6` ahead of the alpha → main release. **Recommend landing this before cutting 1.43.0.**

## Symptom

`turbo --version` on the published `1.42.0-alpha.6` reports **`1.40.0`**:

```
published package.json version: 1.42.0-alpha.6
lib/esm/version.js:              version = '1.40.0'
lib/cjs/version.js:              version = '1.40.0'
```

Pulling on that thread: the last `chore(release)` commit and the last `CHANGELOG.md` entry are both **1.40.0, dated 2026-01-16**. Every release since — 1.41.x, 1.42.0, and all prereleases — published to npm with no changelog entry, no version stamp, and no release commit.

## Cause

The workflow runs `yarn workspace @ardrive/turbo-sdk semantic-release`, which sets cwd to `packages/turbo-sdk`. There's no config there, so semantic-release falls back to its **default** plugin set, silently dropping `@semantic-release/changelog`, `/exec`, and `/git`. The release still succeeds, which is why it went unnoticed.

Straight from the alpha.6 release log — note what's absent:

```
Loaded plugin "prepare" from "@semantic-release/npm"     <- the only prepare plugin
```

Reproduced locally, and the contrast is unambiguous:

```
A) cwd = packages/turbo-sdk   -> npm, github, commit-analyzer, release-notes-generator only
B) cwd = repo root            -> + changelog, + exec, + git   (verifyConditions/prepare/publish)
```

`.releaserc` is already entirely root-relative — `pkgRoot: packages/turbo-sdk`, `./packages/turbo-sdk/update-version.sh`, the `packages/turbo-sdk/bundles/...` asset path — so the root is where it was always meant to run.

## Second, latent bug

`update-version.sh` resolved `./src/version.ts` against the caller's cwd. Once semantic-release runs from the root, that path doesn't exist — so the cwd fix alone would **not** have fixed the stamping. Worse, the script had no `set -e`, so `sed` failed and it still exited 0:

```
$ ./packages/turbo-sdk/update-version.sh 9.9.9-test     # pre-fix, from repo root
sed: can't read ./src/version.ts: No such file or directory
exit=0                                                  # silent failure
```

It now `cd`s to its own directory and runs under `set -euo pipefail`.

## Verification

Invoked from the repo root exactly as the exec plugin calls it:

```
BEFORE: version = '1.40.0'
AFTER src:      version = '9.9.9-test'
AFTER lib/esm:  version = '9.9.9-test'
AFTER lib/cjs:  version = '9.9.9-test'
```

(reverted afterwards; `src/version.ts` is untouched in this diff)

## Why it matters for 1.43.0

`version.ts` feeds the `x-turbo-source-version` header on **every** request, so service-side telemetry currently attributes all SDK traffic to 1.40.0 — precisely the signal you want when triaging reports like #440. Without this, a 28-commit, 8-feature 1.43.0 would ship with no changelog entry and a version header three minor versions stale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation reliability by running releases from the repository root.
  * Ensured version updates work consistently regardless of the command’s starting directory.
  * Added safeguards to stop versioning and release tasks when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->