### PR TITLE
fix(ci): gate integration tests on service health and capture service logs

### DIFF
--- a/packages/turbo-sdk/docker-compose.yml
+++ b/packages/turbo-sdk/docker-compose.yml
@@ -170,7 +170,10 @@ services:
       start_period: 10s
 
   payment-service:
-    image: ghcr.io/ardriveapp/payment-service:latest
+    # Pinnable like the upload-service images above. Left at `latest` by
+    # default, but CI can pin a known-good tag when a bad publish upstream
+    # would otherwise break every integration run with no way to opt out.
+    image: ghcr.io/ardriveapp/payment-service:${PAYMENT_SERVICE_IMAGE_TAG:-latest}
     ports:
       - "4000:4000"
     healthcheck:

--- a/packages/turbo-sdk/run-tests.sh
+++ b/packages/turbo-sdk/run-tests.sh
@@ -5,6 +5,38 @@ BUNDLER_ARWEAVE_WALLET=$(cat ./tests/wallets/ByQEA5jhJvzlhfI4sFgB23kjGpxDK6OIE0i
 docker compose pull --quiet
 docker compose up --quiet-pull -d
 
+# Dump service logs so a failure is diagnosable from the CI log alone. Without
+# this the job output shows only container lifecycle events, which cannot
+# distinguish "service was slow to start" from "service started and is broken".
+dump_logs() {
+  echo "===================== docker compose ps ====================="
+  docker compose ps
+  for svc in payment-service upload-service; do
+    echo "===================== logs: $svc (tail 200) ================"
+    docker compose logs --tail=200 "$svc" 2>&1 || true
+  done
+}
+
+# Block until a service answers its health endpoint. Previously only LocalStack
+# was gated, so the suite could start firing at a payment-service that was not
+# up yet. Every request then burned the SDK's 5 retries with backoff (~31s per
+# call), blowing per-test timeouts and cascading into "test did not finish
+# before its parent and was cancelled" across whole suites.
+wait_for_health() {
+  local name=$1 url=$2 timeout=${3:-180} elapsed=0 interval=5
+  echo "Waiting for $name to be ready at $url ..."
+  while [ $elapsed -lt $timeout ]; do
+    if curl -fs -m 5 "$url" >/dev/null 2>&1; then
+      echo "$name is ready (${elapsed}s)"
+      return 0
+    fi
+    sleep $interval
+    elapsed=$((elapsed + interval))
+  done
+  echo "ERROR: timed out after ${timeout}s waiting for $name at $url"
+  return 1
+}
+
 # Wait for LocalStack to be ready (up to 120 seconds)
 timeout=120
 interval=5
@@ -24,6 +56,16 @@ done
 
 if [ $elapsed -ge $timeout ]; then
   echo "Timed out waiting for LocalStack to be ready."
+  dump_logs
+  docker compose down -v
+  exit 1
+fi
+
+# The services the integration suite actually talks to. Fail fast and loudly
+# here rather than 90 minutes later as a wall of unrelated test timeouts.
+if ! wait_for_health "payment-service" "http://localhost:4000/health" 180 \
+  || ! wait_for_health "upload-service" "http://localhost:3000/health" 180; then
+  dump_logs
   docker compose down -v
   exit 1
 fi
@@ -40,6 +82,11 @@ else
   yarn dotenv -e .env.test yarn test
 fi
 exit_code=$?
+
+# On failure, surface the service logs alongside the test output.
+if [ $exit_code -ne 0 ]; then
+  dump_logs
+fi
 
 # Tear down the docker-compose setup
 docker compose down -v


### PR DESCRIPTION
The integration suite has failed **3 of the last 5 runs** for reasons unrelated to the code under test. Every failure was a timeout, never an assertion.

| run | failures | test-suite duration |
|---|---|---|
| #442 release | 57 | — |
| #444 first | 56 | ~18m |
| #444 rerun | 9 | **1h36m** |
| healthy (#442 PR) | 0 | 11m9s |

## Root cause

`run-tests.sh` waited only on LocalStack, so the suite could start firing at a `payment-service` that wasn't up. Each call then burned the SDK's 5 retries with exponential backoff — hence the uniform **~31000ms** timings across `getBalance`, `getFiatRates`, `createCheckoutSession`, `fund`, and the credit-sharing suite. Parent suites then hit their own deadline and cancelled their children:

```
50  Max retries reached
'test did not finish before its parent and was cancelled'
```

That's how a handful of genuinely failed calls became 56 reported failures.

## Changes

**Health-gate the services the suite actually talks to.** Both `payment-service` and `upload-service` already declare healthchecks in `docker-compose.yml` — nothing ever waited on them. Now the run blocks (180s cap) and fails fast rather than surfacing 90 minutes later as unrelated test noise.

**Capture service logs on failure.** `docker compose ps` plus the last 200 lines from both services. Today the job log contains only container lifecycle events, which is why none of the last three failures could be diagnosed without a rerun — it's impossible to tell "slow to start" from "started and broken."

**Make the payment-service image pinnable** via `PAYMENT_SERVICE_IMAGE_TAG`, matching the three `upload-service` images. It was hardcoded to `latest`, so CI silently follows whatever was published upstream with no way to pin a known-good tag. Default unchanged.

## Verification

- `bash -n run-tests.sh` clean; `docker compose config` valid
- health gate returns immediately against a live endpoint (`prod-upload is ready (0s)`) and fails at its deadline against a dead one (`10.013s`, rc=1) rather than hanging

## Deliberately not in scope

`creditSharing.node.test.ts` asserts hardcoded absolute winc (`'566'`, `'766'`) on a wallet whose state depends on every preceding test completing exactly once, and assumes a 1-second approval has expired after a 1.5-second sleep. That's what produced the `'666' !== '566'` failure in the #444 rerun — off by exactly one approval's 100 winc. It wants delta-based assertions, but that changes test semantics and deserves its own PR rather than riding along here.

Note this PR cannot prove itself green in one run — if the underlying service is genuinely broken, the new gate will now **fail fast and say so**, which is the intended behavior and a better outcome than a 90-minute timeout cascade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for overriding the payment service image tag, with `latest` as the default.
  * Improved test startup by waiting for required services to become healthy.
  * Added clearer diagnostic logs when services fail health checks, tests fail, or LocalStack times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->