### PR TITLE
revert(release): restore the working release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,9 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     steps:
-      # semantic-release's @semantic-release/git plugin pushes the
-      # `chore(release)` commit (CHANGELOG.md + src/version.ts) back to the
-      # release branch. `alpha` and `main` are protected and require a review,
-      # and the default GITHUB_TOKEN (github-actions[bot]) is NOT on the bypass
-      # list — only `ardrive-bot` is — so that push fails with:
-      #   GH006: Protected branch update failed for refs/heads/alpha
-      # Check out (and release) with the bot PAT so the push is allowed. Falls
-      # back to GITHUB_TOKEN if the secret is unset, which fails the same way it
-      # does today rather than in some new one.
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set Up node
         uses: actions/setup-node@v6
         with:
@@ -47,18 +38,10 @@ jobs:
       - name: Build
         run: yarn workspace @ardrive/turbo-sdk build
 
-      # Run from the repo ROOT, not the workspace. `.releaserc` lives at the
-      # root and every path in it is root-relative (`pkgRoot`, the exec
-      # prepareCmd, the release assets). Running this via
-      # `yarn workspace @ardrive/turbo-sdk` sets cwd to packages/turbo-sdk,
-      # where semantic-release finds no config and silently falls back to its
-      # DEFAULT plugins -- dropping @semantic-release/changelog, /exec and
-      # /git. That is why no release since 1.40.0 updated CHANGELOG.md,
-      # stamped src/version.ts, or produced a `chore(release)` commit.
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: yarn semantic-release
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn workspace @ardrive/turbo-sdk semantic-release
 
       - name: Publish Dist Tag
         run: |


### PR DESCRIPTION
Reverts the `release.yml` half of #444 and all of #449. Keeps the `update-version.sh` fix, which is dormant while the root config isn't loaded and correct if this is ever retried.

## Why

#444 made semantic-release load `.releaserc`, which activated `@semantic-release/git`, which has to push the `chore(release)` commit to a protected branch. That push cannot be made with either identity we have:

```
#444  GH006: Protected branch update failed for refs/heads/alpha
      github-actions[bot] is not on the bypass list — only ardrive-bot is

#449  EGITNOPERMISSION Cannot push to the Git repository
      CI_GITHUB_TOKEN does not grant push either; my guess was wrong
```

The net effect of #444 was to turn **"publishes, but writes no CHANGELOG or version stamp"** into **"publishes nothing at all."** That's strictly worse than where this repo has been since January, and not a trade worth keeping while the credential question is open.

## Nothing was damaged

Both failures were clean. `@semantic-release/git` runs in `prepare`, ahead of `publish`, so no partial release reached npm. Throughout all of it, `latest` stayed `1.42.0` and `alpha` stayed `1.42.0-alpha.6`.

## What remains true, and unfixed

CHANGELOG.md hasn't been touched since **2026-01-16**, `version.ts` is frozen at `1.40.0`, and consequently the `x-turbo-source-version` header reports `1.40.0` for every client in the wild — which is exactly the signal you'd want when triaging the next report like #440.

That's a real problem. It's also seven months old and blocking nothing. It should be fixed deliberately — someone with org access confirms which identity is permitted to push to a protected branch, and *then* the config change lands with that identity wired in — rather than by guessing at tokens one release run at a time.

Two concrete paths when someone picks it up:

1. Add `github-actions[bot]` to the bypass list on `alpha`/`main`, or mint a working `ardrive-bot` PAT into `CI_GITHUB_TOKEN`. Then re-land #444 unchanged.
2. Drop `@semantic-release/git` and accept no changelog commit. Worth noting the **published artifact would still get the correct version**, because the workflow builds before semantic-release and `update-version.sh` patches `lib/*/version.js` during `prepare` — so the telemetry problem is fixable without any push at all.

## Scope note

This was my scope creep, not a reported problem. It surfaced while verifying the #440 fix, and I should have filed it rather than fixed it mid-stream.