### PR TITLE
feat(payment): add getArNSNames for custodial ArNS name listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Welcome to the `@ardrive/turbo-sdk`! This SDK provides functionality for interac
   - [Extend, increase undernames, upgrade](#extend-increase-undernames-upgrade)
   - [Polling purchase status](#polling-purchase-status)
   - [ANT custody: transfer & manage records](#ant-custody-transfer--manage-records)
+  - [Listing owned names](#listing-owned-names)
   - [Error handling & retries](#error-handling--retries)
   - [Dependency note (@solana/codecs)](#dependency-note-solanacodecs)
 - [Signers](#signers)
@@ -1030,6 +1031,7 @@ The authenticated client can buy and manage [ArNS](https://ar.io/arns) names and
 
 - **Purchases / management (charge credits):** `getArNSPriceForName`, `purchaseArNSName` (+ the intent wrappers `buyArNSName`, `extendArNSLease`, `increaseArNSUndernameLimit`, `upgradeArNSName`), and `getArNSPurchaseStatus`.
 - **ANT custody:** `transferArNSAnt`, `setArNSRecord`, `removeArNSRecord`.
+- **Listing (read-only, no signature required):** `getArNSNames` -- every name a wallet owns or controls, custodial and self-custody alike.
 
 > Reads such as resolving a name or fetching a record are provided by [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk) and are intentionally out of scope for this client.
 
@@ -1211,6 +1213,46 @@ await turbo.setArNSRecord({
 // Remove a resolution record
 await turbo.removeArNSRecord({ antId: 'ant-id', undername: 'docs' });
 ```
+
+### Listing owned names
+
+`getArNSNames(address)` returns every ArNS name a wallet owns or controls -- both custodial names bought via `buyArNSName`/`purchaseArNSName` and self-custody names, in one list. It's a read-only listing endpoint and does **not** require a signature -- it's available on both `TurboUnauthenticatedClient` (pass an `address`) and `TurboAuthenticatedClient` (`address` optional, defaults to the connected signer's own native address).
+
+A returned name's `custodial: true` means Turbo still manages its ANT (so `transferArNSAnt`/`setArNSRecord`/`removeArNSRecord` above apply to it); `custodial: false` means the name is self-custodied, or custody has already been exited, and the entry is informational only. `type`/`years` are omitted (not present in the JSON) when the selected purchase receipt doesn't carry them (e.g. an `Extend-Lease`/`Increase-Undername-Limit` receipt), and `antId` may be an empty string if no receipt for the name ever carried one -- guard for `antId === ''` before passing it to `@ar.io/sdk`.
+
+> [!NOTE]
+> This endpoint does not report a name's current records or lease/expiration state -- that lives entirely on-chain. Once you have the `antId`, read that directly via [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk) -- it queries the chain directly and needs no round-trip through Turbo.
+
+```typescript
+// Unauthenticated -- any wallet, by address
+const turbo = TurboFactory.unauthenticated();
+const { names } = await turbo.getArNSNames(publicArweaveAddress);
+
+// Authenticated -- defaults to the connected signer's own wallet
+const authenticatedTurbo = TurboFactory.authenticated({ privateKey: arweaveJwk });
+const { names: myNames } = await authenticatedTurbo.getArNSNames();
+```
+
+<details>
+  <summary>Example Output</summary>
+
+```json
+{
+  "names": [
+    {
+      "name": "ardrive",
+      "antId": "ant-process-id",
+      "intent": "Buy-Name",
+      "type": "lease",
+      "years": 1,
+      "purchaseDate": "2026-01-01T00:00:00.000Z",
+      "custodial": true
+    }
+  ]
+}
+```
+
+</details>
 
 ### Error handling & retries
 

--- a/README.md
+++ b/README.md
@@ -1216,7 +1216,7 @@ await turbo.removeArNSRecord({ antId: 'ant-id', undername: 'docs' });
 
 ### Listing owned names
 
-`getArNSNames(address)` returns every ArNS name a wallet owns or controls -- both custodial names bought via `buyArNSName`/`purchaseArNSName` and self-custody names, in one list. It's a read-only listing endpoint and does **not** require a signature -- it's available on both `TurboUnauthenticatedClient` (pass an `address`) and `TurboAuthenticatedClient` (`address` optional, defaults to the connected signer's own native address).
+`getArNSNames(address)` returns every ArNS name a wallet owns or controls -- both custodial names bought via `buyArNSName`/`purchaseArNSName` and self-custody names, in one list. It's a read-only listing endpoint and does **not** require a signature -- it's available on both `TurboUnauthenticatedClient` (pass an `address`) and `TurboAuthenticatedClient` (`address` optional, defaults to the connected signer's own native address -- passing an empty string does not trigger this default).
 
 A returned name's `custodial: true` means Turbo still manages its ANT (so `transferArNSAnt`/`setArNSRecord`/`removeArNSRecord` above apply to it); `custodial: false` means the name is self-custodied, or custody has already been exited, and the entry is informational only. `type`/`years` are omitted (not present in the JSON) when the selected purchase receipt doesn't carry them (e.g. an `Extend-Lease`/`Increase-Undername-Limit` receipt), and `antId` may be an empty string if no receipt for the name ever carried one -- guard for `antId === ''` before passing it to `@ar.io/sdk`.
 
@@ -1229,7 +1229,9 @@ const turbo = TurboFactory.unauthenticated();
 const { names } = await turbo.getArNSNames(publicArweaveAddress);
 
 // Authenticated -- defaults to the connected signer's own wallet
-const authenticatedTurbo = TurboFactory.authenticated({ privateKey: arweaveJwk });
+const authenticatedTurbo = TurboFactory.authenticated({
+  privateKey: arweaveJwk,
+});
 const { names: myNames } = await authenticatedTurbo.getArNSNames();
 ```
 

--- a/packages/turbo-sdk/src/common/payment.test.ts
+++ b/packages/turbo-sdk/src/common/payment.test.ts
@@ -59,6 +59,43 @@ describe('TurboUnauthenticatedPaymentService', () => {
         getStub.firstCall.args[0].endpoint,
         '/arns/my-names/test-address',
       );
+      // The endpoint itself never carries '/v1' -- it's baked into the
+      // httpService's baseURL at construction time. Assert that directly
+      // rather than trusting the test title's claim.
+      assert.equal(
+        (paymentService as any)['httpService']['baseURL'].endsWith('/v1'),
+        true,
+      );
+    });
+
+    it('URL-encodes the address so a caller-controlled value cannot alter the request path', async () => {
+      const paymentService = new TurboUnauthenticatedPaymentService({});
+
+      const getStub = stub(
+        (paymentService as any)['httpService'],
+        'get',
+      ).resolves({ names: [] });
+
+      await paymentService.getArNSNames('../../account/balance/arweave');
+
+      assert.equal(
+        getStub.firstCall.args[0].endpoint,
+        '/arns/my-names/..%2F..%2Faccount%2Fbalance%2Farweave',
+      );
+    });
+
+    it('propagates a rejection from the underlying HTTP call', async () => {
+      const paymentService = new TurboUnauthenticatedPaymentService({});
+
+      const expectedError = new Error('network unreachable');
+      stub((paymentService as any)['httpService'], 'get').rejects(
+        expectedError,
+      );
+
+      await assert.rejects(
+        () => paymentService.getArNSNames('test-address'),
+        expectedError,
+      );
     });
   });
 });
@@ -110,6 +147,37 @@ describe('TurboAuthenticatedPaymentService', () => {
       assert.equal(
         getStub.firstCall.args[0].endpoint,
         '/arns/my-names/signer-native-address',
+      );
+    });
+
+    it('does NOT fall back to the signer when an empty string is provided (matches getBalance)', async () => {
+      const paymentService = new TurboAuthenticatedPaymentService({
+        signer: stubSigner,
+      });
+
+      const getStub = stub(
+        (paymentService as any)['httpService'],
+        'get',
+      ).resolves({ names: [] });
+
+      await paymentService.getArNSNames('');
+
+      assert.equal(getStub.firstCall.args[0].endpoint, '/arns/my-names/');
+    });
+
+    it('propagates a rejection when the signer fails to resolve a native address', async () => {
+      const failingSigner = {
+        getNativeAddress: async () => {
+          throw new Error('wallet locked');
+        },
+      } as unknown as TurboDataItemSigner;
+      const paymentService = new TurboAuthenticatedPaymentService({
+        signer: failingSigner,
+      });
+
+      await assert.rejects(
+        () => paymentService.getArNSNames(),
+        /wallet locked/,
       );
     });
   });

--- a/packages/turbo-sdk/src/common/payment.test.ts
+++ b/packages/turbo-sdk/src/common/payment.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { restore, stub } from 'sinon';
+
+import { TurboArNSNamesResponse, TurboDataItemSigner } from '../types.js';
+import {
+  TurboAuthenticatedPaymentService,
+  TurboUnauthenticatedPaymentService,
+} from './payment.js';
+
+describe('TurboUnauthenticatedPaymentService', () => {
+  afterEach(() => {
+    restore();
+  });
+
+  describe('getArNSNames()', () => {
+    it('GETs /v1/arns/my-names/:address and returns the parsed response', async () => {
+      const paymentService = new TurboUnauthenticatedPaymentService({});
+
+      const expectedResponse: TurboArNSNamesResponse = {
+        names: [
+          {
+            name: 'ardrive',
+            antId: 'test-ant-id',
+            intent: 'Buy-Name',
+            type: 'lease',
+            years: 1,
+            purchaseDate: '2026-01-01T00:00:00.000Z',
+            custodial: true,
+          },
+        ],
+      };
+
+      const getStub = stub(
+        (paymentService as any)['httpService'],
+        'get',
+      ).resolves(expectedResponse);
+
+      const result = await paymentService.getArNSNames('test-address');
+
+      assert.deepEqual(result, expectedResponse);
+      assert.equal(getStub.calledOnce, true);
+      assert.equal(
+        getStub.firstCall.args[0].endpoint,
+        '/arns/my-names/test-address',
+      );
+    });
+  });
+});
+
+describe('TurboAuthenticatedPaymentService', () => {
+  afterEach(() => {
+    restore();
+  });
+
+  const stubSigner = {
+    getNativeAddress: async () => 'signer-native-address',
+  } as unknown as TurboDataItemSigner;
+
+  describe('getArNSNames()', () => {
+    it('uses the provided address without consulting the signer', async () => {
+      const paymentService = new TurboAuthenticatedPaymentService({
+        signer: stubSigner,
+      });
+
+      const expectedResponse: TurboArNSNamesResponse = { names: [] };
+      const getStub = stub(
+        (paymentService as any)['httpService'],
+        'get',
+      ).resolves(expectedResponse);
+
+      const result = await paymentService.getArNSNames('explicit-address');
+
+      assert.deepEqual(result, expectedResponse);
+      assert.equal(
+        getStub.firstCall.args[0].endpoint,
+        '/arns/my-names/explicit-address',
+      );
+    });
+
+    it('falls back to the signer native address when none is provided', async () => {
+      const paymentService = new TurboAuthenticatedPaymentService({
+        signer: stubSigner,
+      });
+
+      const expectedResponse: TurboArNSNamesResponse = { names: [] };
+      const getStub = stub(
+        (paymentService as any)['httpService'],
+        'get',
+      ).resolves(expectedResponse);
+
+      const result = await paymentService.getArNSNames();
+
+      assert.deepEqual(result, expectedResponse);
+      assert.equal(
+        getStub.firstCall.args[0].endpoint,
+        '/arns/my-names/signer-native-address',
+      );
+    });
+  });
+});

--- a/packages/turbo-sdk/src/common/payment.test.ts
+++ b/packages/turbo-sdk/src/common/payment.test.ts
@@ -17,7 +17,12 @@ import { strict as assert } from 'node:assert';
 import { afterEach, describe, it } from 'node:test';
 import { restore, stub } from 'sinon';
 
-import { TurboArNSNamesResponse, TurboDataItemSigner } from '../types.js';
+import type {
+  ArNSFiatPurchaseMethod,
+  TurboArNSName,
+  TurboArNSNamesResponse,
+  TurboDataItemSigner,
+} from '../types.js';
 import {
   TurboAuthenticatedPaymentService,
   TurboUnauthenticatedPaymentService,
@@ -180,5 +185,22 @@ describe('TurboAuthenticatedPaymentService', () => {
         /wallet locked/,
       );
     });
+  });
+});
+
+// Regression: the `intent` and `ArNSFiatPurchaseMethod` unions are widened so a
+// value added service-side stays assignable without an SDK bump. `string & {}`
+// is the usual idiom but trips `ban-types`; `Record<string, never>` looks
+// equivalent and is NOT — it rejects arbitrary strings, silently collapsing the
+// union to its literals. Only `Record<never, never>` actually widens.
+describe('forward-compatible string unions', () => {
+  it('accepts an intent the SDK does not know about', () => {
+    const futureIntent: TurboArNSName['intent'] = 'Transfer-Name';
+    assert.equal(futureIntent, 'Transfer-Name');
+  });
+
+  it('accepts a stripe method the SDK does not know about', () => {
+    const futureMethod: ArNSFiatPurchaseMethod = 'some-future-method';
+    assert.equal(futureMethod, 'some-future-method');
   });
 });

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -149,11 +149,9 @@ export class TurboUnauthenticatedPaymentService
    * names, in one list. See `TurboArNSName` for field semantics, including
    * the `custodial` flag distinguishing the two.
    *
-   * NOTE: this SDK does not yet wrap the ArNS purchase/price/transfer/manage
-   * routes -- this is deliberately the only ArNS method for now. To read a
-   * name's current records or lease/expiration state, use `@ar.io/sdk`
-   * directly against the returned `antId` -- it talks to the chain directly
-   * and needs no round-trip through this SDK/backend.
+   * To read a name's current records or lease/expiration state, use
+   * `@ar.io/sdk` directly against the returned `antId` -- it talks to the
+   * chain directly and needs no round-trip through this SDK/backend.
    */
   public getArNSNames(address: string): Promise<TurboArNSNamesResponse> {
     return this.httpService.get<TurboArNSNamesResponse>({

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -137,9 +137,11 @@ export class TurboUnauthenticatedPaymentService
   }
 
   /**
-   * Returns the ArNS names a wallet owns or controls via Turbo's custodial
-   * ArNS-with-credits feature (buy a name with credits; Turbo spawns and
-   * holds the ANT on the caller's behalf until self-custody exit).
+   * Returns the ArNS names a wallet owns or controls -- both custodial names
+   * bought via Turbo's ArNS-with-credits feature (Turbo may spawn and hold
+   * the ANT on the caller's behalf, depending on the buy) and self-custody
+   * names, in one list. See `TurboArNSName` for field semantics, including
+   * the `custodial` flag distinguishing the two.
    *
    * NOTE: this SDK does not yet wrap the ArNS purchase/price/transfer/manage
    * routes -- this is deliberately the only ArNS method for now. To read a
@@ -149,7 +151,7 @@ export class TurboUnauthenticatedPaymentService
    */
   public getArNSNames(address: string): Promise<TurboArNSNamesResponse> {
     return this.httpService.get<TurboArNSNamesResponse>({
-      endpoint: `/arns/my-names/${address}`,
+      endpoint: `/arns/my-names/${encodeURIComponent(address)}`,
     });
   }
 
@@ -816,6 +818,11 @@ export class TurboAuthenticatedPaymentService
     });
   }
 
+  /**
+   * Defaults to the signer's own address when `userAddress` is omitted
+   * (`null`/`undefined`). Passing `''` does NOT trigger this default --
+   * mirrors `getBalance`'s existing behavior above.
+   */
   public async getArNSNames(
     userAddress?: string,
   ): Promise<TurboArNSNamesResponse> {

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -33,6 +33,7 @@ import {
   TokenTools,
   TokenType,
   TopUpRawResponse,
+  TurboArNSNamesResponse,
   TurboAuthenticatedPaymentServiceConfiguration,
   TurboAuthenticatedPaymentServiceInterface,
   TurboBalanceResponse,
@@ -133,6 +134,23 @@ export class TurboUnauthenticatedPaymentService
     // Normalize: preserve a legitimate `0` (free tier off) or `null` (unlimited),
     // and coerce a missing field (e.g. a 404 body) to `null`.
     return { bytesRemaining: status?.bytesRemaining ?? null };
+  }
+
+  /**
+   * Returns the ArNS names a wallet owns or controls via Turbo's custodial
+   * ArNS-with-credits feature (buy a name with credits; Turbo spawns and
+   * holds the ANT on the caller's behalf until self-custody exit).
+   *
+   * NOTE: this SDK does not yet wrap the ArNS purchase/price/transfer/manage
+   * routes -- this is deliberately the only ArNS method for now. To read a
+   * name's current records or lease/expiration state, use `@ar.io/sdk`
+   * directly against the returned `antId` -- it talks to the chain directly
+   * and needs no round-trip through this SDK/backend.
+   */
+  public getArNSNames(address: string): Promise<TurboArNSNamesResponse> {
+    return this.httpService.get<TurboArNSNamesResponse>({
+      endpoint: `/arns/my-names/${address}`,
+    });
   }
 
   public getFiatRates(): Promise<TurboRatesResponse> {
@@ -796,6 +814,13 @@ export class TurboAuthenticatedPaymentService
       data: Buffer.from([]),
       retry: false, // single-use action-bound nonce; don't re-POST on 5xx
     });
+  }
+
+  public async getArNSNames(
+    userAddress?: string,
+  ): Promise<TurboArNSNamesResponse> {
+    userAddress ??= await this.signer.getNativeAddress();
+    return super.getArNSNames(userAddress);
   }
 
   public async getCreditShareApprovals({

--- a/packages/turbo-sdk/src/common/turbo.test.ts
+++ b/packages/turbo-sdk/src/common/turbo.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  TurboAuthenticatedPaymentServiceInterface,
+  TurboAuthenticatedUploadServiceInterface,
+  TurboDataItemSigner,
+  TurboUnauthenticatedPaymentServiceInterface,
+  TurboUnauthenticatedUploadServiceInterface,
+} from '../types.js';
+import {
+  TurboAuthenticatedClient,
+  TurboUnauthenticatedClient,
+} from './turbo.js';
+
+// getArNSNames is the only piece of the delegation layer under test here --
+// this file exists specifically to close the gap an adversarial review
+// found: TurboUnauthenticatedClient/TurboAuthenticatedClient (the actual
+// public API surface consumers call) had zero coverage of their own; only
+// the underlying TurboUnauthenticatedPaymentService/
+// TurboAuthenticatedPaymentService were unit-tested (see payment.test.ts).
+// A typo delegating to the wrong service method would previously have
+// shipped undetected.
+
+describe('TurboUnauthenticatedClient', () => {
+  describe('getArNSNames()', () => {
+    it('delegates to paymentService.getArNSNames with the given address', async () => {
+      const expectedResponse = { names: [] };
+      let calledWith: unknown;
+      const fakePaymentService = {
+        getArNSNames: async (address: string) => {
+          calledWith = address;
+          return expectedResponse;
+        },
+      } as unknown as TurboUnauthenticatedPaymentServiceInterface;
+
+      const client = new TurboUnauthenticatedClient({
+        paymentService: fakePaymentService,
+        uploadService:
+          {} as unknown as TurboUnauthenticatedUploadServiceInterface,
+      });
+
+      const result = await client.getArNSNames('delegate-test-address');
+
+      assert.deepEqual(result, expectedResponse);
+      assert.equal(calledWith, 'delegate-test-address');
+    });
+  });
+});
+
+describe('TurboAuthenticatedClient', () => {
+  describe('getArNSNames()', () => {
+    it('delegates to paymentService.getArNSNames, passing userAddress through untouched', async () => {
+      const expectedResponse = { names: [] };
+      let calledWith: unknown;
+      const fakePaymentService = {
+        getArNSNames: async (userAddress?: string) => {
+          calledWith = userAddress;
+          return expectedResponse;
+        },
+      } as unknown as TurboAuthenticatedPaymentServiceInterface;
+
+      const client = new TurboAuthenticatedClient({
+        paymentService: fakePaymentService,
+        uploadService:
+          {} as unknown as TurboAuthenticatedUploadServiceInterface,
+        signer: {} as unknown as TurboDataItemSigner,
+      });
+
+      const explicitResult = await client.getArNSNames('explicit-address');
+      assert.deepEqual(explicitResult, expectedResponse);
+      assert.equal(calledWith, 'explicit-address');
+
+      // The client itself does not resolve a default address -- that
+      // resolution lives one layer down, in
+      // TurboAuthenticatedPaymentService.getArNSNames (see payment.test.ts).
+      // Here we only assert the client passes `undefined` straight through
+      // rather than substituting its own default.
+      const omittedResult = await client.getArNSNames();
+      assert.deepEqual(omittedResult, expectedResponse);
+      assert.equal(calledWith, undefined);
+    });
+  });
+});

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -33,6 +33,7 @@ import {
   NativeAddress,
   TokenType,
   TurboAbortSignal,
+  TurboArNSNamesResponse,
   TurboAuthenticatedClientConfiguration,
   TurboAuthenticatedClientInterface,
   TurboAuthenticatedPaymentServiceInterface,
@@ -178,6 +179,21 @@ export class TurboUnauthenticatedClient
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse> {
     return this.paymentService.getArNSPurchaseStatus(p);
+  }
+
+  /**
+   * Returns the ArNS names a wallet owns or controls via Turbo's custodial
+   * ArNS-with-credits feature. `custodial: true` on a returned name means
+   * Turbo still holds/manages its ANT (transfer/manage routes apply);
+   * `custodial: false` means self-custody (or an already-completed exit) and
+   * is informational only.
+   *
+   * NOTE: this SDK does not yet wrap the ArNS purchase/price/transfer/manage
+   * routes. To read a name's current records or lease/expiration state, use
+   * `@ar.io/sdk` directly against the returned `antId`.
+   */
+  getArNSNames(address: NativeAddress): Promise<TurboArNSNamesResponse> {
+    return this.paymentService.getArNSNames(address);
   }
 
   /**
@@ -437,6 +453,15 @@ export class TurboAuthenticatedClient
     undername: string;
   }): Promise<{ antId: string; undername: string; messageId: string }> {
     return this.paymentService.removeArNSRecord(params);
+  }
+
+  /**
+   * Returns the ArNS names owned or controlled by the connected signer's
+   * wallet (or the given `userAddress`) via Turbo's custodial
+   * ArNS-with-credits feature.
+   */
+  getArNSNames(userAddress?: NativeAddress): Promise<TurboArNSNamesResponse> {
+    return this.paymentService.getArNSNames(userAddress);
   }
 
   /**

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -323,8 +323,7 @@ export type TurboPaymentHistoryParams = {
  * no on-chain ownership check) -- guard for `antId === ''` before passing it
  * to `@ar.io/sdk`.
  *
- * NOTE: this SDK does not (yet) wrap the ArNS purchase/price/transfer/manage
- * routes. To read a name's current records or lease/expiration state, use
+ * To read a name's current records or lease/expiration state, use
  * `@ar.io/sdk` directly against the `antId` returned here.
  */
 export type TurboArNSName = {
@@ -342,7 +341,7 @@ export type TurboArNSName = {
     | 'Extend-Lease'
     | 'Upgrade-Name'
     | 'Increase-Undername-Limit'
-    | (string & Record<string, never>);
+    | (string & Record<never, never>);
   type?: 'lease' | 'permabuy';
   years?: number;
   purchaseDate: string;

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -304,6 +304,33 @@ export type TurboPaymentHistoryParams = {
   cursor?: string;
 };
 
+/**
+ * A single ArNS name returned by `getArNSNames`. `custodial: true` means Turbo
+ * still holds/manages the underlying ANT on the caller's behalf (e.g. via the
+ * ArNS-with-credits purchase flow) and Turbo's transfer/manage routes apply to
+ * it; `custodial: false` means the name is self-custodied (or has already been
+ * exited from custody) and is returned for historical/informational purposes
+ * only.
+ *
+ * NOTE: this SDK does not (yet) wrap the ArNS purchase/price/transfer/manage
+ * routes -- see `getArNSNames` below for the full list of what remains
+ * unwrapped. To read a name's current records or lease/expiration state, use
+ * `@ar.io/sdk` directly against the `antId` returned here.
+ */
+export type TurboArNSName = {
+  name: string;
+  antId: string;
+  intent: string;
+  type: 'lease' | 'permabuy';
+  years?: number;
+  purchaseDate: string;
+  custodial: boolean;
+};
+
+export type TurboArNSNamesResponse = {
+  names: TurboArNSName[];
+};
+
 export type TurboFiatToArResponse = {
   currency: Currency;
   rate: number;
@@ -1097,6 +1124,14 @@ export interface TurboUnauthenticatedPaymentServiceInterface {
   getArNSPurchaseStatus(p: {
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse>;
+  /**
+   * Returns the ArNS names a wallet owns or controls via Turbo's custodial
+   * ArNS-with-credits feature. This is a read-only listing endpoint; it does
+   * not require a signature. See `TurboArNSName` for field semantics. To
+   * read a name's current records or lease/expiration state, use
+   * `@ar.io/sdk` directly against the returned `antId`.
+   */
+  getArNSNames: (address: string) => Promise<TurboArNSNamesResponse>;
   getSupportedCurrencies(): Promise<TurboCurrenciesResponse>;
   getSupportedCountries(): Promise<TurboCountriesResponse>;
   getTurboCryptoWallets(): Promise<Record<TokenType, string>>;
@@ -1160,6 +1195,8 @@ export interface TurboAuthenticatedPaymentServiceInterface
   getPaymentHistory(
     params?: TurboPaymentHistoryParams,
   ): Promise<TurboPaymentHistoryResponse>;
+
+  getArNSNames: (userAddress?: UserAddress) => Promise<TurboArNSNamesResponse>;
 
   getCreditShareApprovals(p: {
     userAddress?: UserAddress;

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -312,16 +312,38 @@ export type TurboPaymentHistoryParams = {
  * exited from custody) and is returned for historical/informational purposes
  * only.
  *
+ * `intent`/`type`/`years`/`purchaseDate` describe the specific purchase
+ * receipt Turbo selected for this name and are historical/informational, NOT
+ * authoritative for the name's current on-chain state. `type`/`years` may be
+ * absent -- omitted from the response entirely, not `null` -- when the
+ * selected receipt is an action (e.g. Extend-Lease/Increase-Undername-Limit)
+ * that doesn't carry them. `antId` may be an empty string if no receipt Turbo
+ * has for this name ever carried one (e.g. the caller only ever extended a
+ * name it doesn't own -- ArNS extend/upgrade/increase-undername actions have
+ * no on-chain ownership check) -- guard for `antId === ''` before passing it
+ * to `@ar.io/sdk`.
+ *
  * NOTE: this SDK does not (yet) wrap the ArNS purchase/price/transfer/manage
- * routes -- see `getArNSNames` below for the full list of what remains
- * unwrapped. To read a name's current records or lease/expiration state, use
+ * routes. To read a name's current records or lease/expiration state, use
  * `@ar.io/sdk` directly against the `antId` returned here.
  */
 export type TurboArNSName = {
   name: string;
   antId: string;
-  intent: string;
-  type: 'lease' | 'permabuy';
+  /**
+   * The ArNS action recorded on the selected purchase receipt. Widened with
+   * `(string & {})` so new intents added server-side don't require a
+   * client-side type change, while still getting autocomplete for the known
+   * values.
+   */
+  intent:
+    | 'Buy-Name'
+    | 'Buy-Record'
+    | 'Extend-Lease'
+    | 'Upgrade-Name'
+    | 'Increase-Undername-Limit'
+    | (string & Record<string, never>);
+  type?: 'lease' | 'permabuy';
   years?: number;
   purchaseDate: string;
   custodial: boolean;


### PR DESCRIPTION
## Summary

Adds `getArNSNames(address)` — a thin client wrapper around the new backend endpoint `GET /v1/arns/my-names/:address` (companion PR: ar-io/ar-io-bundler#267). Returns every ArNS name a wallet owns or controls — both custodial names bought via the ArNS-with-credits purchase flow this SDK already wraps (`buyArNSName`/`purchaseArNSName`) and self-custody names — in one list, with a `custodial` flag distinguishing the two.

- Available on both `TurboUnauthenticatedClient` (pass an `address`) and `TurboAuthenticatedClient` (`address` optional, defaults to the connected signer's own native address).
- Read-only, no signature required.
- Deliberately does **not** wrap records/lease-expiration reads — once you have a name's `antId` from this method, read current on-chain state directly via [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk), avoiding an unnecessary round trip through this SDK/backend.

New types: `TurboArNSName`, `TurboArNSNamesResponse`. Docs added under the existing "ArNS Names (paid with Turbo Credits)" section as a new "Listing owned names" subsection.

## Review-found fixes (2nd + 3rd commits)

An independent adversarial review of the 1st commit surfaced several real gaps, all fixed:
- `TurboArNSName.type` was typed required, but the backend omits the key entirely (not `null`) for `Extend-Lease`/`Increase-Undername-Limit` receipts — made optional.
- `intent` was a bare `string`; widened to a known-values-plus-string union for autocomplete without losing forward-compatibility.
- The `address` path segment was interpolated unencoded — a value like `../../account/balance/arweave` could silently retarget the request. Now `encodeURIComponent`'d.
- `antId` can be an empty string when no purchase receipt for a name ever carried one — documented in both the type and README, since the whole point of the field is to feed it to `@ar.io/sdk`.
- Added tests for the actual public API surface (`TurboUnauthenticatedClient`/`TurboAuthenticatedClient` delegation — previously untested), error propagation, the `/v1` prefix, the URL-encoding fix, and the empty-string-does-not-fall-back-to-signer foot-gun.
- README nits: heading param name now matches the implementation; corrected an overstated claim about credit purchases unconditionally spawning an ANT (provisioning is gated server-side).

## Rebase note

This branch was originally forked before `alpha` gained the full ArNS purchase/custody client (`purchaseArNSName`, `buyArNSName`, `transferArNSAnt`, etc., from #435 and follow-ups). It's been rebased on top of current `alpha` — `getArNSNames` is a pure addition alongside that work, no overlap or duplication (confirmed no existing "list names" method before adding this), and the new "Listing owned names" README subsection sits alongside the existing purchase/custody subsections in the same "ArNS Names" section.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint src` — clean
- [x] `prettier --check` — clean
- [x] `yarn test:unit` — 122/122 passing (includes this PR's new tests + all pre-existing alpha tests, zero regressions)
- [x] `yarn build` (web/esm/cjs/types) — clean
- [x] Independent adversarial review pass completed and all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Qks2NnecUvJEfKJeVJoe7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SDK support for listing ArNS names owned or controlled by a wallet.
  * Supports unauthenticated lookups by wallet address and authenticated lookups using the signer’s address by default.
  * Responses include name details, purchase information, ArNS actions, and custodial status.

* **Documentation**
  * Added usage guidance, request options, response fields, limitations, and examples for the ArNS names listing feature.

* **Tests**
  * Added coverage for authenticated and unauthenticated requests, address handling, URL encoding, errors, and client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->