### PR TITLE
fix(release): push the release commit with the bot PAT, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,18 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     steps:
+      # semantic-release's @semantic-release/git plugin pushes the
+      # `chore(release)` commit (CHANGELOG.md + src/version.ts) back to the
+      # release branch. `alpha` and `main` are protected and require a review,
+      # and the default GITHUB_TOKEN (github-actions[bot]) is NOT on the bypass
+      # list — only `ardrive-bot` is — so that push fails with:
+      #   GH006: Protected branch update failed for refs/heads/alpha
+      # Check out (and release) with the bot PAT so the push is allowed. Falls
+      # back to GITHUB_TOKEN if the secret is unset, which fails the same way it
+      # does today rather than in some new one.
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Set Up node
         uses: actions/setup-node@v6
         with:
@@ -48,7 +57,7 @@ jobs:
       # stamped src/version.ts, or produced a `chore(release)` commit.
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: yarn semantic-release
 
       - name: Publish Dist Tag


### PR DESCRIPTION
#444 got semantic-release to load `.releaserc`, and the first run with the real plugin set immediately surfaced the next blocker.

## What happened

The plugins now load correctly — `changelog`, `exec`, and `git` all appear, which they never did before. Then:

```
git push --tags https://github.com/ardriveapp/turbo-sdk HEAD:alpha
remote: error: GH006: Protected branch update failed for refs/heads/alpha
```

`@semantic-release/git` pushes the `chore(release)` commit (CHANGELOG.md + `src/version.ts`) back to the release branch. `alpha` requires one approving review, and its bypass list contains exactly one actor:

```
bypassAllowances.users = [ ardrive-bot ]
```

The workflow authenticates as `github-actions[bot]` through the default `GITHUB_TOKEN`, which is **not** on that list. This was invisible until now because the git plugin never loaded, so nothing ever attempted the push.

## The fix

The repo already has a **`CI_GITHUB_TOKEN`** secret that **no workflow references** — consistent with a bot PAT that was provisioned and never wired up. This uses it for both:

- the `actions/checkout` token (semantic-release pushes with the credentials checkout persists), and
- the `GITHUB_TOKEN` env for the release step

with `|| secrets.GITHUB_TOKEN` as a fallback, so an unset secret fails exactly the way it does today rather than in a new way.

## The failure was clean

`@semantic-release/git` runs in `prepare`, ahead of `publish`, so the push failure aborted the release **before npm**. Nothing was published, no partial state: `alpha` on npm is still `1.42.0-alpha.6`.

## What I can't verify

I cannot confirm from here that `CI_GITHUB_TOKEN` belongs to `ardrive-bot` or carries the required scopes — secret values aren't readable, and my token is refused `admin:org`. **The next release run is the test.** If the token is wrong, the release fails at the same push it already fails at, so this can't make things worse.

If it does turn out to be the wrong token, the alternatives are: add `github-actions[bot]` to the bypass list on `alpha`/`main`, or mint a fresh `ardrive-bot` PAT into `CI_GITHUB_TOKEN`.