### PR TITLE
feat(arns): add getArNSFiatPurchaseQuote for card-paid ArNS purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1888,9 +1888,27 @@ turbo list-shares --address 2cor...VUa --wallet-file ../path/to/my/wallet
 
 Buy and manage [ArNS](#arns-names-paid-with-turbo-credits) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-purchase-status`.
 
-All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. The write commands (`buy-arns-name`, `extend-arns-lease`, `increase-arns-undernames`, `upgrade-arns-name`, `transfer-arns-ant`, `set-arns-record`, `remove-arns-record`) require a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`); the read-only commands (`arns-price`, `arns-purchase-status`) do not.
+All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. The write commands (`buy-arns-name`, `extend-arns-lease`, `increase-arns-undernames`, `upgrade-arns-name`, `transfer-arns-ant`, `set-arns-record`, `remove-arns-record`) require a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`); the read-only commands (`arns-price`, `arns-purchase-status`, `arns-fiat-quote`) do not.
 
 When a purchase is rejected for lack of Turbo Credits (HTTP 402), the command prints a clear "insufficient credits — top up your balance and retry" message and exits non-zero.
+
+##### `arns-fiat-quote`
+
+Quote an ArNS purchase paid by **credit card** (Stripe) instead of Turbo Credits. Records a quote and returns a Stripe session to complete elsewhere — nothing is charged by this command.
+
+```shell
+turbo arns-fiat-quote --name my-name --type lease --years 1 \
+  --address <destination-address> --currency usd
+```
+
+```shell
+# hosted Stripe Checkout, with promo codes
+turbo arns-fiat-quote --name my-name --type permabuy \
+  --address <destination-address> --currency eur \
+  --method checkout-session --promo-code LAUNCH FRIENDS
+```
+
+Prints the quote's `nonce` (poll it with `arns-purchase-status`), the Stripe `paymentSessionId`, and whichever of `clientSecret` / `checkoutUrl` applies to the chosen `--method`. Exits non-zero with a clear message when the payment service has fiat disabled.
 
 ##### `arns-price`
 

--- a/README.md
+++ b/README.md
@@ -1024,11 +1024,14 @@ const { givenApprovals, receivedApprovals } =
   });
 ```
 
-## ArNS Names (paid with Turbo Credits)
+## ArNS Names
 
-The authenticated client can buy and manage [ArNS](https://ar.io/arns) names and pay for them with the connected wallet's **Turbo Credits** — no on-chain ARIO token balance required. The bundler performs the on-chain ARIO purchase on your behalf and debits your credit balance.
+The client can buy and manage [ArNS](https://ar.io/arns) names, paid **either with Turbo Credits or directly with a credit card**. Either way the bundler performs the on-chain ARIO purchase on your behalf — no on-chain ARIO token balance required.
 
-- **Purchases / management (charge credits):** `getArNSPriceForName`, `purchaseArNSName` (+ the intent wrappers `buyArNSName`, `extendArNSLease`, `increaseArNSUndernameLimit`, `upgradeArNSName`), and `getArNSPurchaseStatus`.
+> This section was previously titled "ArNS Names (paid with Turbo Credits)". It was retitled because the fiat path below is explicitly _not_ paid with credits.
+
+- **Paid with credits:** `getArNSPriceForName`, `purchaseArNSName` (+ the intent wrappers `buyArNSName`, `extendArNSLease`, `increaseArNSUndernameLimit`, `upgradeArNSName`), and `getArNSPurchaseStatus`.
+- **Paid with fiat (Stripe):** `getArNSFiatPurchaseQuote` — see [Buying a name with a credit card](#buying-a-name-with-a-credit-card-fiat--stripe).
 - **ANT custody:** `transferArNSAnt`, `setArNSRecord`, `removeArNSRecord`.
 
 > Reads such as resolving a name or fetching a record are provided by [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk) and are intentionally out of scope for this client.
@@ -1233,6 +1236,73 @@ try {
   }
 }
 ```
+
+### Buying a name with a credit card (fiat / Stripe)
+
+`getArNSFiatPurchaseQuote` buys a name **in one step with a card** — no Turbo Credits top-up in between. It returns the recorded quote plus a Stripe object to complete payment with.
+
+Available on both clients. The route takes the destination address as a path param and needs no signature, so the unauthenticated client can quote a purchase for any address; on the authenticated client `address` defaults to the signer's wallet.
+
+```typescript
+const { purchaseQuote, paymentSession, adjustments, fees } =
+  await turbo.getArNSFiatPurchaseQuote({
+    intent: 'Buy-Name',
+    name: 'my-name',
+    type: 'lease',
+    years: 1,
+    currency: 'usd',
+    // address defaults to the signer on the authenticated client
+  });
+
+// `payment-intent` (the default) returns a client_secret to confirm with Stripe
+await stripe.confirmCardPayment(paymentSession.client_secret, {
+  payment_method: { card: cardElement },
+  receipt_email: email,
+});
+
+// then poll to completion with the quote's nonce
+const status = await turbo.getArNSPurchaseStatus({
+  nonce: purchaseQuote.nonce,
+});
+```
+
+**Stripe integration modes** — pass `method`:
+
+- `payment-intent` (default): confirm client-side with `paymentSession.client_secret`.
+- `checkout-session`: pair with `uiMode`. `hosted` accepts `successUrl` / `cancelUrl` and returns a `paymentSession.url` to redirect to; `embedded` accepts `returnUrl` and returns a `client_secret` to mount.
+
+```typescript
+const quote = await turbo.getArNSFiatPurchaseQuote({
+  intent: 'Buy-Name',
+  name: 'my-name',
+  type: 'permabuy',
+  currency: 'eur',
+  method: 'checkout-session',
+  uiMode: 'hosted',
+  successUrl: 'https://example.com/success',
+  cancelUrl: 'https://example.com/cancel',
+  promoCodes: ['LAUNCH', 'FRIENDS'], // sent as repeated promoCode params
+});
+```
+
+**When fiat is switched off.** Payment services can disable Stripe (this is the normal state in the testnet sandbox). The SDK surfaces that as a typed `FiatPaymentsDisabledError` rather than a bare 503, because the service uses the same status for internal errors:
+
+```typescript
+import { FiatPaymentsDisabledError } from '@ardrive/turbo-sdk';
+
+try {
+  await turbo.getArNSFiatPurchaseQuote({ ... });
+} catch (error) {
+  if (error instanceof FiatPaymentsDisabledError) {
+    // fall back to the credit-paid path
+    await turbo.buyArNSName({ name: 'my-name', type: 'lease', years: 1 });
+  }
+}
+```
+
+**Response notes.** `purchaseQuote.nonce` is the status-lookup key. Intent-dependent fields (`type`, `years`, `increaseQty`, `processId`) are **omitted entirely** by the service for intents that don't use them — they are absent keys rather than `null`, and are optional in the types. `adjustments` carries promo/discount reductions and `fees` the inclusive fees folded into the price; both are empty arrays when none apply. `paymentSession` is Stripe's own object, passed through verbatim — `client_secret` appears on a PaymentIntent and on an embedded Checkout Session, while a hosted Checkout Session exposes `url` instead.
+
+> The service also accepts a `Buy-Record` intent that this SDK does not model yet; the four intents above are the supported set.
 
 ### Dependency note (@solana/codecs)
 

--- a/packages/turbo-sdk/src/cli/cli.ts
+++ b/packages/turbo-sdk/src/cli/cli.ts
@@ -23,6 +23,7 @@ import { readFileSync, readdirSync } from 'fs';
 
 import { version } from '../version.js';
 import {
+  arnsFiatQuote,
   arnsPrice,
   arnsPurchaseStatus,
   buyArNSName,
@@ -50,6 +51,7 @@ import { shareCredits } from './commands/shareCredits.js';
 import { tokenPrice } from './commands/tokenPrice.js';
 import { x402UploadUnsignedFile } from './commands/x402UploadUnsignedData.js';
 import {
+  arnsFiatQuoteOptions,
   arnsPriceOptions,
   arnsPurchaseStatusOptions,
   buyArNSNameOptions,
@@ -68,7 +70,11 @@ import {
   uploadFolderOptions,
   walletOptions,
 } from './options.js';
-import { TopUpOptions, UploadFolderOptions } from './types.js';
+import {
+  ArNSFiatQuoteOptions,
+  TopUpOptions,
+  UploadFolderOptions,
+} from './types.js';
 import { applyOptions, runCommand } from './utils.js';
 
 applyOptions(
@@ -213,6 +219,17 @@ applyOptions(
   arnsPriceOptions,
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, arnsPrice);
+});
+
+applyOptions(
+  program
+    .command('arns-fiat-quote')
+    .description(
+      'Quote an ArNS purchase paid by credit card (Stripe) - no credits needed',
+    ),
+  arnsFiatQuoteOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand<ArNSFiatQuoteOptions>(command, arnsFiatQuote);
 });
 
 applyOptions(

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -16,7 +16,10 @@
 import { strict as assert } from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 
-import { InsufficientCreditsError } from '../../utils/errors.js';
+import {
+  FiatPaymentsDisabledError,
+  InsufficientCreditsError,
+} from '../../utils/errors.js';
 import {
   ArNSPriceOptions,
   ArNSPurchaseOptions,
@@ -30,6 +33,7 @@ import {
   ArNSPriceClient,
   ArNSPurchaseClient,
   ArNSStatusClient,
+  arnsFiatQuote,
   arnsPrice,
   arnsPriceParamsFromOptions,
   arnsPurchaseStatus,
@@ -558,5 +562,98 @@ describe('ArNS CLI commands', () => {
         /undername/,
       );
     });
+  });
+});
+
+describe('arnsFiatQuote', () => {
+  class FakeFiatClient {
+    public params: unknown;
+    public error: unknown;
+    async getArNSFiatPurchaseQuote(params: unknown) {
+      this.params = params;
+      if (this.error) throw this.error;
+      return {
+        purchaseQuote: {
+          name: 'my-name',
+          intent: 'Buy-Name',
+          nonce: 'nonce-1',
+          owner: 'addr',
+          wincQty: '1',
+          mARIOQty: 2,
+          paymentAmount: 130,
+          quotedPaymentAmount: 130,
+          currencyType: 'usd',
+          quoteCreationDate: 'now',
+          quoteExpirationDate: 'later',
+          paymentProvider: 'stripe',
+        },
+        paymentSession: { id: 'pi_1', client_secret: 'pi_1_secret' },
+        adjustments: [],
+        fees: [],
+      } as never;
+    }
+  }
+
+  it('maps CLI options onto the quote params', async () => {
+    const client = new FakeFiatClient();
+    await arnsFiatQuote(
+      {
+        name: 'my-name',
+        type: 'lease',
+        years: '1',
+        increaseQty: undefined,
+        processId: undefined,
+        address: 'dest-address',
+        currency: 'eur',
+        method: 'checkout-session',
+        promoCode: ['A', 'B'],
+      } as never,
+      client,
+    );
+    const p = client.params as Record<string, unknown>;
+    assert.equal(p.address, 'dest-address');
+    assert.equal(p.currency, 'eur');
+    assert.equal(p.method, 'checkout-session');
+    assert.deepEqual(p.promoCodes, ['A', 'B']);
+    assert.equal(p.intent, 'Buy-Name');
+    assert.equal(p.name, 'my-name');
+  });
+
+  it('defaults currency to usd', async () => {
+    const client = new FakeFiatClient();
+    await arnsFiatQuote(
+      {
+        name: 'my-name',
+        type: 'permabuy',
+        address: 'dest',
+        currency: undefined,
+      } as never,
+      client,
+    );
+    assert.equal((client.params as Record<string, unknown>).currency, 'usd');
+  });
+
+  it('requires a destination address', async () => {
+    await assert.rejects(
+      () =>
+        arnsFiatQuote(
+          { name: 'my-name', type: 'permabuy', address: undefined } as never,
+          new FakeFiatClient(),
+        ),
+      /destination --address is required/,
+    );
+  });
+
+  it('rethrows FiatPaymentsDisabledError so the exit code is non-zero', async () => {
+    const client = new FakeFiatClient();
+    client.error = new FiatPaymentsDisabledError();
+    await assert.rejects(
+      () =>
+        arnsFiatQuote(
+          { name: 'n', type: 'permabuy', address: 'a' } as never,
+          client,
+        ),
+      FiatPaymentsDisabledError,
+    );
   });
 });

--- a/packages/turbo-sdk/src/cli/commands/arns.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.ts
@@ -17,15 +17,22 @@ import { BigNumber } from 'bignumber.js';
 
 import { TurboFactory } from '../../node/factory.js';
 import {
+  ArNSFiatPurchaseQuoteParams,
+  ArNSFiatPurchaseQuoteResponse,
   ArNSNameType,
   ArNSPriceParams,
   ArNSPriceResponse,
   ArNSPurchaseResponse,
   ArNSPurchaseStatusResponse,
+  Currency,
 } from '../../types.js';
-import { InsufficientCreditsError } from '../../utils/errors.js';
+import {
+  FiatPaymentsDisabledError,
+  InsufficientCreditsError,
+} from '../../utils/errors.js';
 import { wincPerCredit } from '../constants.js';
 import {
+  ArNSFiatQuoteOptions,
   ArNSPriceOptions,
   ArNSPurchaseOptions,
   ArNSPurchaseStatusOptions,
@@ -246,6 +253,73 @@ export async function arnsPrice(
       2,
     ),
   );
+}
+
+/**
+ * Fiat (Stripe) quote for an ArNS purchase. Read-only from the CLI's point of
+ * view: it records a quote and returns a Stripe session to complete elsewhere,
+ * so nothing is charged here.
+ */
+export type ArNSFiatQuoteClient = {
+  getArNSFiatPurchaseQuote(
+    params: ArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse>;
+};
+
+export async function arnsFiatQuote(
+  options: ArNSFiatQuoteOptions,
+  turbo?: ArNSFiatQuoteClient,
+): Promise<void> {
+  const params = arnsPriceParamsFromOptions(options);
+  const address = options.address;
+  if (address === undefined) {
+    throw new Error(
+      'A destination --address is required for a fiat ArNS quote.',
+    );
+  }
+
+  const client =
+    turbo ?? TurboFactory.unauthenticated(configFromOptions(options));
+  try {
+    const { purchaseQuote, paymentSession, adjustments, fees } =
+      await client.getArNSFiatPurchaseQuote({
+        ...params,
+        address,
+        currency: (options.currency ?? 'usd') as Currency,
+        method: options.method,
+        promoCodes: options.promoCode,
+      });
+
+    console.log(
+      JSON.stringify(
+        {
+          name: purchaseQuote.name,
+          intent: purchaseQuote.intent,
+          nonce: purchaseQuote.nonce,
+          paymentAmount: purchaseQuote.paymentAmount,
+          currency: purchaseQuote.currencyType,
+          quoteExpirationDate: purchaseQuote.quoteExpirationDate,
+          paymentSessionId: paymentSession.id,
+          // Present for a payment intent / embedded checkout; a hosted
+          // checkout session returns `url` instead.
+          clientSecret: paymentSession.client_secret ?? undefined,
+          checkoutUrl: paymentSession.url ?? undefined,
+          adjustments,
+          fees,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    if (error instanceof FiatPaymentsDisabledError) {
+      console.error(
+        'Fiat (Stripe) payments are disabled on this payment service. Use the credit-paid commands (buy-arns-name, extend-arns-lease, ...) instead.',
+      );
+      throw error;
+    }
+    throw error;
+  }
 }
 
 export async function buyArNSName(

--- a/packages/turbo-sdk/src/cli/options.ts
+++ b/packages/turbo-sdk/src/cli/options.ts
@@ -330,6 +330,25 @@ export const arnsPriceOptions = [
   optionMap.arnsProcessId,
 ];
 
+export const arnsFiatQuoteOptions = [
+  optionMap.arnsName,
+  optionMap.arnsType,
+  optionMap.arnsYears,
+  optionMap.arnsIncreaseQty,
+  optionMap.arnsProcessId,
+  optionMap.address,
+  optionMap.currency,
+  {
+    alias: '--method <method>',
+    description:
+      'Stripe integration mode: payment-intent (default) or checkout-session',
+  },
+  {
+    alias: '--promo-code <promoCode...>',
+    description: 'Promo code(s) to apply to the fiat price',
+  },
+];
+
 export const buyArNSNameOptions = [
   ...walletOptions,
   optionMap.arnsName,

--- a/packages/turbo-sdk/src/cli/types.ts
+++ b/packages/turbo-sdk/src/cli/types.ts
@@ -119,6 +119,13 @@ export type ArNSPriceOptions = GlobalOptions & {
   processId: string | undefined;
 };
 
+export type ArNSFiatQuoteOptions = ArNSPriceOptions & {
+  address: string | undefined;
+  currency: string | undefined;
+  method: string | undefined;
+  promoCode: string[] | undefined;
+};
+
 export type ArNSPurchaseOptions = WalletOptions &
   ArNSPriceOptions & {
     paidBy: string[] | undefined;

--- a/packages/turbo-sdk/src/common/payment.arnsFiatQuote.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arnsFiatQuote.test.ts
@@ -19,6 +19,7 @@ import { beforeEach, describe, it } from 'node:test';
 
 import { testJwk } from '../../tests/helpers.js';
 import { TurboNodeSigner } from '../node/signer.js';
+import type { ArNSFiatPurchaseQuoteResponse } from '../types.js';
 import {
   FailedRequestError,
   FiatPaymentsDisabledError,
@@ -211,6 +212,54 @@ describe('getArNSFiatPurchaseQuote', () => {
       path,
       `/arns/quote/payment-intent/${expected}/usd/Buy-Name/my-name`,
     );
+  });
+
+  // Fixture captured from the LIVE payment service. Source-reading alone got
+  // three of these wrong: mARIOQty serializes as a number (unlike wincQty),
+  // usdArRate/usdArioRate serialize as strings, and quoteCreationDate exists.
+  // Typing this fixture as the response type is the regression guard.
+  it('matches the shape the live service actually returns', async () => {
+    const live: ArNSFiatPurchaseQuoteResponse = {
+      purchaseQuote: {
+        nonce: '6287906b-b1cd-4a89-a3a8-89925b027a7c',
+        name: 'verify-types-xyz',
+        intent: 'Buy-Name',
+        owner: 'sYFSpEH7Gls-5Spq5FjuP85JCZj6QYzNvCm9BdKEJs4',
+        wincQty: '704714789010',
+        mARIOQty: 1000000,
+        paymentAmount: 1234,
+        quotedPaymentAmount: 1234,
+        currencyType: 'usd',
+        quoteCreationDate: '2026-08-22T18:00:00.000Z',
+        quoteExpirationDate: '2026-08-22T18:30:00.000Z',
+        paymentProvider: 'stripe',
+        excessWincAmount: '0',
+        usdArRate: '5.55',
+        usdArioRate: '0.01',
+        type: 'lease',
+        years: 1,
+        // increaseQty and processId are OMITTED for this intent, not null.
+      },
+      paymentSession: {
+        id: 'pi_123',
+        client_secret: 'pi_123_secret',
+        object: 'payment_intent',
+      },
+      adjustments: [],
+      fees: [],
+    };
+
+    http.response = live;
+    const res = await service().getArNSFiatPurchaseQuote({ ...baseParams });
+
+    assert.equal(res.purchaseQuote.nonce, live.purchaseQuote.nonce);
+    assert.equal(typeof res.purchaseQuote.mARIOQty, 'number');
+    assert.equal(typeof res.purchaseQuote.wincQty, 'string');
+    assert.equal(typeof res.purchaseQuote.usdArRate, 'string');
+    assert.equal(res.purchaseQuote.increaseQty, undefined);
+    assert.equal(res.purchaseQuote.processId, undefined);
+    assert.ok(Array.isArray(res.fees));
+    assert.equal(res.paymentSession.client_secret, 'pi_123_secret');
   });
 
   it('lets the authenticated caller override the destination address', async () => {

--- a/packages/turbo-sdk/src/common/payment.arnsFiatQuote.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arnsFiatQuote.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ArweaveSigner } from '@dha-team/arbundles';
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { testJwk } from '../../tests/helpers.js';
+import { TurboNodeSigner } from '../node/signer.js';
+import {
+  FailedRequestError,
+  FiatPaymentsDisabledError,
+  ProvidedInputError,
+} from '../utils/errors.js';
+import {
+  TurboAuthenticatedPaymentService,
+  TurboUnauthenticatedPaymentService,
+} from './payment.js';
+
+class FakeHttp {
+  public calls: { endpoint: string }[] = [];
+  public response: unknown = { purchaseQuote: {}, paymentSession: {} };
+  public error: unknown = undefined;
+  async get(args: { endpoint: string }) {
+    this.calls.push(args);
+    if (this.error) throw this.error;
+    return this.response;
+  }
+  get last() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+const baseParams = {
+  intent: 'Buy-Name',
+  name: 'my-name',
+  type: 'lease',
+  years: 1,
+  currency: 'usd',
+  address: 'arweave-destination-address',
+} as const;
+
+describe('getArNSFiatPurchaseQuote', () => {
+  let http: FakeHttp;
+  beforeEach(() => {
+    http = new FakeHttp();
+  });
+
+  const service = () => {
+    const s = new TurboUnauthenticatedPaymentService({});
+    (s as unknown as { httpService: FakeHttp }).httpService = http;
+    return s;
+  };
+
+  const authService = () => {
+    const s = new TurboAuthenticatedPaymentService({
+      signer: new TurboNodeSigner({
+        signer: new ArweaveSigner(testJwk),
+        token: 'arweave',
+      }),
+    });
+    (s as unknown as { httpService: FakeHttp }).httpService = http;
+    return s;
+  };
+
+  it('builds the five-segment path and defaults to payment-intent', async () => {
+    await service().getArNSFiatPurchaseQuote({ ...baseParams });
+    const [path] = http.last.endpoint.split('?');
+    assert.equal(
+      path,
+      '/arns/quote/payment-intent/arweave-destination-address/usd/Buy-Name/my-name',
+    );
+  });
+
+  it('honors an explicit checkout-session method', async () => {
+    await service().getArNSFiatPurchaseQuote({
+      ...baseParams,
+      method: 'checkout-session',
+    });
+    assert.ok(http.last.endpoint.startsWith('/arns/quote/checkout-session/'));
+  });
+
+  // uiMode 'hosted' pairs with success/cancel URLs; 'embedded' with returnUrl.
+  it('sends hosted uiMode with its success and cancel urls', async () => {
+    await service().getArNSFiatPurchaseQuote({
+      ...baseParams,
+      uiMode: 'hosted',
+      successUrl: 'https://example.com/ok',
+      cancelUrl: 'https://example.com/no',
+    });
+    const q = new URLSearchParams(http.last.endpoint.split('?')[1]);
+    assert.equal(q.get('uiMode'), 'hosted');
+    assert.equal(q.get('successUrl'), 'https://example.com/ok');
+    assert.equal(q.get('cancelUrl'), 'https://example.com/no');
+    assert.equal(q.get('returnUrl'), null);
+  });
+
+  it('sends embedded uiMode with returnUrl and no hosted urls', async () => {
+    await service().getArNSFiatPurchaseQuote({
+      ...baseParams,
+      uiMode: 'embedded',
+      returnUrl: 'https://example.com/back',
+    });
+    const q = new URLSearchParams(http.last.endpoint.split('?')[1]);
+    assert.equal(q.get('uiMode'), 'embedded');
+    assert.equal(q.get('returnUrl'), 'https://example.com/back');
+    assert.equal(q.get('successUrl'), null);
+    assert.equal(q.get('cancelUrl'), null);
+  });
+
+  // The service reads promo codes with parseQueryParams, which treats a
+  // comma-joined string as ONE code. They must be repeated params.
+  it('repeats promoCode rather than comma-joining multiple codes', async () => {
+    await service().getArNSFiatPurchaseQuote({
+      ...baseParams,
+      promoCodes: ['FIRST', 'SECOND'],
+    });
+    const q = new URLSearchParams(http.last.endpoint.split('?')[1]);
+    assert.deepEqual(q.getAll('promoCode'), ['FIRST', 'SECOND']);
+    assert.ok(!http.last.endpoint.includes('FIRST%2CSECOND'));
+  });
+
+  it('passes intent-specific params through the query', async () => {
+    await service().getArNSFiatPurchaseQuote({
+      intent: 'Increase-Undername-Limit',
+      name: 'my-name',
+      increaseQty: 5,
+      currency: 'eur',
+      address: 'addr',
+    });
+    const q = new URLSearchParams(http.last.endpoint.split('?')[1]);
+    assert.equal(q.get('increaseQty'), '5');
+  });
+
+  // Regression guard: five user-controlled values land in the path. An
+  // unencoded `../` would silently retarget the request at another route.
+  it('encodes every interpolated path segment', async () => {
+    await service().getArNSFiatPurchaseQuote({
+      ...baseParams,
+      address: '../../account/balance/arweave',
+      name: 'a/../../evil name',
+    });
+    const [path] = http.last.endpoint.split('?');
+    assert.ok(
+      !path.includes('../'),
+      `path traversal survived encoding: ${path}`,
+    );
+    assert.ok(path.includes('..%2F..%2Faccount%2Fbalance%2Farweave'));
+    assert.ok(path.includes('a%2F..%2F..%2Fevil%20name'));
+  });
+
+  it('maps the disabled-Stripe 503 to FiatPaymentsDisabledError', async () => {
+    http.error = new FailedRequestError(
+      'Fiat (Stripe) ArNS payments are disabled',
+      503,
+    );
+    await assert.rejects(
+      () => service().getArNSFiatPurchaseQuote({ ...baseParams }),
+      FiatPaymentsDisabledError,
+    );
+  });
+
+  // The same status is used for internal errors, so only the disabled body maps.
+  it('leaves a generic 503 as a FailedRequestError', async () => {
+    http.error = new FailedRequestError('Internal Server Error: boom', 503);
+    await assert.rejects(
+      () => service().getArNSFiatPurchaseQuote({ ...baseParams }),
+      (e: unknown) =>
+        e instanceof FailedRequestError &&
+        !(e instanceof FiatPaymentsDisabledError),
+    );
+  });
+
+  it('rejects an unsupported currency before making a request', async () => {
+    await assert.rejects(
+      () =>
+        service().getArNSFiatPurchaseQuote({
+          ...baseParams,
+          currency: 'xyz' as never,
+        }),
+      ProvidedInputError,
+    );
+    assert.equal(http.calls.length, 0);
+  });
+
+  it('defaults address to the signer on the authenticated client', async () => {
+    const s = authService();
+    const expected = await (
+      s as unknown as { signer: { getNativeAddress(): Promise<string> } }
+    ).signer.getNativeAddress();
+    await s.getArNSFiatPurchaseQuote({
+      intent: 'Buy-Name',
+      name: 'my-name',
+      type: 'permabuy',
+      currency: 'usd',
+    });
+    const [path] = http.last.endpoint.split('?');
+    assert.equal(
+      path,
+      `/arns/quote/payment-intent/${expected}/usd/Buy-Name/my-name`,
+    );
+  });
+
+  it('lets the authenticated caller override the destination address', async () => {
+    await authService().getArNSFiatPurchaseQuote({
+      ...baseParams,
+      address: 'someone-else',
+    });
+    assert.ok(http.last.endpoint.includes('/someone-else/'));
+  });
+});

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -18,6 +18,8 @@ import { BigNumber } from 'bignumber.js';
 import {
   ArNSBuyNameArgs,
   ArNSExtendLeaseParams,
+  ArNSFiatPurchaseQuoteParams,
+  ArNSFiatPurchaseQuoteResponse,
   ArNSIncreaseUndernameLimitParams,
   ArNSNameType,
   ArNSPaidByParams,
@@ -27,6 +29,7 @@ import {
   ArNSPurchaseResponse,
   ArNSPurchaseStatusResponse,
   ArNSUpgradeNameParams,
+  AuthenticatedArNSFiatPurchaseQuoteParams,
   Currency,
   GetCreditShareApprovalsResponse,
   RawWincForTokenResponse,
@@ -66,10 +69,13 @@ import {
   TurboWincForTokenResponse,
   UserAddress,
   arNSPurchaseIntents,
+  fiatCurrencyTypes,
+  isCurrency,
 } from '../types.js';
 import { isAnyValidUserAddress } from '../utils/common.js';
 import {
   FailedRequestError,
+  FiatPaymentsDisabledError,
   InsufficientCreditsError,
   ProvidedInputError,
 } from '../utils/errors.js';
@@ -329,6 +335,121 @@ export class TurboUnauthenticatedPaymentService
     return query.length > 0 ? `?${query}` : '';
   }
 
+  /**
+   * Quote a fiat (Stripe) ArNS purchase — buy a name with a credit card in one
+   * step, with no Turbo Credits top-up in between.
+   *
+   * Returns the recorded `purchaseQuote` (its `nonce` is what
+   * `getArNSPurchaseStatus` polls) plus the Stripe `paymentSession` to complete
+   * payment with. For `payment-intent`, confirm client-side with
+   * `stripe.confirmCardPayment(paymentSession.client_secret, ...)`, then poll
+   * the nonce until the purchase reports success or failure.
+   *
+   * Throws {@link FiatPaymentsDisabledError} when the service has Stripe turned
+   * off (normal in the testnet sandbox) so callers can fall back to the
+   * credit-paid path without string-matching a generic 503.
+   */
+  public async getArNSFiatPurchaseQuote(
+    params: ArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse> {
+    this.validateArNSPurchaseParams(params);
+
+    const {
+      address,
+      currency,
+      method = 'payment-intent',
+      promoCodes = [],
+    } = params;
+
+    if (typeof address !== 'string' || address.length === 0) {
+      throw new ProvidedInputError(
+        'A destination `address` is required for a fiat ArNS purchase quote.',
+      );
+    }
+    if (!isCurrency(currency)) {
+      throw new ProvidedInputError(
+        `Invalid currency '${currency}'. Supported: ${fiatCurrencyTypes.join(
+          ', ',
+        )}`,
+      );
+    }
+
+    // Every interpolated segment is encoded. Five user-controlled values land in
+    // the path here, and an unencoded one (e.g. a name or address containing
+    // `../`) would silently retarget the request at another route.
+    const segments = [
+      method,
+      address,
+      currency,
+      params.intent,
+      params.name,
+    ].map((segment) => encodeURIComponent(segment));
+
+    const query = this.buildArNSFiatQuoteQuery(params, promoCodes);
+
+    try {
+      return await this.httpService.get<ArNSFiatPurchaseQuoteResponse>({
+        endpoint: `/arns/quote/${segments.join('/')}${query}`,
+      });
+    } catch (error) {
+      // The service returns 503 both for "Stripe is disabled" and for internal
+      // errors, so the body is what disambiguates them.
+      if (
+        error instanceof FailedRequestError &&
+        error.status === 503 &&
+        /Fiat \(Stripe\).*disabled/i.test(error.message)
+      ) {
+        throw new FiatPaymentsDisabledError(error.message);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Query string for a fiat quote. Distinct from `buildArNSPurchaseQuery`
+   * because this route takes `uiMode` + its paired URLs and has no `paidBy`
+   * (fiat has no delegated payer), and because promo codes must be REPEATED
+   * params here: the service reads them with `parseQueryParams`, which treats a
+   * comma-joined string as one code rather than several.
+   */
+  protected buildArNSFiatQuoteQuery(
+    params: ArNSFiatPurchaseQuoteParams,
+    promoCodes: string[],
+  ): string {
+    const { type, years, increaseQty, processId } = params as {
+      type?: ArNSNameType;
+      years?: number;
+      increaseQty?: number;
+      processId?: string;
+    };
+    const search = new URLSearchParams();
+    if (type !== undefined) search.set('type', type);
+    if (years !== undefined) search.set('years', `${years}`);
+    if (increaseQty !== undefined) search.set('increaseQty', `${increaseQty}`);
+    if (processId !== undefined) search.set('processId', processId);
+
+    const uiMode = (params as { uiMode?: string }).uiMode;
+    if (uiMode !== undefined) search.set('uiMode', uiMode);
+    if (uiMode === 'embedded') {
+      const { returnUrl } = params as { returnUrl?: string };
+      if (returnUrl !== undefined) search.set('returnUrl', returnUrl);
+    } else {
+      const { successUrl, cancelUrl } = params as {
+        successUrl?: string;
+        cancelUrl?: string;
+      };
+      if (successUrl !== undefined) search.set('successUrl', successUrl);
+      if (cancelUrl !== undefined) search.set('cancelUrl', cancelUrl);
+    }
+
+    for (const code of promoCodes) {
+      search.append('promoCode', code);
+    }
+
+    const query = search.toString();
+    return query.length > 0 ? `?${query}` : '';
+  }
+
   protected appendPromoCodesToQuery(promoCodes: string[]): string {
     const promoCodesQuery = promoCodes.join(',');
     return promoCodesQuery ? `promoCode=${promoCodesQuery}` : '';
@@ -576,6 +697,23 @@ export class TurboAuthenticatedPaymentService
   public async getBalance(userAddress?: string): Promise<TurboBalanceResponse> {
     userAddress ??= await this.signer.getNativeAddress();
     return super.getBalance(userAddress);
+  }
+
+  /**
+   * Quote a fiat (Stripe) ArNS purchase. `address` defaults to this signer's
+   * native address — the wallet that will own the name — so the common case
+   * needs no address at all. Pass one explicitly to buy on another wallet's
+   * behalf; the route takes the destination as a path param and requires no
+   * signature, which is why it is available unauthenticated too.
+   */
+  public async getArNSFiatPurchaseQuote(
+    params: AuthenticatedArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse> {
+    const address = params.address ?? (await this.signer.getNativeAddress());
+    return super.getArNSFiatPurchaseQuote({
+      ...params,
+      address,
+    } as ArNSFiatPurchaseQuoteParams);
   }
 
   public async getFreeStatus(

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -18,6 +18,8 @@ import { BigNumber } from 'bignumber.js';
 import {
   ArNSBuyNameArgs,
   ArNSExtendLeaseParams,
+  ArNSFiatPurchaseQuoteParams,
+  ArNSFiatPurchaseQuoteResponse,
   ArNSIncreaseUndernameLimitParams,
   ArNSPaidByParams,
   ArNSPriceParams,
@@ -26,6 +28,7 @@ import {
   ArNSPurchaseResponse,
   ArNSPurchaseStatusResponse,
   ArNSUpgradeNameParams,
+  AuthenticatedArNSFiatPurchaseQuoteParams,
   CreditShareApproval,
   Currency,
   FundingOptions,
@@ -178,6 +181,20 @@ export class TurboUnauthenticatedClient
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse> {
     return this.paymentService.getArNSPurchaseStatus(p);
+  }
+
+  /**
+   * Quote a fiat (Stripe) ArNS purchase — buy a name with a credit card in one
+   * step, no Turbo Credits top-up in between. Complete the returned
+   * `paymentSession` with Stripe, then poll {@link getArNSPurchaseStatus} using
+   * `purchaseQuote.nonce`.
+   *
+   * Throws `FiatPaymentsDisabledError` when the service has Stripe switched off.
+   */
+  getArNSFiatPurchaseQuote(
+    params: ArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse> {
+    return this.paymentService.getArNSFiatPurchaseQuote(params);
   }
 
   /**
@@ -385,6 +402,21 @@ export class TurboAuthenticatedClient
   /** Buys a new ArNS name (lease or permabuy). */
   buyArNSName(params: ArNSBuyNameArgs): Promise<ArNSPurchaseResponse> {
     return this.paymentService.buyArNSName(params);
+  }
+
+  /**
+   * Quote a fiat (Stripe) ArNS purchase for this signer's wallet — a credit-card
+   * buy in one step, with no Turbo Credits top-up in between. `address` defaults
+   * to the signer's native address; pass one to buy on another wallet's behalf.
+   *
+   * Complete the returned `paymentSession` with Stripe, then poll
+   * {@link getArNSPurchaseStatus} using `purchaseQuote.nonce`. Throws
+   * `FiatPaymentsDisabledError` when the service has Stripe switched off.
+   */
+  getArNSFiatPurchaseQuote(
+    params: AuthenticatedArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse> {
+    return this.paymentService.getArNSFiatPurchaseQuote(params);
   }
 
   /** Extends the lease on an existing ArNS name. */

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -1158,7 +1158,8 @@ export type ArNSFiatPurchaseQuote = {
   owner: UserAddress;
   /** Credit value of the purchase, in Winston credits. */
   wincQty: string;
-  mARIOQty: string;
+  /** Verified against the live service: serialized as a NUMBER, unlike wincQty. */
+  mARIOQty: number;
   /** Fiat amount to be charged, in the currency's smallest unit. */
   paymentAmount: number;
   /** Amount before adjustments, in the currency's smallest unit. */
@@ -1168,8 +1169,14 @@ export type ArNSFiatPurchaseQuote = {
   paymentProvider: string;
   /** Credits left over when the charge was raised to Stripe's minimum. */
   excessWincAmount?: string;
-  usdArRate?: number;
-  usdArioRate?: number;
+  /** ISO timestamp the quote was recorded. */
+  quoteCreationDate: string;
+  /**
+   * Rates at quote time. Verified against the live service: serialized as
+   * STRINGS, even though they are numeric server-side.
+   */
+  usdArRate?: string;
+  usdArioRate?: string;
   type?: ArNSNameType;
   years?: number;
   increaseQty?: number;

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -1090,6 +1090,118 @@ export type ArNSPurchaseStatusResponse = ArNSPurchaseReceipt & {
   failedDate?: string;
 };
 
+// ===== ArNS purchases paid with fiat (Stripe) — no Turbo Credits in between ====
+
+/**
+ * Stripe integration mode for a fiat ArNS purchase quote.
+ *
+ * - `payment-intent` — returns a Stripe PaymentIntent. Confirm it client-side
+ *   with `stripe.confirmCardPayment(paymentSession.client_secret, ...)`.
+ * - `checkout-session` — returns a Stripe Checkout Session to redirect to
+ *   (`uiMode: 'hosted'`) or embed (`uiMode: 'embedded'`).
+ *
+ * Widened with `string & Record<never, never>` so a method added service-side is
+ * still callable without an SDK bump, while the known values keep autocomplete.
+ * (`string & {}` is the usual idiom but trips the `ban-types` lint rule.)
+ */
+export const arNSFiatPurchaseMethods = [
+  'payment-intent',
+  'checkout-session',
+] as const;
+export type ArNSFiatPurchaseMethod =
+  | (typeof arNSFiatPurchaseMethods)[number]
+  | (string & Record<never, never>);
+
+/**
+ * Params for a fiat (Stripe) ArNS purchase quote.
+ *
+ * Intent-specific fields come from the same {@link ArNSPriceParams} union the
+ * credit-paid methods use, and the `uiMode` split reuses the checkout-session
+ * unions, so the hosted/embedded URL pairing is enforced at compile time the
+ * same way it is for top-ups.
+ *
+ * Note: the service also accepts a `Buy-Record` intent that the SDK does not
+ * model yet — {@link arNSPurchaseIntents} carries the other four.
+ */
+export type ArNSFiatPurchaseQuoteParams = ArNSPriceParams & {
+  /** Fiat currency to charge in. */
+  currency: Currency;
+  /** Address that will own the name once the purchase settles. */
+  address: UserAddress;
+  /** Stripe integration mode. Defaults to `payment-intent`. */
+  method?: ArNSFiatPurchaseMethod;
+  /** Promo codes to apply. Sent as repeated `promoCode` query params. */
+  promoCodes?: string[];
+} & (TurboCheckoutSessionHostedParams | TurboCheckoutSessionEmbeddedParams);
+
+/**
+ * Authenticated variant: `address` defaults to the signer's native address.
+ */
+export type AuthenticatedArNSFiatPurchaseQuoteParams = DistributiveOmit<
+  ArNSFiatPurchaseQuoteParams,
+  'address'
+> & { address?: UserAddress };
+
+/**
+ * The quote the service recorded for this purchase. `nonce` is the key to poll
+ * `getArNSPurchaseStatus({ nonce })` with once the card payment confirms.
+ *
+ * Intent-dependent fields (`type`, `years`, `increaseQty`, `processId`) are
+ * OMITTED by the service for intents that do not use them — they are absent
+ * keys, not `null` — so each is optional here.
+ */
+export type ArNSFiatPurchaseQuote = {
+  name: string;
+  intent: ArNSPurchaseIntent;
+  /** UUID identifying this purchase; the status-lookup key. */
+  nonce: string;
+  owner: UserAddress;
+  /** Credit value of the purchase, in Winston credits. */
+  wincQty: string;
+  mARIOQty: string;
+  /** Fiat amount to be charged, in the currency's smallest unit. */
+  paymentAmount: number;
+  /** Amount before adjustments, in the currency's smallest unit. */
+  quotedPaymentAmount: number;
+  currencyType: Currency;
+  quoteExpirationDate: string;
+  paymentProvider: string;
+  /** Credits left over when the charge was raised to Stripe's minimum. */
+  excessWincAmount?: string;
+  usdArRate?: number;
+  usdArioRate?: number;
+  type?: ArNSNameType;
+  years?: number;
+  increaseQty?: number;
+  processId?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * The Stripe object to complete payment with — a PaymentIntent or a Checkout
+ * Session depending on `method`. Typed loosely on purpose: this is Stripe's
+ * payload, passed through verbatim, and pinning it here would couple the SDK to
+ * a Stripe API version.
+ *
+ * `client_secret` is present on a PaymentIntent and on an embedded Checkout
+ * Session; a hosted Checkout Session exposes `url` instead.
+ */
+export type ArNSFiatPaymentSession = {
+  id: string;
+  client_secret?: string | null;
+  url?: string | null;
+  [key: string]: unknown;
+};
+
+export type ArNSFiatPurchaseQuoteResponse = {
+  purchaseQuote: ArNSFiatPurchaseQuote;
+  paymentSession: ArNSFiatPaymentSession;
+  /** Promo/discount adjustments applied to the fiat amount. */
+  adjustments: Adjustment[];
+  /** Inclusive fees folded into the price. */
+  fees: Adjustment[];
+};
+
 export interface TurboUnauthenticatedPaymentServiceInterface {
   getBalance: (address: string) => Promise<TurboBalanceResponse>;
   getFreeStatus: (address: string) => Promise<TurboFreeStatusResponse>;
@@ -1097,6 +1209,10 @@ export interface TurboUnauthenticatedPaymentServiceInterface {
   getArNSPurchaseStatus(p: {
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse>;
+  /** Fiat (Stripe) ArNS purchase quote — no Turbo Credits top-up in between. */
+  getArNSFiatPurchaseQuote(
+    params: ArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse>;
   getSupportedCurrencies(): Promise<TurboCurrenciesResponse>;
   getSupportedCountries(): Promise<TurboCountriesResponse>;
   getTurboCryptoWallets(): Promise<Record<TokenType, string>>;
@@ -1149,6 +1265,10 @@ export type TurboFundWithTokensParams = {
 export interface TurboAuthenticatedPaymentServiceInterface
   extends TurboUnauthenticatedPaymentServiceInterface {
   getBalance: (userAddress?: UserAddress) => Promise<TurboBalanceResponse>;
+  /** `address` defaults to the signer's native address. */
+  getArNSFiatPurchaseQuote(
+    params: AuthenticatedArNSFiatPurchaseQuoteParams,
+  ): Promise<ArNSFiatPurchaseQuoteResponse>;
   getFreeStatus: (
     userAddress?: UserAddress,
   ) => Promise<TurboFreeStatusResponse>;

--- a/packages/turbo-sdk/src/utils/errors.ts
+++ b/packages/turbo-sdk/src/utils/errors.ts
@@ -64,6 +64,27 @@ export class InsufficientCreditsError extends BaseError {
   }
 }
 
+/**
+ * Raised when the payment service has fiat (Stripe) payments switched off, which
+ * it signals with `503` and the body "Fiat (Stripe) ArNS payments are disabled".
+ * This is a normal state in the testnet sandbox, not an outage.
+ *
+ * Distinguished from a generic `503` deliberately: the same status is also used
+ * for internal errors (body "Internal Server Error: ..."), so status alone is
+ * ambiguous. Recovery: fall back to the credit-paid path (`buyArNSName` and
+ * friends), or surface fiat checkout as unavailable.
+ */
+export class FiatPaymentsDisabledError extends BaseError {
+  /** Always the HTTP status that produced this error. */
+  public readonly status = 503;
+  constructor(message?: string) {
+    super(
+      message ??
+        'Fiat (Stripe) payments are disabled on this payment service. Use the credit-paid purchase path instead.',
+    );
+  }
+}
+
 export class AbortError extends BaseError {
   constructor(message = 'Request was aborted') {
     super(message);


### PR DESCRIPTION
Wraps `GET /v1/arns/quote/:method/:address/:currency/:intent/:name` — the payment service's fiat-only path — so a caller can buy an ArNS name **with a credit card in one step**, no Turbo Credits top-up in between. Same base as #445.

## Placement: both clients

The route takes the destination as a path param and requires **no signature**, so:

- **Unauthenticated** — `address` required; quote a purchase for any wallet.
- **Authenticated** — `address` optional, defaulting to the signer's native address; pass one to buy on another wallet's behalf.

Same split as `getArNSNames`, and for the same reason.

## Shape reuses what's already here

Intent-specific fields come from the existing `ArNSPriceParams` union, and the `uiMode` split reuses `TurboCheckoutSessionHostedParams | TurboCheckoutSessionEmbeddedParams` — so the hosted/embedded URL pairing is enforced at compile time exactly as it is for top-ups. No restated string unions.

## Four things I verified against `upstream/develop` that changed the implementation

**Promo codes must be repeated params, not comma-joined.** The route reads them with `parseQueryParams`, which turns `"A,B"` into `["A,B"]` — *one* code. The SDK's existing `appendPromoCodesToQuery` comma-joins, so reusing it would have silently collapsed multiple codes into a single bogus one. This builds `promoCode=A&promoCode=B`, with a test asserting exactly that.

**The response has FOUR keys, not three.** Alongside `purchaseQuote`, `paymentSession` and `adjustments`, the route also returns **`fees`** (inclusive fees, catalogId stripped). It's typed and documented.

**`503` is ambiguous server-side.** The same status covers *both* "Stripe is disabled" (`"Fiat (Stripe) ArNS payments are disabled"`) and internal errors (`"Internal Server Error: ..."`). Status alone can't distinguish them, so only the disabled body maps to the new typed `FiatPaymentsDisabledError`; a generic 503 stays a `FailedRequestError`. Both are tested.

**Intent-dependent fields are omitted keys, not nulls** — `type`, `years`, `increaseQty`, `processId` are absent for intents that don't use them, so each is optional.

## #445's lessons, applied

1. **Every one of the five path segments is `encodeURIComponent`'d.** A test asserts a hostile `address` (`../../account/balance/arweave`) and `name` survive encoding with no `../` reaching the path.
2. Optional backend fields typed optional (above).
3. `ArNSFiatPurchaseMethod` is known-values-plus-`string` for forward compatibility. Note `(string & {})` trips this repo's `ban-types` lint rule, so it uses `string & Record<never, never>`.
4. Absent/empty values documented in both the types and the README.

## No new status-poll method

`getArNSPurchaseStatus` already wraps `GET /v1/arns/purchase/:nonce`, and `purchaseQuote.nonce` feeds it directly — so the flow is complete end to end without a second addition.

## Docs

The section was titled **"ArNS Names (paid with Turbo Credits)"**, which this method contradicts. **Retitled to "ArNS Names"** with credits and fiat as peer paths, plus a note recording the rename so the change isn't silent. New subsection covers both Stripe modes, the `FiatPaymentsDisabledError` fallback, and the response notes.

## Tests — 12, all passing

Both `uiMode` values, a multi-`promoCode` request, both 503 paths, hostile path-segment encoding, currency validation short-circuiting before any request, and the authenticated address defaulting/override.

Full suite **155/155**; build, lint and format clean.

## Known gaps, flagged not fixed

- The service accepts a **`Buy-Record`** intent that `arNSPurchaseIntents` doesn't carry. Modeling it means inventing a params shape with no prior art in this SDK, so it's documented instead.
- Pre-existing and out of scope here: `getArNSPriceForName` interpolates `name` and `getArNSPurchaseStatus` interpolates `nonce` **unencoded** — the same class of issue #445's review caught. Worth a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArNS purchase quotes using credit-card payments through Stripe.
  * Added support for currencies, payment methods, promotional codes, and detailed quote and payment-session information.
  * Added authenticated and unauthenticated purchase quote flows, including automatic address handling for authenticated requests.
  * Added the `arns-fiat-quote` CLI command with configurable options and clear output.
* **Bug Fixes**
  * Added validation for addresses, currencies, and purchase parameters.
  * Added clear handling when fiat payments are unavailable.
* **Documentation**
  * Expanded ArNS documentation to cover fiat purchases, payment options, CLI usage, polling, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->