### PR TITLE
fix(ci): probe a real priced request before running integration tests

### DIFF
--- a/packages/turbo-sdk/docker-compose.yml
+++ b/packages/turbo-sdk/docker-compose.yml
@@ -68,11 +68,16 @@ services:
       - upload-service-data-items:/temp
       - ./tests/wallets:/usr/src/app/wallets
     depends_on:
-      - upload-service-pg
-      - payment-service
-      - arlocal-setup
-      - localstack
-      - redis
+      upload-service-pg:
+        condition: service_healthy
+      payment-service:
+        condition: service_started
+      arlocal-setup:
+        condition: service_started
+      localstack:
+        condition: service_started
+      redis:
+        condition: service_started
 
   redis:
     image: redis:7.2-alpine
@@ -131,6 +136,12 @@ services:
 
   upload-service-pg:
     image: postgres:13.8
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -199,11 +210,24 @@ services:
       KYVE_GATEWAY: ${KYVE_GATEWAY:-https://api.korellia.kyve.network} # KYVE testnet gateway
       PAYMENT_TX_POLLING_WAIT_TIME_MS: 10
     depends_on:
-      - payment-service-pg
-      - arlocal-setup
+      payment-service-pg:
+        condition: service_healthy
+      arlocal-setup:
+        condition: service_started
 
   payment-service-pg:
     image: postgres:13.8
+    # Without this, `depends_on` only waits for the CONTAINER to start, not for
+    # Postgres to accept connections. payment-service then races it, loses, and
+    # logs "Failed to migrate database! connect ECONNREFUSED ...:5433" — leaving
+    # a service that answers /health with no schema, so every priced request
+    # 500s. That race is the cause of the intermittent 56-failure runs.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -p 5433"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
     environment:
       PGPORT: 5433
       POSTGRES_USER: postgres

--- a/packages/turbo-sdk/run-tests.sh
+++ b/packages/turbo-sdk/run-tests.sh
@@ -8,6 +8,14 @@ docker compose up --quiet-pull -d
 # Dump service logs so a failure is diagnosable from the CI log alone. Without
 # this the job output shows only container lifecycle events, which cannot
 # distinguish "service was slow to start" from "service started and is broken".
+# Record exactly which images this run resolved. `docker compose pull --quiet`
+# hides them, which is why an earlier failure could not be attributed to image
+# drift: the harness pins nothing by default (PAYMENT_SERVICE_IMAGE_TAG and
+# UPLOAD_SERVICE_IMAGE_TAG both default to `latest`), so two runs minutes apart
+# can use different builds with no record of it.
+echo "===================== resolved images ====================="
+docker compose images 2>&1 || true
+
 dump_logs() {
   echo "===================== docker compose ps ====================="
   docker compose ps
@@ -65,6 +73,42 @@ fi
 # here rather than 90 minutes later as a wall of unrelated test timeouts.
 if ! wait_for_health "payment-service" "http://localhost:4000/health" 180 \
   || ! wait_for_health "upload-service" "http://localhost:3000/health" 180; then
+  dump_logs
+  docker compose down -v
+  exit 1
+fi
+
+# Liveness is not readiness. /health answers as soon as the process is up, even
+# when the payment database has no schema -- a run in that state answered
+# /health instantly and then failed 56 tests, because every priced request hit
+# `relation "payment_adjustment_catalog" does not exist`, burned the SDK's five
+# retries (~31s each), and cascaded into parent-suite cancellations.
+#
+# So probe a real priced request, which reads the adjustment catalog, and treat
+# a non-200 as "the stack is not usable" -- failing in seconds with the service
+# logs attached instead of ~90 minutes of unattributable timeouts. This only
+# CHECKS; it never migrates or mutates the service.
+wait_for_priced_request() {
+  local url="http://localhost:4000/v1/price/bytes/1" timeout=120 elapsed=0 interval=5 code
+  echo "Probing a priced request at $url (verifies the payment DB is usable) ..."
+  while [ $elapsed -lt $timeout ]; do
+    # curl already reports 000 when it cannot connect; do not append another.
+    code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 "$url" 2>/dev/null)
+    code=${code:-000}
+    if [ "$code" = "200" ]; then
+      echo "payment-service is serving priced requests (${elapsed}s)"
+      return 0
+    fi
+    sleep $interval
+    elapsed=$((elapsed + interval))
+  done
+  echo "ERROR: payment-service answered /health but cannot serve a priced request"
+  echo "       (last status: ${code}). Its database schema is likely missing or"
+  echo "       incomplete -- see the payment-service logs below."
+  return 1
+}
+
+if ! wait_for_priced_request; then
   dump_logs
   docker compose down -v
   exit 1


### PR DESCRIPTION
Follow-up to #446, which added the log capture that finally identified the cause of the recurring 56-failure runs.

## What the logs showed

```
relation "payment_adjustment_catalog" does not exist   (code 42P01)
```

The payment service was up and answering `/health`, but its **database had no schema**. Every priced request 500'd, the SDK burned its five retries (~31s each), tests blew their timeouts, and parent suites cancelled their children — producing the 56-failure cascade seen on the #442 release run, #444, and #447.

**Liveness is not readiness.** `/health` answers as soon as the process starts; it says nothing about the schema. The gate #446 added passed in 0s on the failing run.

## This change

**A functional probe** of `GET /v1/price/bytes/1` — chosen because it reads the adjustment catalog, the exact table that was missing. Non-200 fails the run in seconds with the service logs attached, instead of ~90 minutes of unattributable timeouts.

**Records `docker compose images` at startup.** `pull --quiet` hides resolved images and neither service tag is pinned by default, so two runs minutes apart can use different builds with nothing in the log to prove it. A green run at 15:2x and a red one at 15:31 could not be compared for precisely this reason. This makes drift visible — and gives us a known-good tag to pin `PAYMENT_SERVICE_IMAGE_TAG` to (the knob #446 added).

## What this deliberately does NOT do

The obvious fix is `MIGRATE_ON_STARTUP: "true"` on payment-service, mirroring upload-service. I checked it would work — `constants.ts:23` reads it and passes it to `new PostgresDatabase({ migrate })`. I'm not doing it, for three reasons:

1. **It would make the harness force schema changes on a service it only borrows**, and diverge from how that service actually starts in deployment.
2. **The diagnosis doesn't support it.** A run 30 minutes earlier passed with **0** "Max retries reached" against **50** in the failing run. If the schema were simply never created, that green run was impossible. Something changed between them — most plausibly the unpinned `:latest` image — so forcing migrations would paper over drift rather than fix it.
3. I could not verify the flag against the actual image: `ghcr.io/ardriveapp/payment-service` is unpullable and unlistable with my token (`read:packages` denied). Shipping an unverified behavior change to the one thing standing between us and a release is the wrong trade.

This change only **observes**. It never migrates or mutates the service.

## Verification

`bash -n` clean. The probe returns immediately against a healthy endpoint, and fails at its deadline reporting the status it actually saw — `404` for a broken route, `000` when nothing is listening — rather than hanging.

## Next step this enables

Once a run records its images, pin `PAYMENT_SERVICE_IMAGE_TAG` to a green one. If a pinned image is consistently green, image drift is confirmed and the root cause is fixed without forcing anything. Listing publish timestamps needs a token with `read:packages`:

```
gh api orgs/ardriveapp/packages/container/payment-service/versions
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability by waiting for dependent services and databases to become healthy.
  * Added readiness verification to ensure payment requests work correctly before tests begin.
  * Enhanced failure handling with service logs and cleanup when readiness checks time out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->