### PR TITLE
fix(cli): stop arns-fiat-quote sending the pricing placeholder processId

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Welcome to the `@ardrive/turbo-sdk`! This SDK provides functionality for interac
   - [TurboFactory](#turbofactory)
   - [TurboUnauthenticatedClient](#turbounauthenticatedclient)
   - [TurboAuthenticatedClient](#turboauthenticatedclient)
-- [ArNS Names (paid with Turbo Credits)](#arns-names-paid-with-turbo-credits)
+- [ArNS Names](#arns-names)
   - [Purchase lifecycle](#purchase-lifecycle)
   - [Connecting a signer](#connecting-a-signer)
   - [Pricing a name](#pricing-a-name)
@@ -1886,7 +1886,7 @@ turbo list-shares --address 2cor...VUa --wallet-file ../path/to/my/wallet
 
 #### ArNS Commands
 
-Buy and manage [ArNS](#arns-names-paid-with-turbo-credits) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-purchase-status`.
+Buy and manage [ArNS](#arns-names) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-purchase-status`.
 
 All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. The write commands (`buy-arns-name`, `extend-arns-lease`, `increase-arns-undernames`, `upgrade-arns-name`, `transfer-arns-ant`, `set-arns-record`, `remove-arns-record`) require a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`); the read-only commands (`arns-price`, `arns-purchase-status`, `arns-fiat-quote`) do not.
 

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -619,6 +619,45 @@ describe('arnsFiatQuote', () => {
     assert.equal(p.name, 'my-name');
   });
 
+  // Regression: arnsPriceParamsFromOptions substitutes a placeholder
+  // processId ('pricing-only-no-process-id') for pricing. A quote records a
+  // REAL purchase, so that placeholder must never reach the service — omitting
+  // processId is what asks Turbo to custodially provision the ANT.
+  it('never sends the pricing placeholder processId', async () => {
+    const client = new FakeFiatClient();
+    await arnsFiatQuote(
+      {
+        name: 'my-name',
+        type: 'lease',
+        years: '1',
+        address: 'dest',
+        processId: undefined,
+      } as never,
+      client,
+    );
+    const p = client.params as Record<string, unknown>;
+    assert.equal(p.processId, undefined);
+    assert.ok(!JSON.stringify(p).includes('pricing-only-no-process-id'));
+  });
+
+  it('forwards an explicitly supplied processId', async () => {
+    const client = new FakeFiatClient();
+    await arnsFiatQuote(
+      {
+        name: 'my-name',
+        type: 'lease',
+        years: '1',
+        address: 'dest',
+        processId: 'real-ant-process-id',
+      } as never,
+      client,
+    );
+    assert.equal(
+      (client.params as Record<string, unknown>).processId,
+      'real-ant-process-id',
+    );
+  });
+
   it('defaults currency to usd', async () => {
     const client = new FakeFiatClient();
     await arnsFiatQuote(

--- a/packages/turbo-sdk/src/cli/commands/arns.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.ts
@@ -271,6 +271,15 @@ export async function arnsFiatQuote(
   turbo?: ArNSFiatQuoteClient,
 ): Promise<void> {
   const params = arnsPriceParamsFromOptions(options);
+
+  // `arnsPriceParamsFromOptions` substitutes PRICING_PLACEHOLDER_PROCESS_ID for
+  // an omitted Buy-Name `processId`, which is fine for a price lookup but NOT
+  // here: a quote records a real purchase, and that placeholder is not a valid
+  // ANT. Send `processId` only when the caller actually supplied one — omitting
+  // it is what tells Turbo to custodially provision the ANT.
+  if (options.processId === undefined) {
+    delete (params as { processId?: string }).processId;
+  }
   const address = options.address;
   if (address === undefined) {
     throw new Error(


### PR DESCRIPTION
Two defects CodeRabbit found reviewing #447 **after** it merged. Both are mine.

## 1. Major — a placeholder ANT id reached a real purchase quote

`arnsPriceParamsFromOptions` substitutes `PRICING_PLACEHOLDER_PROCESS_ID` (`'pricing-only-no-process-id'`) when a Buy-Name omits `processId`. That's harmless for a price lookup, which is all the helper was written for.

`arns-fiat-quote` reused it. So running the command without `--process-id` recorded a **real purchase quote carrying a processId that is not a valid ANT**.

Worse than a stray field: omitting `processId` is precisely the signal that asks Turbo to custodially provision the ANT (Model A). The placeholder **inverted the intended default**, on a path that persists state and takes payment.

Now sent only when the caller actually supplied one.

## 2. Minor — orphaned documentation anchors

Retitling the section to "ArNS Names" changed its anchor to `#arns-names`, leaving links pointing at `#arns-names-paid-with-turbo-credits`. CodeRabbit flagged the inline link at README:1889; the **table-of-contents entry at README:23 was broken the same way** and is fixed too.

## Tests

Regression tests both directions — the placeholder never reaches the service, and an explicitly supplied `processId` still does. 162/162 unit tests, lint and format clean.

## Worth stating plainly

This is what merging #447 without a review cost. CodeRabbit's hourly limit deferred the review, not the bugs — and the Major one would have shipped a broken custodial-provisioning default to anyone using the new CLI command. The same review pass on #445 also caught a union that silently wasn't forward-compatible.

**#448 still has no review** for the same reason. It's test-harness only, so the exposure is far lower, but it's the last unreviewed thing from this batch.