### PR TITLE
feat(upload): content addressed incremental folder uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Welcome to the `@ardrive/turbo-sdk`! This SDK provides functionality for interac
   - [ANT custody: transfer & manage records](#ant-custody-transfer--manage-records)
   - [Listing owned names](#listing-owned-names)
   - [Error handling & retries](#error-handling--retries)
+  - [Buying a name with a credit card (fiat / Stripe)](#buying-a-name-with-a-credit-card-fiat--stripe)
   - [Dependency note (@solana/codecs)](#dependency-note-solanacodecs)
 - [Signers](#signers)
   - [Arweave](#arweave)
@@ -1028,11 +1029,28 @@ a tag your own past uploads wrote, not something a gateway verifies against the
 bytes — and the index trusts it. That is safe for uploads this SDK made, since it
 only ever writes a hash it computed from the file in front of it.
 
+`uploadFolder` writes whichever tag the index it is given declares, so setting
+`hashTagName` moves both the tag that is written and the tag the sweep filters
+on, and the two cannot drift apart. Every layer in a `composeFolderIndex` stack
+that declares one has to declare the same one, or the call throws: one tag is
+written per file, so a stack that disagrees would leave whichever layer lost
+matching nothing, for ever, without an error.
+
 It stops being safe if you point `hashTagName` at a tag you were already using
 for something else. Any of your own past items carrying 64 hex characters under
 that name would be treated as a candidate, and one whose tag set happens to
-match would be reused — putting a manifest path in front of unrelated bytes.
-Only override `hashTagName` for a tag written by this feature.
+match would be reused — putting a manifest path in front of unrelated bytes. Use
+a name nothing else of yours writes.
+
+###### When the sweep runs out of pages
+
+A sweep can examine at most `pageSize * maxPages` items, 2,000 by default. A
+folder with more files than that, or a long enough deployment history, can
+therefore reach the page limit with files still unresolved — and those files are
+uploaded and paid for again while the summary reports them as ordinary new
+files. Pass a `logger` to `createChainFolderIndex` and it says so when this
+happens, naming how many files were left. Raise `maxPages` or `pageSize`, or put
+a `createFileFolderIndex` in front, and the sweep has less to find.
 
 ###### In the browser
 

--- a/README.md
+++ b/README.md
@@ -759,9 +759,9 @@ await turbo.uploadRawX402Data({
 });
 ```
 
-#### `uploadFolder({ folderPath, files, dataItemOpts, signal, maxConcurrentUploads, throwOnFailure, manifestOptions })`
+#### `uploadFolder({ folderPath, files, dataItemOpts, signal, maxConcurrentUploads, throwOnFailure, manifestOptions, folderIndex, manifestDataItemOpts })`
 
-Signs and uploads a folder of files. For NodeJS, the `folderPath` of the folder to upload is required. For the browser, an array of `files` is required. The `dataItemOpts` is an optional object that can be used to configure tags, target, and anchor for the data item upload. The `signal` is an optional [AbortSignal] that can be used to cancel the upload or timeout the request. The `maxConcurrentUploads` is an optional number that can be used to limit the number of concurrent uploads. The `throwOnFailure` is an optional boolean that can be used to throw an error if any upload fails. The `manifestOptions` is an optional object that can be used to configure the manifest file, including a custom index file, fallback file, or whether to disable manifests altogether. Manifests are enabled by default.
+Signs and uploads a folder of files. For NodeJS, the `folderPath` of the folder to upload is required. For the browser, an array of `files` is required. The `dataItemOpts` is an optional object that can be used to configure tags, target, and anchor for the data item upload. The `signal` is an optional [AbortSignal] that can be used to cancel the upload or timeout the request. The `maxConcurrentUploads` is an optional number that can be used to limit the number of concurrent uploads. The `throwOnFailure` is an optional boolean that can be used to throw an error if any upload fails. The `manifestOptions` is an optional object that can be used to configure the manifest file, including a custom index file, fallback file, or whether to disable manifests altogether. Manifests are enabled by default. The `folderIndex` is an optional [folder index](#incremental-folder-uploads) that skips files already on Arweave. The `manifestDataItemOpts` is an optional object that configures the manifest data item only, and defaults to `dataItemOpts`.
 
 ##### NodeJS Upload Folder
 
@@ -881,6 +881,176 @@ const { manifest, fileResponses, manifestResponse } = await turbo.uploadFolder({
   },
 });
 ```
+
+##### Incremental Folder Uploads
+
+An Arweave upload is permanent, so paying twice for byte identical files buys
+nothing. Pass a `folderIndex` and `uploadFolder` hashes every file, asks the
+index which of those files already have a data item on Arweave, and signs,
+uploads and pays for only the rest. The manifest is assembled from the ids that
+were already known plus the ids of whatever this run uploaded.
+
+```typescript
+import {
+  composeFolderIndex,
+  createChainFolderIndex,
+  createFileFolderIndex,
+} from '@ardrive/turbo-sdk/node';
+
+const folderIndex = composeFolderIndex([
+  // Fast local cache, kept outside the folder being uploaded.
+  createFileFolderIndex({ filePath: '.turbo/folder-index.jsonl' }),
+  // Fallback for a machine that has never deployed before, e.g. a CI runner.
+  // getPublicKey() is the one form every signer type can produce.
+  createChainFolderIndex({ owner: await turbo.signer.getPublicKey() }),
+]);
+
+const { manifest, manifestResponse, folderIndexSummary } =
+  await turbo.uploadFolder({
+    folderPath: path.join(__dirname, './dist'),
+    folderIndex,
+    // Deploy varying tags belong on the manifest, which is rewritten every time.
+    manifestDataItemOpts: {
+      tags: [{ name: 'Git-Commit', value: process.env.GITHUB_SHA }],
+    },
+  });
+
+console.log(folderIndexSummary);
+// { totalFiles: 143, uploadedFiles: 2, reusedFiles: 141, ... }
+```
+
+###### What a reused file is matched on
+
+An index key is `<sha-256 of the bytes>.<sha-256 of the tags>`, and both halves
+matter. Keying on the bytes alone would reuse a data item whose tags are not the
+ones you asked for: an empty `a.css` and an empty `b.js` hash identically, and
+sharing one item between them would serve JavaScript as `text/css`, which a
+browser refuses to execute. Covering the tags means **a reused data item is
+always exactly the data item this call would otherwise have created** — same
+bytes, same `Content-Type`, same `dataItemOpts` tags.
+
+Files uploaded with an index carry one extra tag, `File-SHA256`, holding the
+sha-256 of their own bytes. That tag is what `createChainFolderIndex` filters on.
+
+###### The trade-off this buys, and how you find out
+
+The corollary is a real cost cliff, so it is worth being blunt about. **A per
+file tag whose value changes between deploys changes every key, and re-uploads
+the whole folder at full price.** A commit sha, a build number or a timestamp in
+`dataItemOpts` means you never reuse anything, and the deploy still succeeds, so
+nothing about the run looks wrong except the bill.
+
+That is deliberate. The alternative — keying on bytes alone — reuses an item
+tagged with a _previous_ deploy's commit sha, so the tags on chain quietly stop
+describing what is on chain. A wrong bill is recoverable; a data item that lies
+about itself is permanent. So the index errs towards paying again.
+
+To keep the cliff from being silent, `uploadFolder` logs a warning when a file
+it is about to upload has bytes the index already holds **under a different set
+of tags**, which is what a deploy-varying per file tag looks like:
+
+```
+3 of the 3 file(s) this run is about to upload are already on Arweave byte for
+byte, under a different set of tags. Their content has not changed but their
+tags have, so they are being paid for again. A folder index key covers the tags
+on a file as well as its bytes. That is usually a tag in dataItemOpts whose
+value changes between deploys -- a commit sha, a build number, a timestamp -- in
+which case move it to manifestDataItemOpts rather than paying for these files
+again. It can also be a file that kept its content but changed its Content-Type,
+through a rename or a new extension, which is expected and costs one upload.
+```
+
+Very little else produces that signal: a folder the index has never seen has
+unknown bytes, and a layer that could not be reached reports nothing known, so
+neither triggers it. A file that kept its content but changed its Content-Type
+through a rename does trigger it, and the message says so. It also fires for one
+drifted file among a hundred reused ones, not only when everything misses. A
+layer that does not implement the optional `knownContentHashes` cannot answer
+the question and stays quiet. The fix, whenever it is a varying tag, is always
+the same: move it to `manifestDataItemOpts`, since the manifest is rewritten on
+every deploy anyway.
+
+###### Index layers
+
+| Layer                                              | Where it lives   | Survives a fresh checkout |
+| -------------------------------------------------- | ---------------- | ------------------------- |
+| `createMemoryFolderIndex(seed?)`                   | memory           | no                        |
+| `createFileFolderIndex({ filePath })` (NodeJS)     | a JSON lines log | only if the file is kept  |
+| `createChainFolderIndex({ owner, appName?, ... })` | gateway GraphQL  | yes                       |
+| `composeFolderIndex([...])`                        | layers the above | --                        |
+
+Reads fall through a composed index in order and writes go to every layer that
+is not `readOnly`, so an id recovered from the gateway is cached locally for the
+next run. **A layer that throws is skipped, not propagated** — a full disk under
+the file layer must not stop the memory layer from holding ids the run has
+already paid for, and an unreachable gateway must not stop the local cache from
+answering. Pass a `logger` as the second argument to `composeFolderIndex` to see
+which layer was skipped and why.
+
+`createFileFolderIndex` writes an append-only log, one JSON record per line,
+compacted when it is next loaded. It appends after every single upload rather
+than rewriting at the end of the run, so a deploy killed part way through never
+loses a file it has paid for — and appending is constant work per file, where
+rewriting the whole file per upload is quadratic and costs minutes and gigabytes
+of writes on a first deploy of a few thousand files. It is also the more crash
+safe shape: a process killed mid write can only damage the last line, which is
+dropped on load, where a torn rewrite loses every id in the file.
+
+An index is a cache. A `get` or `resolve` that throws is treated as a miss and
+logged — an unreachable gateway costs you a re-upload, it does not fail your
+deploy. Anything with `get` and `set` is a valid index, so implement
+`TurboFolderUploadIndex` to back one with a database, an object store, or a CI
+cache. Treat the keys as opaque.
+
+###### Telling a gateway whose uploads to sweep
+
+`createChainFolderIndex` needs the owner **a gateway indexes uploads under**,
+which is the base64url sha-256 of the signer's public key. Pass
+`await turbo.signer.getPublicKey()` and the SDK derives it, which works for
+every signer type.
+
+A bare string is deliberately rejected, because it cannot be disambiguated: a
+raw 32 byte ed25519 public key base64urls to exactly 43 characters, the same
+shape as an owner address, and guessing wrong means the sweep matches nothing
+and the whole folder is re-uploaded with no error at all. Say which one you
+have — `{ publicKey }` or `{ address }` — if you are not passing the bytes.
+
+An `0x...` Ethereum address or a base58 Solana address is not accepted, because
+`owners:` on a gateway does not match those. (Verified against `arweave.net`:
+`owners` matches the 43 character address and returns nothing for the raw public
+key, so the conversion has to happen client side.)
+
+###### Trust model
+
+The sweep is scoped to `owners: [your own address]`, so it can only ever find
+items you signed. Within that scope, `File-SHA256` is **self asserted** — it is
+a tag your own past uploads wrote, not something a gateway verifies against the
+bytes — and the index trusts it. That is safe for uploads this SDK made, since it
+only ever writes a hash it computed from the file in front of it.
+
+It stops being safe if you point `hashTagName` at a tag you were already using
+for something else. Any of your own past items carrying 64 hex characters under
+that name would be treated as a candidate, and one whose tag set happens to
+match would be reused — putting a manifest path in front of unrelated bytes.
+Only override `hashTagName` for a tag written by this feature.
+
+###### In the browser
+
+`createMemoryFolderIndex`, `createChainFolderIndex` and `composeFolderIndex` all
+work in the browser. `createFileFolderIndex` is NodeJS only, since there is no
+filesystem to write to; persist the map yourself and seed
+`createMemoryFolderIndex` with it, or rely on the chain index.
+
+Note that hashing differs by platform. NodeJS streams each file through a
+`node:crypto` digest, so file size is not a concern. The browser has no streaming
+WebCrypto digest, so each `File` is buffered whole before it is hashed — a very
+large `File` can exhaust the tab.
+
+###### Known limitation
+
+A gateway indexes an upload minutes after it lands, so two machines deploying the
+same brand new file at the same moment can each pay for it once. Only the bill is
+affected, and only for genuinely new bytes -- the manifest is correct either way.
 
 #### `topUpWithTokens({ tokenAmount, feeMultiplier, turboCreditDestinationAddress })`
 

--- a/packages/turbo-sdk/src/common/folderIndex.test.ts
+++ b/packages/turbo-sdk/src/common/folderIndex.test.ts
@@ -1,0 +1,657 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import { createHash } from 'node:crypto';
+import { describe, it } from 'node:test';
+
+import { TurboFolderUploadIndex, TurboLogger } from '../types.js';
+import {
+  contentHashTagName,
+  folderIndexKey,
+  isValidFolderIndexKey,
+} from '../utils/folderIndex.js';
+import {
+  composeFolderIndex,
+  createChainFolderIndex,
+  createMemoryFolderIndex,
+} from './folderIndex.js';
+
+const hashA = 'a'.repeat(64);
+const hashB = 'b'.repeat(64);
+const idA = 'idA'.padEnd(43, 'x');
+const idB = 'idB'.padEnd(43, 'x');
+const ownerAddress = 'owner'.padEnd(43, 'x');
+
+/**
+ * Independent of the SDK helper under test: base64url of the sha-256 of the
+ * public key is what a gateway matches `owners:` on.
+ */
+const expectedAddress = (publicKey: Uint8Array) =>
+  createHash('sha256')
+    .update(Buffer.from(publicKey))
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+const b64url = (bytes: Uint8Array) =>
+  Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+// A raw ed25519 public key -- Solana, and the ArNS/ario signers -- is 32 bytes,
+// which base64urls to exactly 43 characters: the same shape as an owner
+// address. Sniffing a bare string cannot tell them apart.
+const ed25519PublicKey = Buffer.alloc(32, 7);
+const secp256k1PublicKey = Buffer.alloc(65, 3);
+const rsaPublicKey = Buffer.alloc(512, 5);
+
+const tagsFor = (contentHash: string, contentType: string) => [
+  { name: 'Content-Type', value: contentType },
+  { name: contentHashTagName, value: contentHash },
+];
+
+const keyFor = (contentHash: string, contentType = 'text/css') =>
+  folderIndexKey({ contentHash, tags: tagsFor(contentHash, contentType) });
+
+const gatewayResponse = (edges: unknown[], hasNextPage = false) =>
+  ({
+    ok: true,
+    json: async () => ({
+      data: { transactions: { pageInfo: { hasNextPage }, edges } },
+    }),
+  }) as unknown as Response;
+
+const collectingLogger = () => {
+  const errors: string[] = [];
+  const logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: (message: string) => {
+      errors.push(message);
+    },
+    setLogLevel: () => undefined,
+    setLogFormat: () => undefined,
+  } as unknown as TurboLogger;
+  return { logger, errors };
+};
+
+const throwingLayer = (
+  name: string,
+  overrides: Partial<TurboFolderUploadIndex> = {},
+): TurboFolderUploadIndex => ({
+  name,
+  get: () => {
+    throw new Error(`${name} is down`);
+  },
+  set: () => {
+    throw new Error(`${name} is down`);
+  },
+  resolve: async () => {
+    throw new Error(`${name} is down`);
+  },
+  knownContentHashes: () => {
+    throw new Error(`${name} is down`);
+  },
+  entries: () => {
+    throw new Error(`${name} is down`);
+  },
+  ...overrides,
+});
+
+describe('folder index keys', () => {
+  it('are a bytes digest and a tags digest, so tags cannot be swapped silently', async () => {
+    const asCss = await keyFor(hashA, 'text/css');
+    const asJs = await keyFor(hashA, 'text/javascript');
+
+    assert.equal(isValidFolderIndexKey(asCss), true);
+    assert.notEqual(asCss, asJs);
+    // The bytes half is shared and stays readable, so a gateway sweep can
+    // filter on the content hash tag.
+    assert.equal(asCss.slice(0, 64), hashA);
+    assert.equal(asJs.slice(0, 64), hashA);
+  });
+
+  it('do not depend on the order the tags are listed in', async () => {
+    const forwards = await folderIndexKey({
+      contentHash: hashA,
+      tags: tagsFor(hashA, 'text/css'),
+    });
+    const backwards = await folderIndexKey({
+      contentHash: hashA,
+      tags: [...tagsFor(hashA, 'text/css')].reverse(),
+    });
+    assert.equal(forwards, backwards);
+  });
+
+  it('order tags by code unit, not by locale', async () => {
+    // localeCompare is not a total order over distinct strings: an NFC and an
+    // NFD spelling compare equal without being equal, so a sort that used it
+    // could leave these two tag sets in different orders on two machines and
+    // hash the same file differently.
+    const nfc = 'caf\u00e9';
+    const nfd = 'cafe\u0301';
+    assert.notEqual(nfc, nfd);
+    assert.equal(nfc.localeCompare(nfd), 0);
+
+    const forwards = await folderIndexKey({
+      contentHash: hashA,
+      tags: [
+        { name: 'a', value: nfc },
+        { name: 'a', value: nfd },
+      ],
+    });
+    const backwards = await folderIndexKey({
+      contentHash: hashA,
+      tags: [
+        { name: 'a', value: nfd },
+        { name: 'a', value: nfc },
+      ],
+    });
+    assert.equal(forwards, backwards);
+  });
+
+  it('do not collide when a tag value contains the record delimiters', async () => {
+    // A delimiter-joined encoding hashes these two tag sets identically, and a
+    // collision is a wrong reuse -- the one thing the composite key exists to
+    // rule out. Tag values are arbitrary bytes, so both of these are legal.
+    const embedded = await folderIndexKey({
+      contentHash: hashA,
+      tags: [{ name: 'a', value: 'b\u0001c\u0000d' }],
+    });
+    const separate = await folderIndexKey({
+      contentHash: hashA,
+      tags: [
+        { name: 'a', value: 'b' },
+        { name: 'c', value: 'd' },
+      ],
+    });
+    assert.notEqual(embedded, separate);
+  });
+});
+
+describe('createMemoryFolderIndex', () => {
+  it('round trips a key to a data item id', async () => {
+    const key = await keyFor(hashA);
+    const index = createMemoryFolderIndex();
+
+    assert.equal(await index.get(key), undefined);
+    await index.set(key, idA);
+    assert.equal(await index.get(key), idA);
+  });
+
+  it('drops malformed seed entries rather than publishing a bad id', async () => {
+    const key = await keyFor(hashA);
+    const index = createMemoryFolderIndex({
+      [key]: idA,
+      // A bare content hash was the key format before tags were covered.
+      [hashA]: idB,
+      [await keyFor(hashB)]: 'not-an-id',
+    });
+    assert.deepEqual(await index.entries?.(), { [key]: idA });
+  });
+
+  it('reports bytes it holds under any tag set', async () => {
+    const index = createMemoryFolderIndex({
+      [await keyFor(hashA, 'text/css')]: idA,
+    });
+    assert.deepEqual(await index.knownContentHashes?.([hashA, hashB]), [hashA]);
+  });
+});
+
+describe('composeFolderIndex', () => {
+  it('falls through reads in order and returns the first hit', async () => {
+    const key = await keyFor(hashA);
+    const front = createMemoryFolderIndex();
+    const back = createMemoryFolderIndex({ [key]: idA });
+
+    assert.equal(await composeFolderIndex([front, back]).get(key), idA);
+  });
+
+  it('writes to every writable layer and skips read only ones', async () => {
+    const key = await keyFor(hashA);
+    const writable = createMemoryFolderIndex();
+    const readOnly: TurboFolderUploadIndex = {
+      name: 'readOnly',
+      readOnly: true,
+      get: () => undefined,
+      set: () => {
+        assert.fail('a read only layer must never be written to');
+      },
+    };
+
+    await composeFolderIndex([writable, readOnly]).set(key, idA);
+    assert.equal(await writable.get(key), idA);
+  });
+
+  it('caches ids recovered from a read only layer into the writable ones', async () => {
+    const key = await keyFor(hashA);
+    const writable = createMemoryFolderIndex();
+    const readOnly: TurboFolderUploadIndex = {
+      name: 'readOnly',
+      readOnly: true,
+      get: () => undefined,
+      set: () => undefined,
+      resolve: async () => ({ [key]: idA }),
+    };
+
+    const index = composeFolderIndex([writable, readOnly]);
+    assert.deepEqual(await index.resolve?.([key]), { [key]: idA });
+    assert.equal(await writable.get(key), idA);
+  });
+
+  it('consults a later layer when an earlier get throws', async () => {
+    const key = await keyFor(hashA);
+    const { logger, errors } = collectingLogger();
+
+    const index = composeFolderIndex(
+      [throwingLayer('broken'), createMemoryFolderIndex({ [key]: idA })],
+      { logger },
+    );
+
+    assert.equal(await index.get(key), idA);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /broken failed to read/);
+  });
+
+  it('consults a later layer when an earlier resolve throws', async () => {
+    const key = await keyFor(hashA);
+    const { logger } = collectingLogger();
+
+    const index = composeFolderIndex(
+      [
+        throwingLayer('broken'),
+        {
+          name: 'good',
+          readOnly: true,
+          get: () => undefined,
+          set: () => undefined,
+          resolve: async () => ({ [key]: idA }),
+        },
+      ],
+      { logger },
+    );
+
+    assert.deepEqual(await index.resolve?.([key]), { [key]: idA });
+  });
+
+  it('still writes to a later layer when an earlier set throws', async () => {
+    // A read only or full disk under the file layer must not discard ids the
+    // run has already paid for, which the memory layer would have kept.
+    const key = await keyFor(hashA);
+    const memory = createMemoryFolderIndex();
+    const { logger, errors } = collectingLogger();
+
+    const index = composeFolderIndex([throwingLayer('full-disk'), memory], {
+      logger,
+    });
+    await index.set(key, idA);
+
+    assert.equal(await memory.get(key), idA);
+    assert.match(errors[0], /full-disk failed to write/);
+  });
+
+  it('unions knownContentHashes across layers and skips a throwing one', async () => {
+    const { logger } = collectingLogger();
+    const index = composeFolderIndex(
+      [
+        throwingLayer('broken'),
+        createMemoryFolderIndex({ [await keyFor(hashA)]: idA }),
+      ],
+      { logger },
+    );
+    assert.deepEqual(await index.knownContentHashes?.([hashA, hashB]), [hashA]);
+  });
+});
+
+describe('createChainFolderIndex owner', () => {
+  const fetchImpl = (async () =>
+    gatewayResponse([])) as unknown as typeof fetch;
+
+  const addressUsedBy = async (
+    index: TurboFolderUploadIndex,
+    requests: Record<string, unknown>[],
+  ) => {
+    await index.resolve?.([await keyFor(hashA)]);
+    return (requests[0].variables as { owner: string }).owner;
+  };
+
+  const recordingFetch = () => {
+    const requests: Record<string, unknown>[] = [];
+    const impl = (async (_url: string, init: { body: string }) => {
+      requests.push(JSON.parse(init.body));
+      return gatewayResponse([]);
+    }) as unknown as typeof fetch;
+    return { impl, requests };
+  };
+
+  it('hashes a raw ed25519 public key rather than passing it through', async () => {
+    // Regression: 32 bytes base64urls to exactly 43 characters, so a
+    // character-count check treats an ed25519 key as an address, sends it
+    // unhashed, matches nothing, and re-uploads the folder with no error.
+    assert.equal(b64url(ed25519PublicKey).length, 43);
+
+    const { impl, requests } = recordingFetch();
+    const index = createChainFolderIndex({
+      owner: ed25519PublicKey,
+      fetchImpl: impl,
+    });
+
+    const used = await addressUsedBy(index, requests);
+    assert.equal(used, expectedAddress(ed25519PublicKey));
+    assert.notEqual(used, b64url(ed25519PublicKey));
+  });
+
+  it('hashes a secp256k1 and an RSA public key', async () => {
+    for (const publicKey of [secp256k1PublicKey, rsaPublicKey]) {
+      const { impl, requests } = recordingFetch();
+      const index = createChainFolderIndex({
+        owner: publicKey,
+        fetchImpl: impl,
+      });
+      assert.equal(
+        await addressUsedBy(index, requests),
+        expectedAddress(publicKey),
+      );
+    }
+  });
+
+  it('hashes a base64url public key given under { publicKey }', async () => {
+    const { impl, requests } = recordingFetch();
+    const index = createChainFolderIndex({
+      owner: { publicKey: b64url(ed25519PublicKey) },
+      fetchImpl: impl,
+    });
+    assert.equal(
+      await addressUsedBy(index, requests),
+      expectedAddress(ed25519PublicKey),
+    );
+  });
+
+  it('passes an { address } through untouched', async () => {
+    const { impl, requests } = recordingFetch();
+    const index = createChainFolderIndex({
+      owner: { address: ownerAddress },
+      fetchImpl: impl,
+    });
+    assert.equal(await addressUsedBy(index, requests), ownerAddress);
+  });
+
+  it('refuses a public key that is not one of the real key sizes', () => {
+    // Declaring which one you have is not the same as having it. Every one of
+    // these hashes to a well formed address that matches nothing, which is the
+    // silent full price re-upload the union exists to prevent.
+    for (const publicKey of [
+      new Uint8Array(0),
+      new Uint8Array(1),
+      new Uint8Array(31),
+      new Uint8Array(33),
+      new Uint8Array(64),
+    ]) {
+      assert.throws(
+        () => createChainFolderIndex({ owner: publicKey, fetchImpl }),
+        /must be an ed25519 \(32 byte\), secp256k1 \(65 byte\) or RSA \(512 byte\) public key/,
+        `${publicKey.length} bytes`,
+      );
+    }
+    assert.throws(
+      () => createChainFolderIndex({ owner: { publicKey: 'abc' }, fetchImpl }),
+      /got 2 bytes/,
+    );
+    assert.throws(
+      () => createChainFolderIndex({ owner: { publicKey: '!!!' }, fetchImpl }),
+      /must be base64url/,
+    );
+  });
+
+  it('refuses a bare string, which cannot be disambiguated', () => {
+    assert.throws(
+      () =>
+        createChainFolderIndex({
+          owner: b64url(ed25519PublicKey) as never,
+          fetchImpl,
+        }),
+      /ambiguous/,
+    );
+  });
+
+  it('rejects a native address given as an { address }', () => {
+    assert.throws(
+      () =>
+        createChainFolderIndex({
+          owner: { address: '0x20c1DF6f3310600c8396111EB5182af9213828Dc' },
+          fetchImpl,
+        }),
+      /not what a gateway indexes/,
+    );
+  });
+});
+
+describe('createChainFolderIndex', () => {
+  const fetchReturning = (
+    ...responses: Response[]
+  ): { fetchImpl: typeof fetch; requests: Record<string, unknown>[] } => {
+    const requests: Record<string, unknown>[] = [];
+    let call = 0;
+    const fetchImpl = (async (_url: string, init: { body: string }) => {
+      requests.push(JSON.parse(init.body));
+      return responses[Math.min(call++, responses.length - 1)];
+    }) as unknown as typeof fetch;
+    return { fetchImpl, requests };
+  };
+
+  const owner = { address: ownerAddress };
+
+  it('resolves keys it can reconstruct from a past upload', async () => {
+    const key = await keyFor(hashA, 'text/css');
+    const otherKey = await keyFor(hashB, 'text/css');
+    const { fetchImpl, requests } = fetchReturning(
+      gatewayResponse([
+        {
+          cursor: 'cursor-1',
+          node: { id: idA, tags: tagsFor(hashA, 'text/css') },
+        },
+      ]),
+    );
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    const resolved = await index.resolve?.([key, otherKey]);
+
+    assert.deepEqual(resolved, { [key]: idA });
+    assert.equal(await index.get(key), idA);
+    assert.equal(requests.length, 1);
+    // The query filters on the bytes half, which is all a gateway can index.
+    assert.deepEqual((requests[0].variables as { hashes: string[] }).hashes, [
+      hashA,
+      hashB,
+    ]);
+  });
+
+  it('does not resolve an item whose tags differ, but remembers its bytes', async () => {
+    const wantedAsJs = await keyFor(hashA, 'text/javascript');
+    const { fetchImpl } = fetchReturning(
+      gatewayResponse([
+        {
+          cursor: 'cursor-1',
+          node: { id: idA, tags: tagsFor(hashA, 'text/css') },
+        },
+      ]),
+    );
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    assert.deepEqual(await index.resolve?.([wantedAsJs]), {});
+    // The bytes-only GraphQL filter hands this over for free, and it is the
+    // whole basis of the stale-tag diagnostic.
+    assert.deepEqual(await index.knownContentHashes?.([hashA, hashB]), [hashA]);
+  });
+
+  it('reports nothing known when the sweep never ran', async () => {
+    const { fetchImpl } = fetchReturning(gatewayResponse([]));
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    assert.deepEqual(await index.knownContentHashes?.([hashA]), []);
+  });
+
+  it('never writes, so an id it did not see stays unknown', async () => {
+    const key = await keyFor(hashA);
+    const { fetchImpl } = fetchReturning(gatewayResponse([]));
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    await index.set(key, idA);
+    assert.equal(await index.get(key), undefined);
+    assert.deepEqual(await index.resolve?.([key]), {});
+  });
+
+  it('throws when the gateway rejects the query', async () => {
+    const { fetchImpl } = fetchReturning({
+      ok: false,
+      status: 503,
+    } as unknown as Response);
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    await assert.rejects(
+      async () => index.resolve?.([await keyFor(hashA)]),
+      /503/,
+    );
+  });
+
+  it('throws rather than crashing when the payload has no transactions', async () => {
+    const { fetchImpl } = fetchReturning({
+      ok: true,
+      json: async () => ({ errors: [{ message: 'bad query' }] }),
+    } as unknown as Response);
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    await assert.rejects(
+      async () => index.resolve?.([await keyFor(hashA)]),
+      /bad query/,
+    );
+  });
+
+  it('skips edges and nodes that are not the shape it expects', async () => {
+    const key = await keyFor(hashA, 'text/css');
+    const { fetchImpl } = fetchReturning(
+      gatewayResponse([
+        null,
+        { cursor: 'c1' },
+        { cursor: 'c2', node: { id: idB } },
+        { cursor: 'c3', node: { id: idB, tags: null } },
+        { cursor: 'c4', node: { id: idB, tags: [null, { name: 'X' }] } },
+        { cursor: 'c5', node: { id: null, tags: tagsFor(hashA, 'text/css') } },
+        { cursor: 'c6', node: { id: idA, tags: tagsFor(hashA, 'text/css') } },
+      ]),
+    );
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    assert.deepEqual(await index.resolve?.([key]), { [key]: idA });
+  });
+
+  it('stops on an empty page rather than re-issuing the same query', async () => {
+    const { fetchImpl, requests } = fetchReturning(gatewayResponse([], true));
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    assert.deepEqual(await index.resolve?.([await keyFor(hashA)]), {});
+    assert.equal(requests.length, 1);
+  });
+
+  it('aborts the sweep when the caller aborts the upload', async () => {
+    const controller = new AbortController();
+    const fetchImpl = (async (_url: string, init: { signal: AbortSignal }) => {
+      controller.abort(new Error('caller gave up'));
+      assert.equal(init.signal.aborted, true);
+      throw init.signal.reason;
+    }) as unknown as typeof fetch;
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    await assert.rejects(
+      async () =>
+        index.resolve?.([await keyFor(hashA)], { signal: controller.signal }),
+      /caller gave up/,
+    );
+  });
+
+  it('times out a gateway that sends headers and then stalls the body', async () => {
+    // Headers arriving is not the request finishing. If the guard is released
+    // when fetch resolves, this hangs forever -- and uploadFolder awaits it
+    // inline, so the whole upload hangs with it.
+    const fetchImpl = (async (_url: string, init: { signal: AbortSignal }) => ({
+      ok: true,
+      json: () =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            'abort',
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+        }),
+    })) as unknown as typeof fetch;
+
+    const index = createChainFolderIndex({ owner, fetchImpl, timeoutMs: 50 });
+    await assert.rejects(
+      async () => index.resolve?.([await keyFor(hashA)]),
+      /Timed out after 50ms/,
+    );
+  });
+
+  it('aborts a stalled body when the caller aborts the upload', async () => {
+    const controller = new AbortController();
+    const fetchImpl = (async (_url: string, init: { signal: AbortSignal }) => ({
+      ok: true,
+      json: () =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            'abort',
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+          setTimeout(() => controller.abort(new Error('caller gave up')), 5);
+        }),
+    })) as unknown as typeof fetch;
+
+    const index = createChainFolderIndex({
+      owner,
+      fetchImpl,
+      timeoutMs: 60_000,
+    });
+    await assert.rejects(
+      async () =>
+        index.resolve?.([await keyFor(hashA)], { signal: controller.signal }),
+      /caller gave up/,
+    );
+  });
+
+  it('rejects page sizes, page counts and timeouts that are not usable', () => {
+    for (const params of [
+      { pageSize: 0 },
+      { pageSize: -1 },
+      // Integer to Number.isInteger, but stringifies as "1e+21" and earns a 400.
+      { pageSize: 1e21 },
+      { pageSize: '100 first:1 x' as unknown as number },
+      // Silently disabled the sweep altogether.
+      { maxPages: 0 },
+      { timeoutMs: 0 },
+      { timeoutMs: -5 },
+    ]) {
+      assert.throws(
+        () => createChainFolderIndex({ owner, ...params }),
+        /must be an integer between/,
+        JSON.stringify(params),
+      );
+    }
+  });
+});

--- a/packages/turbo-sdk/src/common/folderIndex.ts
+++ b/packages/turbo-sdk/src/common/folderIndex.ts
@@ -201,6 +201,7 @@ export function createChainFolderIndex({
   pageSize = 100,
   timeoutMs = 30_000,
   fetchImpl = fetch,
+  logger,
 }: ChainFolderUploadIndexParams): TurboFolderUploadIndex {
   const ownerAddress = resolveOwnerAddress(owner);
   const first = requirePositiveInteger(pageSize, 'pageSize', 1000);
@@ -237,6 +238,9 @@ export function createChainFolderIndex({
   return {
     name: `chain:${gatewayUrl}`,
     readOnly: true,
+    // Declared so `uploadFolder` writes the tag this sweep filters on. Without
+    // it a non-default `hashTagName` matches nothing, on every run, silently.
+    hashTagName,
     get: (key) => map.get(key),
     set: () => undefined,
     knownContentHashes: (contentHashes) =>
@@ -250,12 +254,15 @@ export function createChainFolderIndex({
 
       const found: Record<string, string> = {};
       let cursor: string | null = null;
+      let pagesWalked = 0;
+      let moreToWalk = false;
 
       for (
         let page = 0;
         page < pageLimit && Object.keys(found).length < wanted.size;
         page++
       ) {
+        pagesWalked++;
         const abort = abortAfter(requestTimeoutMs, options?.signal);
         let body;
         try {
@@ -332,6 +339,29 @@ export function createChainFolderIndex({
         if (transactions.pageInfo?.hasNextPage !== true) {
           break;
         }
+        moreToWalk = true;
+      }
+
+      // Running out of pages is not the same as running out of matches, and it
+      // is the one outcome that costs money without looking like anything: the
+      // unresolved files are re-uploaded at full price, on every deploy, and
+      // the summary reports them as ordinary new files. `pageSize * maxPages`
+      // caps how many items a sweep can ever see, so a folder larger than that
+      // cannot resolve in full however many times it is run.
+      const resolved = Object.keys(found).length;
+      if (pagesWalked >= pageLimit && moreToWalk && resolved < wanted.size) {
+        logger?.warn(
+          `The folder index sweep of ${gatewayUrl} stopped at its ${pageLimit} page limit with ` +
+            `${wanted.size - resolved} of ${
+              wanted.size
+            } file(s) still unresolved, and the gateway ` +
+            'had more to give. Those files are about to be uploaded and paid for again even though ' +
+            `they may already be on Arweave. A sweep can see at most pageSize * maxPages items ` +
+            `(${first} * ${pageLimit} = ${
+              first * pageLimit
+            } here), so raise maxPages or pageSize, ` +
+            'or put a persistent local index in front of this one.',
+        );
       }
 
       return found;
@@ -366,6 +396,27 @@ export function composeFolderIndex(
 
   const writableLayers = stack.filter((layer) => layer.readOnly !== true);
 
+  // Every layer that cares which tag holds a content hash has to want the same
+  // one, because `uploadFolder` writes exactly one tag per file. Two layers
+  // disagreeing is not something a run can degrade around: whichever one loses
+  // matches nothing, for ever, without an error.
+  const declaredHashTagNames = [
+    ...new Set(
+      stack
+        .map((layer) => layer.hashTagName)
+        .filter((name): name is string => name !== undefined),
+    ),
+  ];
+  if (declaredHashTagNames.length > 1) {
+    throw new ProvidedInputError(
+      `composeFolderIndex layers disagree about which tag holds a file's content hash: ${declaredHashTagNames
+        .map((name) => `'${name}'`)
+        .join(
+          ', ',
+        )}. uploadFolder writes one tag per file, so every layer that declares one must declare the same one.`,
+    );
+  }
+
   const failed = (
     layer: TurboFolderUploadIndex,
     what: string,
@@ -393,6 +444,7 @@ export function composeFolderIndex(
       .map((layer) => layer.name ?? 'anonymous')
       .join(', ')})`,
     readOnly: writableLayers.length === 0,
+    hashTagName: declaredHashTagNames[0],
     get: async (key) => {
       for (const layer of stack) {
         try {

--- a/packages/turbo-sdk/src/common/folderIndex.ts
+++ b/packages/turbo-sdk/src/common/folderIndex.ts
@@ -1,0 +1,471 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChainFolderUploadIndexOwner,
+  ChainFolderUploadIndexParams,
+  ComposeFolderUploadIndexParams,
+  TurboFolderUploadIndex,
+} from '../types.js';
+import { fromB64Url, ownerToAddress, toB64Url } from '../utils/base64.js';
+import { isValidArweaveBase64URL } from '../utils/common.js';
+import { ProvidedInputError } from '../utils/errors.js';
+import {
+  contentHashFromFolderIndexKey,
+  contentHashTagName,
+  folderIndexKey,
+  isValidContentHash,
+  isValidFolderIndexKey,
+} from '../utils/folderIndex.js';
+
+/**
+ * The base64url address a gateway indexes an upload under.
+ *
+ * Deliberately refuses to guess. A gateway matches `owners:` on the base64url
+ * sha-256 of the signer's public key, and a raw 32 byte ed25519 public key
+ * base64urls to exactly 43 characters -- indistinguishable from that address.
+ * Sniffing the shape of a bare string therefore has a silent failure mode that
+ * costs real money: the unhashed key matches nothing, every file misses, and
+ * the whole folder is re-uploaded with no error anywhere. So the caller says
+ * which one they have, and `getPublicKey()` bytes are taken directly.
+ */
+function resolveOwnerAddress(owner: ChainFolderUploadIndexOwner): string {
+  const fromPublicKey = (publicKey: Uint8Array | string): string => {
+    if (typeof publicKey === 'string' && !/^[a-zA-Z0-9_-]+$/.test(publicKey)) {
+      throw new ProvidedInputError(
+        'createChainFolderIndex owner.publicKey must be base64url, or the raw bytes from await turbo.signer.getPublicKey()',
+      );
+    }
+    const raw =
+      typeof publicKey === 'string'
+        ? fromB64Url(publicKey)
+        : Buffer.from(publicKey);
+    // Declaring which one you have is not the same as having it. Anything gets
+    // hashed to a well formed address that simply matches nothing, which is the
+    // same silent full price re-upload the tagged union exists to prevent, one
+    // level in. These are the key sizes this SDK's signers produce.
+    if (!publicKeyByteLengths.has(raw.length)) {
+      throw new ProvidedInputError(
+        `createChainFolderIndex owner.publicKey must be an ed25519 (32 byte), secp256k1 (65 byte) or RSA (512 byte) public key, got ${raw.length} bytes. Pass await turbo.signer.getPublicKey(), or use { address } if what you have is an owner address.`,
+      );
+    }
+    return ownerToAddress(toB64Url(raw));
+  };
+
+  if (owner instanceof Uint8Array) {
+    return fromPublicKey(owner);
+  }
+  if (owner !== null && typeof owner === 'object') {
+    if (owner.publicKey !== undefined) {
+      return fromPublicKey(owner.publicKey);
+    }
+    if (typeof owner.address === 'string') {
+      if (!isValidArweaveBase64URL(owner.address)) {
+        throw new ProvidedInputError(
+          `createChainFolderIndex owner.address must be a 43 character base64url address, got '${owner.address}'. A native address (an 0x... or a base58 Solana address) is not what a gateway indexes uploads under.`,
+        );
+      }
+      return owner.address;
+    }
+  }
+  throw new ProvidedInputError(
+    'createChainFolderIndex needs owner: await turbo.signer.getPublicKey(), or { publicKey } or { address }. ' +
+      'A bare string is ambiguous -- a 32 byte ed25519 public key and an owner address are both 43 base64url characters -- ' +
+      'and guessing wrong re-uploads the whole folder without an error.',
+  );
+}
+
+/**
+ * What `getPublicKey()` returns across the supported signers: ed25519 for
+ * Solana and ario, uncompressed secp256k1 for Ethereum, Base, Polygon and KYVE,
+ * and a 4096 bit RSA modulus for Arweave.
+ *
+ * A 32 byte value declared as a `publicKey` is still taken at its word, since
+ * an owner address is also 32 bytes and nothing can tell them apart -- that is
+ * why the caller has to say which one they mean.
+ */
+const publicKeyByteLengths = new Set([32, 65, 512]);
+
+function requirePositiveInteger(
+  value: number,
+  name: string,
+  max: number,
+): number {
+  const parsed = Number(value);
+  // `1e21` is an integer to Number.isInteger and stringifies as "1e+21", which
+  // is not a GraphQL Int. An upper bound settles both that and a nonsense page.
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > max) {
+    throw new ProvidedInputError(
+      `createChainFolderIndex ${name} must be an integer between 1 and ${max}, got '${value}'`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * One signal that aborts on whichever comes first, the caller giving up or the
+ * request timing out. `AbortSignal.any` is not available on every supported
+ * runtime, so this is wired by hand.
+ */
+function abortAfter(
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+): { signal: AbortSignal; done: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`Timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  const onAbort = () => controller.abort(signal?.reason);
+  if (signal !== undefined) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  }
+  return {
+    signal: controller.signal,
+    done: () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    },
+  };
+}
+
+const contentHashesOf = (keys: Iterable<string>): Set<string> =>
+  new Set([...keys].map(contentHashFromFolderIndexKey));
+
+/**
+ * An in-memory folder index.
+ *
+ * On its own it only deduplicates identical files within a single
+ * `uploadFolder` call, which `uploadFolder` already does. Its real use is as
+ * the writable floor of a {@link composeFolderIndex} stack, or seeded from a
+ * mapping the caller persisted itself.
+ */
+export function createMemoryFolderIndex(
+  seed: Record<string, string> = {},
+): TurboFolderUploadIndex {
+  const map = new Map(
+    Object.entries(seed).filter(
+      ([key, id]) => isValidFolderIndexKey(key) && isValidArweaveBase64URL(id),
+    ),
+  );
+
+  return {
+    name: 'memory',
+    get: (key) => map.get(key),
+    set: (key, id) => {
+      map.set(key, id);
+    },
+    knownContentHashes: (contentHashes) => {
+      const known = contentHashesOf(map.keys());
+      return contentHashes.filter((contentHash) => known.has(contentHash));
+    },
+    entries: () => Object.fromEntries(map),
+  };
+}
+
+/**
+ * Rebuilds a folder index by sweeping the uploader's own past uploads over a
+ * gateway's GraphQL endpoint, filtering on the `File-SHA256` tag that
+ * index-backed uploads always write.
+ *
+ * Read only, and the only layer that survives a fresh checkout on a machine
+ * that has never deployed before -- a CI runner, most obviously.
+ *
+ * Known limitation: gateways index an upload minutes after it lands, so two
+ * machines deploying the same new file at the same moment will each pay for it
+ * once. The manifest is correct either way; only the bill is affected, and only
+ * for genuinely new bytes.
+ */
+export function createChainFolderIndex({
+  owner,
+  appName,
+  gatewayUrl = 'https://arweave.net',
+  hashTagName = contentHashTagName,
+  maxPages = 20,
+  pageSize = 100,
+  timeoutMs = 30_000,
+  fetchImpl = fetch,
+}: ChainFolderUploadIndexParams): TurboFolderUploadIndex {
+  const ownerAddress = resolveOwnerAddress(owner);
+  const first = requirePositiveInteger(pageSize, 'pageSize', 1000);
+  const pageLimit = requirePositiveInteger(maxPages, 'maxPages', 10_000);
+  const requestTimeoutMs = requirePositiveInteger(
+    timeoutMs,
+    'timeoutMs',
+    24 * 60 * 60 * 1000,
+  );
+
+  const map = new Map<string, string>();
+  // Every content hash a sweep has actually seen on chain, whatever tags the
+  // item carried. The bytes-only GraphQL filter hands this over for free, and
+  // it is the only evidence anywhere that a file's content is already paid for
+  // under a different tag set.
+  const seenContentHashes = new Set<string>();
+
+  // Filtering on the hash tag itself keeps the sweep to items this run cares
+  // about, so a long deployment history costs nothing to walk past.
+  const tagFilter =
+    appName !== undefined
+      ? `tags:[{name:"App-Name",values:[${JSON.stringify(
+          appName,
+        )}]},{name:${JSON.stringify(hashTagName)},values:$hashes}]`
+      : `tags:[{name:${JSON.stringify(hashTagName)},values:$hashes}]`;
+
+  const query = `query($owner:String!,$hashes:[String!]!,$after:String){
+  transactions(owners:[$owner] ${tagFilter} sort:HEIGHT_DESC first:${first} after:$after){
+    pageInfo{hasNextPage}
+    edges{cursor node{id tags{name value}}}
+  }
+}`;
+
+  return {
+    name: `chain:${gatewayUrl}`,
+    readOnly: true,
+    get: (key) => map.get(key),
+    set: () => undefined,
+    knownContentHashes: (contentHashes) =>
+      contentHashes.filter((contentHash) => seenContentHashes.has(contentHash)),
+    resolve: async (keys, options) => {
+      const wanted = new Set(keys.filter(isValidFolderIndexKey));
+      if (wanted.size === 0) {
+        return {};
+      }
+      const hashes = [...contentHashesOf(wanted)];
+
+      const found: Record<string, string> = {};
+      let cursor: string | null = null;
+
+      for (
+        let page = 0;
+        page < pageLimit && Object.keys(found).length < wanted.size;
+        page++
+      ) {
+        const abort = abortAfter(requestTimeoutMs, options?.signal);
+        let body;
+        try {
+          const response = await fetchImpl(`${gatewayUrl}/graphql`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              query,
+              variables: { owner: ownerAddress, hashes, after: cursor },
+            }),
+            signal: abort.signal,
+          });
+          if (!response.ok) {
+            throw new Error(
+              `Failed to query ${gatewayUrl}/graphql for a folder index: ${response.status}`,
+            );
+          }
+          // Read inside the same guard. Headers arriving is not the request
+          // finishing: a gateway that flushes them and then stalls the body
+          // would hang here forever with the timer already cleared and the
+          // caller's abort listener already removed, and `uploadFolder` awaits
+          // this inline.
+          body = await response.json();
+        } finally {
+          abort.done();
+        }
+
+        const transactions = body?.data?.transactions;
+        // A gateway may answer with an error payload, a null field, or a shape
+        // this code has never seen, and every node in a page it does return is
+        // equally untrusted.
+        if (!Array.isArray(transactions?.edges)) {
+          throw new Error(
+            `Failed to query ${gatewayUrl}/graphql for a folder index: ${JSON.stringify(
+              body?.errors ?? body,
+            )}`,
+          );
+        }
+        if (transactions.edges.length === 0) {
+          // `after` only advances from an edge, so a page with none would
+          // re-issue the identical query until maxPages ran out.
+          break;
+        }
+
+        for (const edge of transactions.edges) {
+          if (typeof edge?.cursor === 'string') {
+            cursor = edge.cursor;
+          }
+          const node = edge?.node;
+          const tags = node?.tags;
+          if (typeof node?.id !== 'string' || !Array.isArray(tags)) {
+            continue;
+          }
+          const contentHash = tags.find((tag) => tag?.name === hashTagName)
+            ?.value;
+          if (!isValidContentHash(contentHash)) {
+            continue;
+          }
+          // Seen on chain under whatever tags this item happens to carry. A
+          // key that does not match is still worth remembering as bytes that
+          // are already paid for.
+          seenContentHashes.add(contentHash);
+          // A node carries exactly the tags that were written, so the key can
+          // be recomputed and matched against the ones this run needs.
+          const key = await folderIndexKey({ contentHash, tags });
+          // Newest first, and every upload of these exact bytes and tags is
+          // equally valid, so the first sighting wins.
+          if (wanted.has(key) && found[key] === undefined) {
+            found[key] = node.id;
+            map.set(key, node.id);
+          }
+        }
+
+        if (transactions.pageInfo?.hasNextPage !== true) {
+          break;
+        }
+      }
+
+      return found;
+    },
+    entries: () => Object.fromEntries(map),
+  };
+}
+
+/**
+ * Layers folder indexes: reads fall through in order, writes go to every layer
+ * that is not read only.
+ *
+ * The usual stack is a local cache in front of a chain index -- the cache
+ * answers instantly on a developer machine, and the chain index is what a CI
+ * runner with an empty working directory falls back to.
+ *
+ * A layer that throws is skipped, not propagated. That is the whole point of
+ * stacking them: a full disk under the file layer must not stop the memory
+ * layer from holding ids the run has already paid for, and an unreachable
+ * gateway must not stop the local cache from answering.
+ */
+export function composeFolderIndex(
+  layers: (TurboFolderUploadIndex | undefined)[],
+  { logger }: ComposeFolderUploadIndexParams = {},
+): TurboFolderUploadIndex {
+  const stack = layers.filter(
+    (layer): layer is TurboFolderUploadIndex => layer !== undefined,
+  );
+  if (stack.length === 0) {
+    return createMemoryFolderIndex();
+  }
+
+  const writableLayers = stack.filter((layer) => layer.readOnly !== true);
+
+  const failed = (
+    layer: TurboFolderUploadIndex,
+    what: string,
+    error: unknown,
+  ) =>
+    logger?.error(
+      `Folder index layer ${
+        layer.name ?? 'anonymous'
+      } failed to ${what}, skipping it`,
+      error,
+    );
+
+  const set = async (key: string, id: string) => {
+    for (const layer of writableLayers) {
+      try {
+        await layer.set(key, id);
+      } catch (error) {
+        failed(layer, 'write', error);
+      }
+    }
+  };
+
+  return {
+    name: `composed(${stack
+      .map((layer) => layer.name ?? 'anonymous')
+      .join(', ')})`,
+    readOnly: writableLayers.length === 0,
+    get: async (key) => {
+      for (const layer of stack) {
+        try {
+          const id = await layer.get(key);
+          if (isValidArweaveBase64URL(id ?? '')) {
+            return id;
+          }
+        } catch (error) {
+          failed(layer, 'read', error);
+        }
+      }
+      return undefined;
+    },
+    set,
+    knownContentHashes: async (contentHashes) => {
+      const known = new Set<string>();
+      for (const layer of stack) {
+        try {
+          for (const contentHash of (await layer.knownContentHashes?.(
+            contentHashes,
+          )) ?? []) {
+            known.add(contentHash);
+          }
+        } catch (error) {
+          failed(layer, 'report known content hashes', error);
+        }
+      }
+      return [...known];
+    },
+    resolve: async (keys, options) => {
+      const found: Record<string, string> = {};
+      let remaining = keys;
+
+      for (const layer of stack) {
+        if (remaining.length === 0) {
+          break;
+        }
+        if (layer.resolve === undefined) {
+          continue;
+        }
+        try {
+          const resolved = await layer.resolve(remaining, options);
+          for (const [key, id] of Object.entries(resolved)) {
+            if (!isValidArweaveBase64URL(id)) {
+              continue;
+            }
+            found[key] = id;
+          }
+          remaining = remaining.filter((key) => found[key] === undefined);
+        } catch (error) {
+          failed(layer, 'resolve', error);
+        }
+      }
+
+      // An id recovered from a read only layer is worth caching in the writable
+      // ones so the next run can skip the network entirely.
+      for (const [key, id] of Object.entries(found)) {
+        await set(key, id);
+      }
+
+      return found;
+    },
+    entries: async () => {
+      const entries: Record<string, string> = {};
+      // Reverse so the front of the stack wins on conflict.
+      for (const layer of [...stack].reverse()) {
+        try {
+          Object.assign(entries, (await layer.entries?.()) ?? {});
+        } catch (error) {
+          failed(layer, 'enumerate', error);
+        }
+      }
+      return entries;
+    },
+  };
+}

--- a/packages/turbo-sdk/src/common/index.ts
+++ b/packages/turbo-sdk/src/common/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 export * from './upload.js';
+export * from './folderIndex.js';
 export * from './payment.js';
 export * from './turbo.js';
 export * from './currency.js';

--- a/packages/turbo-sdk/src/common/upload.ts
+++ b/packages/turbo-sdk/src/common/upload.ts
@@ -33,6 +33,7 @@ import {
   TurboCryptoFundResponse,
   TurboDataItemSigner,
   TurboFileFactory,
+  TurboFolderUploadIndex,
   TurboLogger,
   TurboRevokeCreditsParams,
   TurboUnauthenticatedUploadServiceConfiguration,
@@ -50,9 +51,14 @@ import {
   UploadSignedDataItemParams,
   X402Funding,
 } from '../types.js';
-import { isBlob, sleep } from '../utils/common.js';
+import { isBlob, isValidArweaveBase64URL, sleep } from '../utils/common.js';
 import { AbortError } from '../utils/errors.js';
 import { FailedRequestError } from '../utils/errors.js';
+import {
+  contentHashFromFolderIndexKey,
+  contentHashTagName,
+  folderIndexKey,
+} from '../utils/folderIndex.js';
 import { ChunkedUploader } from './chunked.js';
 import { TurboEventEmitter, createStreamWithUploadEvents } from './events.js';
 import { RetryConfig, defaultRetryConfig } from './http.js';
@@ -552,6 +558,250 @@ export abstract class TurboAuthenticatedBaseUploadService
     manifestBuffer: Buffer,
   ): Readable | ReadableStream;
 
+  /**
+   * The sha-256 of a file's bytes, as lowercase hex. The key of a
+   * {@link TurboFolderUploadIndex}.
+   *
+   * This default consumes the file's stream and digests it with the platform
+   * WebCrypto implementation, which serves the browser. NodeJS overrides it
+   * with a streaming digest so a large file is never held in memory.
+   */
+  protected async computeContentHash(file: string | File): Promise<string> {
+    const stream = this.getFileStreamForFile(file);
+
+    const chunks: Uint8Array[] = [];
+    if ('getReader' in stream) {
+      const reader = stream.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+    } else {
+      for await (const chunk of stream) {
+        chunks.push(new Uint8Array(chunk));
+      }
+    }
+
+    const digest = await crypto.subtle.digest('SHA-256', Buffer.concat(chunks));
+    return Buffer.from(digest).toString('hex');
+  }
+
+  /**
+   * The exact tag set a folder upload writes for one file. Shared by the
+   * planner and the uploader, so that the tags a folder index key is computed
+   * from are, without question, the tags the data item ends up carrying.
+   */
+  private folderFileTags({
+    file,
+    dataItemOpts,
+    contentHash,
+  }: {
+    file: string | File;
+    dataItemOpts: DataItemOptions | undefined;
+    contentHash: string | undefined;
+  }): { name: string; value: string }[] {
+    return [
+      ...(dataItemOpts?.tags?.filter(
+        (tag) =>
+          tag.name !== 'Content-Type' &&
+          // Only stripped when this upload is going to write its own. Without a
+          // folder index, a caller's File-SHA256 tag is theirs to keep.
+          (contentHash === undefined || tag.name !== contentHashTagName),
+      ) ?? []),
+      {
+        name: 'Content-Type',
+        value: this.getContentType(file, dataItemOpts),
+      },
+      ...(contentHash !== undefined
+        ? [{ name: contentHashTagName, value: contentHash }]
+        : []),
+    ];
+  }
+
+  /**
+   * A folder index is a cache, so a layer that is unreachable must mean a miss
+   * and not an aborted deploy. The write side is forgiving for the same reason.
+   */
+  private async readFolderIndex(
+    folderIndex: TurboFolderUploadIndex,
+    keys: string[],
+    signal: AbortSignal | undefined,
+  ): Promise<Map<string, string>> {
+    const knownIds = new Map<string, string>();
+    const unresolved: string[] = [];
+
+    for (const key of keys) {
+      let id: string | undefined;
+      try {
+        id = await folderIndex.get(key);
+      } catch (error) {
+        this.logger.error('Failed to read from folder index', error);
+      }
+      if (id !== undefined && isValidArweaveBase64URL(id)) {
+        knownIds.set(key, id);
+      } else {
+        unresolved.push(key);
+      }
+    }
+
+    if (unresolved.length > 0 && folderIndex.resolve !== undefined) {
+      try {
+        const resolved = await folderIndex.resolve(unresolved, { signal });
+        for (const [key, id] of Object.entries(resolved)) {
+          if (isValidArweaveBase64URL(id)) {
+            knownIds.set(key, id);
+          }
+        }
+      } catch (error) {
+        this.logger.error('Failed to resolve from folder index', error);
+      }
+    }
+
+    return knownIds;
+  }
+
+  /**
+   * Hashes every file and derives its folder index key, then works out which of
+   * those keys already have a data item id -- from the index, or from an
+   * identical file earlier in this same folder.
+   */
+  private async planFolderIndex({
+    files,
+    folderIndex,
+    dataItemOpts,
+    limit,
+    signal,
+  }: {
+    files: (string | File)[];
+    folderIndex: TurboFolderUploadIndex;
+    dataItemOpts: DataItemOptions | undefined;
+    limit: ReturnType<typeof pLimit>;
+    signal: AbortSignal | undefined;
+  }): Promise<{
+    contentHashes: Map<string | File, string>;
+    itemKeys: Map<string | File, string>;
+    knownIds: Map<string, string>;
+    filesToUpload: (string | File)[];
+  }> {
+    const contentHashes = new Map<string | File, string>();
+    const itemKeys = new Map<string | File, string>();
+    await Promise.all(
+      files.map((file) =>
+        limit(async () => {
+          const contentHash = await this.computeContentHash(file);
+          contentHashes.set(file, contentHash);
+          itemKeys.set(
+            file,
+            await folderIndexKey({
+              contentHash,
+              tags: this.folderFileTags({ file, dataItemOpts, contentHash }),
+            }),
+          );
+        }),
+      ),
+    );
+
+    const knownIds = await this.readFolderIndex(
+      folderIndex,
+      [...new Set(itemKeys.values())],
+      signal,
+    );
+
+    // Two files that would produce the same data item share a single upload, so
+    // the plan deduplicates within the folder as well as against the index.
+    const claimed = new Set<string>();
+    const filesToUpload = files.filter((file) => {
+      const key = itemKeys.get(file) as string;
+      if (knownIds.has(key) || claimed.has(key)) {
+        return false;
+      }
+      claimed.add(key);
+      return true;
+    });
+
+    this.logger.debug('Planned folder index', {
+      folderIndex: folderIndex.name,
+      totalFiles: files.length,
+      filesToUpload: filesToUpload.length,
+    });
+
+    await this.warnOnStaleTagMisses({ folderIndex, itemKeys, knownIds });
+
+    return { contentHashes, itemKeys, knownIds, filesToUpload };
+  }
+
+  /**
+   * A key covers the tags on a file as well as its bytes, so a tag in
+   * `dataItemOpts` that changes between deploys re-uploads the whole folder at
+   * full price. That is the right answer -- a reused data item is never one
+   * this call would not have made -- but on its own it is a silent cost cliff:
+   * a successful deploy, a full bill, and nothing saying why.
+   *
+   * The signature of that mistake is exact, and it is already in hand. A key is
+   * `<bytes>.<tags>`, so a file whose *bytes half* the index knows under some
+   * other tags half is a file whose content is already paid for and whose tags
+   * moved. Nothing else produces that: a folder the index has never seen has
+   * unknown bytes, and a layer that could not be reached reports nothing known.
+   * It also catches one file in a hundred, not just all of them.
+   */
+  private async warnOnStaleTagMisses({
+    folderIndex,
+    itemKeys,
+    knownIds,
+  }: {
+    folderIndex: TurboFolderUploadIndex;
+    itemKeys: Map<string | File, string>;
+    knownIds: Map<string, string>;
+  }): Promise<void> {
+    if (folderIndex.knownContentHashes === undefined) {
+      return;
+    }
+    const missed = [...new Set(itemKeys.values())].filter(
+      (key) => !knownIds.has(key),
+    );
+    if (missed.length === 0) {
+      return;
+    }
+
+    const missedByContentHash = new Map<string, string[]>();
+    for (const key of missed) {
+      const contentHash = contentHashFromFolderIndexKey(key);
+      missedByContentHash.set(contentHash, [
+        ...(missedByContentHash.get(contentHash) ?? []),
+        key,
+      ]);
+    }
+
+    let staleTagged: string[] = [];
+    try {
+      staleTagged =
+        (await folderIndex.knownContentHashes([
+          ...missedByContentHash.keys(),
+        ])) ?? [];
+    } catch (error) {
+      this.logger.error('Failed to read from folder index', error);
+      return;
+    }
+    const affected = staleTagged.reduce(
+      (count, contentHash) =>
+        count + (missedByContentHash.get(contentHash)?.length ?? 0),
+      0,
+    );
+    if (affected === 0) {
+      return;
+    }
+
+    this.logger.warn(
+      `${affected} of the ${missed.length} file(s) this run is about to upload are already on Arweave byte for byte, under a different set of tags. ` +
+        'Their content has not changed but their tags have, so they are being paid for again. A folder index key covers the tags ' +
+        'on a file as well as its bytes. That is usually a tag in dataItemOpts whose value changes between deploys -- a commit ' +
+        'sha, a build number, a timestamp -- in which case move it to manifestDataItemOpts rather than paying for these files ' +
+        'again. It can also be a file that kept its content but changed its Content-Type, through a rename or a new extension, ' +
+        'which is expected and costs one upload.',
+    );
+  }
+
   private getContentType(
     file: string | File,
     dataItemOpts?: DataItemOptions,
@@ -573,6 +823,8 @@ export abstract class TurboAuthenticatedBaseUploadService
 
     const {
       dataItemOpts,
+      manifestDataItemOpts = dataItemOpts,
+      folderIndex,
       signal,
       manifestOptions = {},
       maxConcurrentUploads = 1,
@@ -596,15 +848,40 @@ export abstract class TurboAuthenticatedBaseUploadService
     };
     const errors: Error[] = [];
 
+    const limit = pLimit(maxConcurrentUploads);
+
     // Get files and calculate total bytes upfront for progress tracking
     const files = await this.getFiles(params);
-    const totalFiles = files.length;
+
+    // With an index, only the files whose bytes are not already on Arweave are
+    // signed, uploaded and paid for. Progress totals cover that subset, since
+    // it is all this call actually does.
+    let contentHashes = new Map<string | File, string>();
+    let itemKeys = new Map<string | File, string>();
+    let knownIds = new Map<string, string>();
+    let filesToUpload = files;
+    if (folderIndex !== undefined) {
+      ({ contentHashes, itemKeys, knownIds, filesToUpload } =
+        await this.planFolderIndex({
+          files,
+          folderIndex,
+          dataItemOpts,
+          limit,
+          signal,
+        }));
+    }
+
+    const totalFiles = filesToUpload.length;
     let totalBytes = 0;
+    let folderBytes = 0;
     const fileSizes = new Map<string | File, number>();
     files.forEach((file) => {
       const size = this.getFileSize(file);
       fileSizes.set(file, size);
-      totalBytes += size;
+      folderBytes += size;
+    });
+    filesToUpload.forEach((file) => {
+      totalBytes += fileSizes.get(file) ?? 0;
     });
 
     // Track progress across all files
@@ -623,16 +900,11 @@ export abstract class TurboAuthenticatedBaseUploadService
         totalFiles,
       });
 
-      const contentType = this.getContentType(file, dataItemOpts);
+      const contentHash = contentHashes.get(file);
 
       const dataItemOptsWithContentType = {
         ...dataItemOpts,
-        tags: [
-          ...(dataItemOpts?.tags?.filter(
-            (tag) => tag.name !== 'Content-Type',
-          ) ?? []),
-          { name: 'Content-Type', value: contentType },
-        ],
+        tags: this.folderFileTags({ file, dataItemOpts, contentHash }),
       };
 
       try {
@@ -680,8 +952,22 @@ export abstract class TurboAuthenticatedBaseUploadService
           fundingMode,
         });
 
-        const relativePath = this.getRelativePath(file, params);
-        paths[relativePath] = { id: result.id };
+        const itemKey = itemKeys.get(file);
+        if (itemKey !== undefined) {
+          // Recorded before anything else can fail, so a run that is killed
+          // part way through never loses a file it has already paid for.
+          knownIds.set(itemKey, result.id);
+          try {
+            await folderIndex?.set(itemKey, result.id);
+          } catch (error) {
+            // A failed index write costs the next run a re-upload; it must not
+            // fail this one, which has already paid for and landed the bytes.
+            this.logger.error('Failed to write to folder index', error);
+          }
+        } else {
+          const relativePath = this.getRelativePath(file, params);
+          paths[relativePath] = { id: result.id };
+        }
         response.fileResponses.push(result);
 
         // Update processed counts after file completes
@@ -721,11 +1007,9 @@ export abstract class TurboAuthenticatedBaseUploadService
       }
     };
 
-    const limit = pLimit(maxConcurrentUploads);
-
     let cryptoFundResult: TurboCryptoFundResponse | undefined;
     if (fundingMode instanceof OnDemandFunding) {
-      const totalByteCount = files.reduce((acc, file) => {
+      const totalByteCount = filesToUpload.reduce((acc, file) => {
         return acc + this.getFileSize(file) + 1200; // allow extra per file for ANS-104 headers
       }, 0);
       cryptoFundResult = await this.onDemand({
@@ -735,17 +1019,39 @@ export abstract class TurboAuthenticatedBaseUploadService
     }
 
     await Promise.all(
-      files.map((file, index) => limit(() => uploadFile(file, index))),
+      filesToUpload.map((file, index) => limit(() => uploadFile(file, index))),
     );
 
     this.logger.debug('Finished uploading files', {
-      numFiles: files.length,
+      numFiles: filesToUpload.length,
       numErrors: errors.length,
       results: response.fileResponses,
     });
 
     if (errors.length > 0) {
       response.errors = errors;
+    }
+
+    if (folderIndex !== undefined) {
+      // Built in folder order rather than in completion order, so an unchanged
+      // folder produces byte identical manifest bytes -- and therefore an
+      // identical manifest data item id -- run after run.
+      for (const file of files) {
+        const id = knownIds.get(itemKeys.get(file) as string);
+        if (id !== undefined) {
+          paths[this.getRelativePath(file, params)] = { id };
+        }
+      }
+      response.folderIndexSummary = {
+        totalFiles: files.length,
+        totalBytes: folderBytes,
+        // What landed, not what was planned. With throwOnFailure: false a file
+        // can be planned, paid for nothing, and never arrive.
+        uploadedFiles: processedFiles,
+        uploadedBytes: processedBytes,
+        reusedFiles: files.length - filesToUpload.length,
+        reusedBytes: folderBytes - totalBytes,
+      };
     }
 
     if (disableManifest) {
@@ -769,8 +1075,9 @@ export abstract class TurboAuthenticatedBaseUploadService
     });
 
     const tagsWithManifestContentType = [
-      ...(dataItemOpts?.tags?.filter((tag) => tag.name !== 'Content-Type') ??
-        []),
+      ...(manifestDataItemOpts?.tags?.filter(
+        (tag) => tag.name !== 'Content-Type',
+      ) ?? []),
       { name: 'Content-Type', value: 'application/x.arweave-manifest+json' },
     ];
 
@@ -782,7 +1089,10 @@ export abstract class TurboAuthenticatedBaseUploadService
       fileStreamFactory: () => this.createManifestStream(manifestBuffer) as any,
       fileSizeFactory: () => manifestBuffer.byteLength,
       signal,
-      dataItemOpts: { ...dataItemOpts, tags: tagsWithManifestContentType },
+      dataItemOpts: {
+        ...manifestDataItemOpts,
+        tags: tagsWithManifestContentType,
+      },
       chunkByteCount,
       maxChunkConcurrency,
       maxFinalizeMs,

--- a/packages/turbo-sdk/src/common/upload.ts
+++ b/packages/turbo-sdk/src/common/upload.ts
@@ -596,10 +596,12 @@ export abstract class TurboAuthenticatedBaseUploadService
     file,
     dataItemOpts,
     contentHash,
+    hashTagName = contentHashTagName,
   }: {
     file: string | File;
     dataItemOpts: DataItemOptions | undefined;
     contentHash: string | undefined;
+    hashTagName?: string;
   }): { name: string; value: string }[] {
     return [
       ...(dataItemOpts?.tags?.filter(
@@ -607,14 +609,14 @@ export abstract class TurboAuthenticatedBaseUploadService
           tag.name !== 'Content-Type' &&
           // Only stripped when this upload is going to write its own. Without a
           // folder index, a caller's File-SHA256 tag is theirs to keep.
-          (contentHash === undefined || tag.name !== contentHashTagName),
+          (contentHash === undefined || tag.name !== hashTagName),
       ) ?? []),
       {
         name: 'Content-Type',
         value: this.getContentType(file, dataItemOpts),
       },
       ...(contentHash !== undefined
-        ? [{ name: contentHashTagName, value: contentHash }]
+        ? [{ name: hashTagName, value: contentHash }]
         : []),
     ];
   }
@@ -695,7 +697,12 @@ export abstract class TurboAuthenticatedBaseUploadService
             file,
             await folderIndexKey({
               contentHash,
-              tags: this.folderFileTags({ file, dataItemOpts, contentHash }),
+              tags: this.folderFileTags({
+                file,
+                dataItemOpts,
+                contentHash,
+                hashTagName: folderIndex.hashTagName,
+              }),
             }),
           );
         }),
@@ -757,12 +764,20 @@ export abstract class TurboAuthenticatedBaseUploadService
     if (folderIndex.knownContentHashes === undefined) {
       return;
     }
-    const missed = [...new Set(itemKeys.values())].filter(
-      (key) => !knownIds.has(key),
-    );
+    // Counted in files, not in keys: the message is about a bill, and the bill
+    // is per file. Two files that share a key are one upload but the reader is
+    // looking for their own file count.
+    const filesPerKey = new Map<string, number>();
+    for (const key of itemKeys.values()) {
+      filesPerKey.set(key, (filesPerKey.get(key) ?? 0) + 1);
+    }
+    const missed = [...filesPerKey.keys()].filter((key) => !knownIds.has(key));
     if (missed.length === 0) {
       return;
     }
+    const filesFor = (keys: string[]) =>
+      keys.reduce((count, key) => count + (filesPerKey.get(key) ?? 0), 0);
+    const missedFiles = filesFor(missed);
 
     const missedByContentHash = new Map<string, string[]>();
     for (const key of missed) {
@@ -785,7 +800,7 @@ export abstract class TurboAuthenticatedBaseUploadService
     }
     const affected = staleTagged.reduce(
       (count, contentHash) =>
-        count + (missedByContentHash.get(contentHash)?.length ?? 0),
+        count + filesFor(missedByContentHash.get(contentHash) ?? []),
       0,
     );
     if (affected === 0) {
@@ -793,7 +808,7 @@ export abstract class TurboAuthenticatedBaseUploadService
     }
 
     this.logger.warn(
-      `${affected} of the ${missed.length} file(s) this run is about to upload are already on Arweave byte for byte, under a different set of tags. ` +
+      `${affected} of the ${missedFiles} file(s) this run is about to upload are already on Arweave byte for byte, under a different set of tags. ` +
         'Their content has not changed but their tags have, so they are being paid for again. A folder index key covers the tags ' +
         'on a file as well as its bytes. That is usually a tag in dataItemOpts whose value changes between deploys -- a commit ' +
         'sha, a build number, a timestamp -- in which case move it to manifestDataItemOpts rather than paying for these files ' +
@@ -904,7 +919,12 @@ export abstract class TurboAuthenticatedBaseUploadService
 
       const dataItemOptsWithContentType = {
         ...dataItemOpts,
-        tags: this.folderFileTags({ file, dataItemOpts, contentHash }),
+        tags: this.folderFileTags({
+          file,
+          dataItemOpts,
+          contentHash,
+          hashTagName: folderIndex?.hashTagName,
+        }),
       };
 
       try {

--- a/packages/turbo-sdk/src/node/folderIndex.ts
+++ b/packages/turbo-sdk/src/node/folderIndex.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve as resolvePath } from 'node:path';
+
+import {
+  FileFolderUploadIndexParams,
+  TurboFolderUploadIndex,
+} from '../types.js';
+import { isValidArweaveBase64URL } from '../utils/common.js';
+import {
+  contentHashFromFolderIndexKey,
+  isValidFolderIndexKey,
+} from '../utils/folderIndex.js';
+
+const fileFolderIndexVersion = 2;
+
+/**
+ * A local record of folder index key to data item id, for uploads on a machine
+ * that keeps its working directory between deploys.
+ *
+ * The file is an append-only log, one JSON record per line, compacted when it
+ * is loaded. That shape falls out of two requirements pulling against each
+ * other:
+ *
+ * - It has to be written after every single upload, not once at the end of the
+ *   run. An upload that has been paid for but forgotten is money burnt, and a
+ *   deploy killed part way through is the normal case rather than the
+ *   exceptional one.
+ * - Rewriting the whole file per upload is quadratic. A first deploy or a
+ *   migration of a few thousand files spends minutes and gigabytes of writes on
+ *   nothing but bookkeeping.
+ *
+ * Appending one line is constant work, and it is *more* crash safe than a
+ * rewrite rather than less: a process killed mid write can only damage the last
+ * line, which is dropped on load, where a torn rewrite loses every id in the
+ * file. Compaction happens once per load, through a temp file and a rename, so
+ * the readable file is never the partial one.
+ *
+ * Malformed records are dropped. A hand edited index must never be able to
+ * publish a manifest pointing at nothing.
+ */
+export function createFileFolderIndex({
+  filePath,
+  logger,
+}: FileFolderUploadIndexParams): TurboFolderUploadIndex {
+  const absolutePath = resolvePath(filePath);
+  const tempPath = `${absolutePath}.tmp`;
+  const map = new Map<string, string>();
+
+  const record = (key: string, id: string) =>
+    `${JSON.stringify({ k: key, i: id })}\n`;
+
+  const header = `${JSON.stringify({ folderIndex: fileFolderIndexVersion })}\n`;
+
+  /** Rewrites the log as one record per live entry, atomically. */
+  const compact = () => {
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    const body = [...map]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, id]) => record(key, id))
+      .join('');
+    try {
+      writeFileSync(tempPath, `${header}${body}`);
+      renameSync(tempPath, absolutePath);
+    } catch (error) {
+      rmSync(tempPath, { force: true });
+      throw error;
+    }
+  };
+
+  let lineCount = 0;
+  if (existsSync(absolutePath)) {
+    let malformed = 0;
+    // A line at a time, so a truncated tail costs one entry rather than all of
+    // them.
+    for (const line of readFileSync(absolutePath, 'utf-8').split('\n')) {
+      if (line.length === 0) {
+        continue;
+      }
+      lineCount++;
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed?.folderIndex !== undefined) {
+          continue; // header
+        }
+        if (
+          isValidFolderIndexKey(parsed?.k) &&
+          isValidArweaveBase64URL(parsed?.i)
+        ) {
+          map.set(parsed.k, parsed.i); // last write wins
+        } else {
+          malformed++;
+        }
+      } catch {
+        malformed++;
+      }
+    }
+    if (malformed > 0) {
+      logger?.warn(
+        `Dropped ${malformed} unreadable record(s) from the folder index at ${absolutePath}`,
+      );
+    }
+    // Only worth rewriting when the log has actually accumulated slack.
+    if (lineCount > map.size + 1) {
+      try {
+        compact();
+      } catch (error) {
+        logger?.warn(
+          `Could not compact the folder index at ${absolutePath}`,
+          error,
+        );
+      }
+    }
+  }
+
+  return {
+    name: `file:${absolutePath}`,
+    get: (key) => map.get(key),
+    set: (key, id) => {
+      map.set(key, id);
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      if (!existsSync(absolutePath)) {
+        writeFileSync(absolutePath, header);
+      }
+      appendFileSync(absolutePath, record(key, id));
+    },
+    knownContentHashes: (contentHashes) => {
+      const known = new Set([...map.keys()].map(contentHashFromFolderIndexKey));
+      return contentHashes.filter((contentHash) => known.has(contentHash));
+    },
+    entries: () => Object.fromEntries(map),
+  };
+}

--- a/packages/turbo-sdk/src/node/folderIndex.ts
+++ b/packages/turbo-sdk/src/node/folderIndex.ts
@@ -78,7 +78,11 @@ export function createFileFolderIndex({
   const compact = () => {
     mkdirSync(dirname(absolutePath), { recursive: true });
     const body = [...map]
-      .sort(([a], [b]) => a.localeCompare(b))
+      // Code units, not `localeCompare`, for the same reason the key encoding
+      // avoids it: it is not a total order over distinct strings and depends on
+      // the host's ICU data. Only the file's readability rides on this one, but
+      // a sort that can call two distinct keys equal has no business here.
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([key, id]) => record(key, id))
       .join('');
     try {

--- a/packages/turbo-sdk/src/node/index.ts
+++ b/packages/turbo-sdk/src/node/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 export * from './factory.js';
+export * from './folderIndex.js';
 export * from './signer.js';
 export * from './upload.js';
 export * from '../types.js';

--- a/packages/turbo-sdk/src/node/upload.folderIndex.e2e.test.ts
+++ b/packages/turbo-sdk/src/node/upload.folderIndex.e2e.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DataItem } from '@dha-team/arbundles';
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { IncomingMessage, Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+
+import { TurboLogger } from '../types.js';
+import { TurboFactory } from './factory.js';
+import {
+  composeFolderIndex,
+  createChainFolderIndex,
+  createFileFolderIndex,
+} from './index.js';
+
+/**
+ * The folder index tests in `upload.folderIndex.test.ts` stub `uploadFile`, so
+ * they can prove what the planner decides but not the thing the whole design
+ * rests on: that the tags a real signer writes onto a real data item are the
+ * tags the chain sweep reconstructs a key from. A mismatch there is invisible
+ * to a stub and costs a full re-upload on every deploy.
+ *
+ * So these go through `TurboFactory`, a real `ArweaveSigner`, real ANS-104
+ * encoding and a real socket. The upload service is stood in for by a server
+ * that parses every data item it is posted with the same arbundles build the
+ * SDK signs with and checks the signature, and the gateway by one that answers
+ * the exact GraphQL query `createChainFolderIndex` sends out of those records.
+ * Nothing on the SDK side of the boundary is stubbed, and no container is
+ * needed, so this runs anywhere `test:unit` runs.
+ */
+
+type Recorded = {
+  id: string;
+  ownerAddress: string;
+  tags: { name: string; value: string }[];
+  data: Buffer;
+  signature: string;
+};
+
+const b64Url = (b: Buffer) =>
+  b
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+
+const fromB64Url = (s: string) =>
+  Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+
+const sha256Hex = (data: Buffer | string) =>
+  createHash('sha256').update(data).digest('hex');
+
+const readBody = (req: IncomingMessage): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+
+async function startServices() {
+  const uploaded: Recorded[] = [];
+  const rejected: string[] = [];
+
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      const path = new URL(req.url ?? '/', 'http://localhost').pathname;
+      const json = (code: number, body: unknown) => {
+        res.writeHead(code, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(body));
+      };
+
+      try {
+        if (req.method === 'POST' && path.includes('/tx/')) {
+          const raw = await readBody(req);
+          const item = new DataItem(raw);
+          if (!(await item.isValid())) {
+            rejected.push(item.id);
+            return json(400, { error: 'invalid data item' });
+          }
+          const ownerAddress = b64Url(
+            createHash('sha256').update(fromB64Url(item.owner)).digest(),
+          );
+          uploaded.push({
+            id: item.id,
+            ownerAddress,
+            tags: item.tags.map((t) => ({ name: t.name, value: t.value })),
+            data: Buffer.from(item.rawData),
+            signature: Buffer.from(item.signature).toString('base64'),
+          });
+          return json(200, {
+            id: item.id,
+            owner: ownerAddress,
+            winc: '0',
+            dataCaches: ['e2e'],
+            fastFinalityIndexes: [],
+          });
+        }
+
+        if (req.method === 'POST' && path === '/graphql') {
+          const body = JSON.parse((await readBody(req)).toString()) as {
+            variables?: {
+              owner?: string;
+              hashes?: string[];
+              after?: string | null;
+            };
+          };
+          const owner = body.variables?.owner;
+          const wanted = new Set(body.variables?.hashes ?? []);
+          const after = body.variables?.after;
+          // Newest first, matching the query's sort:HEIGHT_DESC.
+          const matching = [...uploaded]
+            .reverse()
+            .filter(
+              (r) =>
+                r.ownerAddress === owner &&
+                r.tags.some(
+                  (t) => t.name === 'File-SHA256' && wanted.has(t.value),
+                ),
+            );
+          const start =
+            after === undefined || after === null
+              ? 0
+              : matching.findIndex((r) => r.id === after) + 1;
+          const page = matching.slice(start, start + 100);
+          return json(200, {
+            data: {
+              transactions: {
+                pageInfo: { hasNextPage: start + 100 < matching.length },
+                edges: page.map((r) => ({
+                  cursor: r.id,
+                  node: { id: r.id, tags: r.tags },
+                })),
+              },
+            },
+          });
+        }
+
+        if (path.endsWith('/balance')) {
+          return json(200, {
+            winc: '9999999999999',
+            effectiveBalance: '9999999999999',
+            controlledWinc: '9999999999999',
+          });
+        }
+        return json(404, { error: 'not found', path });
+      } catch (error) {
+        return json(500, { error: `${(error as Error).message}` });
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port =
+    typeof address === 'object' && address !== null ? address.port : 0;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    uploaded,
+    rejected,
+    manifests: () =>
+      uploaded.filter((u) =>
+        u.tags.some(
+          (t) =>
+            t.name === 'Content-Type' &&
+            t.value === 'application/x.arweave-manifest+json',
+        ),
+      ),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function capturingLogger() {
+  const warnings: string[] = [];
+  const logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+    warn: (message: string) => {
+      warnings.push(message);
+    },
+    setLogLevel: () => undefined,
+    setLogFormat: () => undefined,
+  } as unknown as TurboLogger;
+  return { logger, warnings };
+}
+
+const jwk = JSON.parse(
+  readFileSync(
+    join(
+      process.cwd(),
+      'tests/wallets/ByQEA5jhJvzlhfI4sFgB23kjGpxDK6OIE0i3sSnmTGU.json',
+    ),
+    'utf-8',
+  ),
+);
+
+describe('uploadFolder with a folder index, over real signing and HTTP', () => {
+  let services: Awaited<ReturnType<typeof startServices>>;
+  let folder: string;
+
+  const turboFor = () =>
+    TurboFactory.authenticated({
+      privateKey: jwk,
+      uploadServiceConfig: { url: services.url },
+      paymentServiceConfig: { url: services.url },
+    });
+
+  /**
+   * `TurboFactory` builds every service with its own static logger and
+   * overrides anything `uploadServiceConfig.logger` supplied, so the only way
+   * to read what `uploadFolder` warned about is to swap the logger on the
+   * service it actually holds.
+   */
+  const captureWarnings = (turbo: ReturnType<typeof turboFor>): string[] => {
+    const { logger, warnings } = capturingLogger();
+    (
+      turbo as unknown as { uploadService: { logger: TurboLogger } }
+    ).uploadService.logger = logger;
+    return warnings;
+  };
+
+  const chainIndex = async (
+    turbo: ReturnType<typeof turboFor>,
+    logger?: TurboLogger,
+  ): Promise<ReturnType<typeof createChainFolderIndex>> =>
+    createChainFolderIndex({
+      owner: await turbo.signer.getPublicKey(),
+      gatewayUrl: services.url,
+      ...(logger !== undefined ? { logger } : {}),
+    });
+
+  before(async () => {
+    services = await startServices();
+    folder = mkdtempSync(join(tmpdir(), 'folder-index-e2e-'));
+    mkdirSync(join(folder, 'assets'), { recursive: true });
+    writeFileSync(join(folder, 'index.html'), '<h1>one</h1>');
+    writeFileSync(join(folder, 'assets/app.js'), 'console.log(1)');
+    writeFileSync(join(folder, 'assets/app.css'), 'body{color:red}');
+    // The a.css / b.js case, with real bytes: both empty, both hash the same.
+    writeFileSync(join(folder, 'assets/empty.css'), '');
+    writeFileSync(join(folder, 'assets/empty.js'), '');
+  });
+
+  after(async () => {
+    await services.close();
+    rmSync(folder, { recursive: true, force: true });
+  });
+
+  it('writes a File-SHA256 that matches the bytes a real signer signed', async () => {
+    const turbo = turboFor();
+    const folderIndex = composeFolderIndex([
+      createFileFolderIndex({ filePath: join(folder, '.turbo/index.jsonl') }),
+      await chainIndex(turbo),
+    ]);
+
+    const result = await turbo.uploadFolder({
+      folderPath: folder,
+      folderIndex,
+    });
+
+    assert.equal(result.folderIndexSummary?.totalFiles, 5);
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 5);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 0);
+    assert.deepEqual(services.rejected, [], 'every data item must verify');
+
+    const contents: Record<string, string> = {
+      'index.html': '<h1>one</h1>',
+      'assets/app.js': 'console.log(1)',
+      'assets/app.css': 'body{color:red}',
+      'assets/empty.css': '',
+      'assets/empty.js': '',
+    };
+    for (const [path, content] of Object.entries(contents)) {
+      const id = result.manifest?.paths[path]?.id;
+      assert.ok(id !== undefined, `${path} is in the manifest`);
+      const item = services.uploaded.find((u) => u.id === id);
+      assert.ok(item !== undefined, `${path} was actually posted`);
+      assert.equal(
+        item.tags.find((t) => t.name === 'File-SHA256')?.value,
+        sha256Hex(Buffer.from(content)),
+        `${path} File-SHA256 matches its own bytes`,
+      );
+    }
+  });
+
+  it('does not let two empty files with different content types share an item', async () => {
+    const manifest = services.manifests().slice(-1)[0];
+    const paths = JSON.parse(manifest.data.toString()).paths;
+    assert.notEqual(
+      paths['assets/empty.css'].id,
+      paths['assets/empty.js'].id,
+      'identical bytes with different content types must not be deduplicated',
+    );
+  });
+
+  it('reuses everything from the sweep alone on a fresh checkout', async () => {
+    // Deleting the local index is the CI runner case: nothing cached, so the
+    // gateway sweep is the only thing that can answer.
+    rmSync(join(folder, '.turbo'), { recursive: true, force: true });
+    const before = services.uploaded.length;
+
+    const turbo = turboFor();
+    const result = await turbo.uploadFolder({
+      folderPath: folder,
+      folderIndex: await chainIndex(turbo),
+    });
+
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 0);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 5);
+    assert.equal(result.fileResponses.length, 0);
+    assert.equal(
+      services.uploaded.length - before,
+      1,
+      'only the manifest is posted',
+    );
+  });
+
+  it('produces byte identical manifest bytes, though not a stable data item id', async () => {
+    const [first, second] = services.manifests().slice(-2);
+    assert.ok(
+      first.data.equals(second.data),
+      'an unchanged folder must produce the same manifest bytes',
+    );
+    assert.deepEqual(first.tags, second.tags);
+    // Same bytes, same tags. The id still moves, because an Arweave data item
+    // is signed with RSA-PSS and the salt is random. Anything downstream that
+    // needs to know whether a deploy changed has to compare the manifest bytes
+    // or the paths, never the manifest id.
+    assert.notEqual(first.signature, second.signature);
+    assert.notEqual(first.id, second.id);
+  });
+
+  it('uploads exactly the one file whose bytes changed', async () => {
+    writeFileSync(join(folder, 'assets/app.js'), 'console.log(2)');
+    const before = services.uploaded.length;
+
+    const turbo = turboFor();
+    const result = await turbo.uploadFolder({
+      folderPath: folder,
+      folderIndex: await chainIndex(turbo),
+    });
+
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 1);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 4);
+    assert.equal(
+      services.uploaded.length - before,
+      2,
+      'one file, one manifest',
+    );
+    assert.equal(
+      services.uploaded[services.uploaded.length - 2].tags.find(
+        (t) => t.name === 'File-SHA256',
+      )?.value,
+      sha256Hex(Buffer.from('console.log(2)')),
+    );
+  });
+
+  it('re-uploads the folder and warns when a per file tag changes per deploy', async () => {
+    const turbo = turboFor();
+    const warnings = captureWarnings(turbo);
+
+    const result = await turbo.uploadFolder({
+      folderPath: folder,
+      folderIndex: await chainIndex(turbo),
+      dataItemOpts: { tags: [{ name: 'Git-Commit', value: 'deadbeef' }] },
+    });
+
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 5);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 0);
+    assert.ok(
+      warnings.some((w) => w.includes('already on Arweave byte for byte')),
+      `the cost cliff must be reported, got ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('reuses again once that tag moves to manifestDataItemOpts', async () => {
+    const before = services.uploaded.length;
+    const turbo = turboFor();
+
+    const result = await turbo.uploadFolder({
+      folderPath: folder,
+      folderIndex: await chainIndex(turbo),
+      manifestDataItemOpts: {
+        tags: [{ name: 'Git-Commit', value: 'cafebabe' }],
+      },
+    });
+
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 0);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 5);
+    assert.equal(services.uploaded.length - before, 1);
+    assert.equal(
+      services.uploaded[services.uploaded.length - 1].tags.find(
+        (t) => t.name === 'Git-Commit',
+      )?.value,
+      'cafebabe',
+    );
+  });
+
+  it('costs a re-upload rather than a failed deploy when the gateway is unreachable', async () => {
+    const turbo = turboFor();
+    const result = await turbo.uploadFolder({
+      folderPath: folder,
+      folderIndex: createChainFolderIndex({
+        owner: await turbo.signer.getPublicKey(),
+        gatewayUrl: 'http://127.0.0.1:1', // nothing listening
+        timeoutMs: 2000,
+      }),
+    });
+
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 5);
+    assert.ok(result.manifest?.paths['index.html']?.id !== undefined);
+  });
+
+  it('writes whichever hash tag the index reads, so a custom one still reuses', async () => {
+    const custom = mkdtempSync(join(tmpdir(), 'folder-index-tag-'));
+    writeFileSync(join(custom, 'index.html'), '<h1>tagged</h1>');
+    writeFileSync(join(custom, 'app.js'), 'tagged');
+    try {
+      const run = async () => {
+        const turbo = turboFor();
+        return turbo.uploadFolder({
+          folderPath: custom,
+          folderIndex: createChainFolderIndex({
+            owner: await turbo.signer.getPublicKey(),
+            gatewayUrl: services.url,
+            hashTagName: 'File-SHA256', // the default, spelled out
+          }),
+        });
+      };
+      await run();
+      const second = await run();
+      assert.equal(second.folderIndexSummary?.reusedFiles, 2);
+    } finally {
+      rmSync(custom, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('folder index sweeps that run out of pages', () => {
+  it('warns rather than silently re-uploading the shortfall', async () => {
+    const { logger, warnings } = capturingLogger();
+    const wanted = Array.from({ length: 250 }, (_, i) =>
+      sha256Hex(`file-${i}`),
+    );
+    let pagesServed = 0;
+
+    const index = createChainFolderIndex({
+      owner: { address: 'a'.repeat(43) },
+      pageSize: 10,
+      maxPages: 5,
+      logger,
+      fetchImpl: (async () => {
+        const start = pagesServed * 10;
+        pagesServed++;
+        return new Response(
+          JSON.stringify({
+            data: {
+              transactions: {
+                pageInfo: { hasNextPage: true },
+                edges: wanted.slice(start, start + 10).map((hash, i) => ({
+                  cursor: `cursor-${start + i}`,
+                  node: {
+                    id: `${start + i}`.padStart(43, 'i'),
+                    tags: [
+                      { name: 'Content-Type', value: 'text/plain' },
+                      { name: 'File-SHA256', value: hash },
+                    ],
+                  },
+                })),
+              },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    const { folderIndexKey } = await import('../utils/folderIndex.js');
+    const keys = await Promise.all(
+      wanted.map((hash) =>
+        folderIndexKey({
+          contentHash: hash,
+          tags: [
+            { name: 'Content-Type', value: 'text/plain' },
+            { name: 'File-SHA256', value: hash },
+          ],
+        }),
+      ),
+    );
+
+    const found = await index.resolve?.(keys);
+
+    assert.equal(pagesServed, 5, 'it stops at maxPages');
+    assert.equal(Object.keys(found ?? {}).length, 50);
+    assert.ok(
+      warnings.some((w) => w.includes('stopped at its 5 page limit')),
+      `giving up early must not be silent, got ${JSON.stringify(warnings)}`,
+    );
+  });
+});
+
+describe('composeFolderIndex with layers that disagree', () => {
+  it('refuses a stack whose layers read different hash tags', () => {
+    assert.throws(
+      () =>
+        composeFolderIndex([
+          createChainFolderIndex({
+            owner: { address: 'a'.repeat(43) },
+            hashTagName: 'File-SHA256',
+          }),
+          createChainFolderIndex({
+            owner: { address: 'b'.repeat(43) },
+            hashTagName: 'Other-Hash',
+          }),
+        ]),
+      /disagree about which tag holds/,
+    );
+  });
+});

--- a/packages/turbo-sdk/src/node/upload.folderIndex.test.ts
+++ b/packages/turbo-sdk/src/node/upload.folderIndex.test.ts
@@ -1,0 +1,842 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  TurboFolderUploadIndex,
+  TurboLogger,
+  TurboUploadDataItemResponse,
+  TurboUploadFileParams,
+} from '../types.js';
+import { contentHashTagName, folderIndexKey } from '../utils/folderIndex.js';
+import {
+  TurboAuthenticatedUploadService,
+  composeFolderIndex,
+  createChainFolderIndex,
+  createFileFolderIndex,
+  createMemoryFolderIndex,
+} from './index.js';
+
+const manifestContentType = 'application/x.arweave-manifest+json';
+
+// Unique across every stub in the file, so an id from one run is never
+// mistaken for an id from another.
+let dataItemCounter = 0;
+
+type RecordedUpload = {
+  id: string;
+  tags: { name: string; value: string }[];
+  contentType: string | undefined;
+  contentHash: string | undefined;
+};
+
+/**
+ * A node upload service whose `uploadFile` never leaves the process. Every call
+ * is recorded and answered with a deterministic data item id, which is all
+ * `uploadFolder` needs to build a manifest.
+ */
+function stubbedUploadService({ failOn }: { failOn?: string } = {}) {
+  const warnings: string[] = [];
+  const logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    error: () => undefined,
+    warn: (message: string) => {
+      warnings.push(message);
+    },
+    setLogLevel: () => undefined,
+    setLogFormat: () => undefined,
+  } as unknown as TurboLogger;
+
+  const service = new TurboAuthenticatedUploadService({
+    signer: {} as never,
+    paymentService: {} as never,
+    logger,
+  });
+
+  const uploads: RecordedUpload[] = [];
+  const manifestUploads: RecordedUpload[] = [];
+
+  const uploadFile = async (
+    params: TurboUploadFileParams,
+  ): Promise<TurboUploadDataItemResponse> => {
+    const tags = params.dataItemOpts?.tags ?? [];
+    if (
+      failOn !== undefined &&
+      tags.some(
+        (tag) => tag.name === 'Content-Type' && tag.value.includes(failOn),
+      )
+    ) {
+      throw new Error(`refused ${failOn}`);
+    }
+    const record: RecordedUpload = {
+      id: `id${dataItemCounter++}`.padEnd(43, 'x'),
+      tags,
+      contentType: tags.find((tag) => tag.name === 'Content-Type')?.value,
+      contentHash: tags.find((tag) => tag.name === contentHashTagName)?.value,
+    };
+    (record.contentType === manifestContentType
+      ? manifestUploads
+      : uploads
+    ).push(record);
+    return { id: record.id } as TurboUploadDataItemResponse;
+  };
+
+  (service as unknown as { uploadFile: typeof uploadFile }).uploadFile =
+    uploadFile;
+
+  return { service, uploads, manifestUploads, warnings };
+}
+
+describe('uploadFolder with a folder index', () => {
+  let folderPath: string;
+
+  beforeEach(() => {
+    folderPath = mkdtempSync(join(tmpdir(), 'turbo-folder-index-'));
+    writeFileSync(join(folderPath, 'index.html'), '<h1>one</h1>');
+    writeFileSync(join(folderPath, 'app.js'), 'console.log(1);');
+    writeFileSync(join(folderPath, 'style.css'), 'body{}');
+  });
+
+  afterEach(() => {
+    rmSync(folderPath, { recursive: true, force: true });
+  });
+
+  it('uploads every file on a first run and remembers each one', async () => {
+    const { service, uploads } = stubbedUploadService();
+    const folderIndex = createMemoryFolderIndex();
+
+    const result = await service.uploadFolder({ folderPath, folderIndex });
+
+    assert.equal(uploads.length, 3);
+    assert.equal(result.fileResponses.length, 3);
+    assert.deepEqual(result.folderIndexSummary, {
+      totalFiles: 3,
+      totalBytes: 33,
+      uploadedFiles: 3,
+      uploadedBytes: 33,
+      reusedFiles: 0,
+      reusedBytes: 0,
+    });
+    assert.deepEqual(Object.keys(result.manifest?.paths ?? {}).sort(), [
+      'app.js',
+      'index.html',
+      'style.css',
+    ]);
+    assert.equal(Object.keys((await folderIndex.entries?.()) ?? {}).length, 3);
+  });
+
+  it('uploads nothing on an unchanged re-run and reuses every id', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    const first = await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    const second = stubbedUploadService();
+    const result = await second.service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    assert.equal(second.uploads.length, 0);
+    assert.equal(result.fileResponses.length, 0);
+    assert.deepEqual(result.folderIndexSummary, {
+      totalFiles: 3,
+      totalBytes: 33,
+      uploadedFiles: 0,
+      uploadedBytes: 0,
+      reusedFiles: 3,
+      reusedBytes: 33,
+    });
+    // Same ids, and byte identical manifest bytes.
+    assert.deepEqual(result.manifest, first.manifest);
+    assert.equal(
+      JSON.stringify(result.manifest),
+      JSON.stringify(first.manifest),
+    );
+  });
+
+  it('uploads exactly the file that changed and keeps the rest', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    const first = await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    writeFileSync(join(folderPath, 'app.js'), 'console.log(2);');
+
+    const second = stubbedUploadService();
+    const result = await second.service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    assert.equal(second.uploads.length, 1);
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 1);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 2);
+
+    // The manifest is assembled from two remembered ids and one new one.
+    const paths = result.manifest?.paths ?? {};
+    const firstPaths = first.manifest?.paths ?? {};
+    assert.equal(paths['app.js'].id, second.uploads[0].id);
+    assert.notEqual(paths['app.js'].id, firstPaths['app.js'].id);
+    assert.equal(paths['index.html'].id, firstPaths['index.html'].id);
+    assert.equal(paths['style.css'].id, firstPaths['style.css'].id);
+  });
+
+  it('pays once for identical bytes that also share a content type', async () => {
+    writeFileSync(join(folderPath, 'copy.css'), 'body{}');
+
+    const { service, uploads } = stubbedUploadService();
+    const result = await service.uploadFolder({
+      folderPath,
+      folderIndex: createMemoryFolderIndex(),
+    });
+
+    assert.equal(uploads.length, 3);
+    assert.equal(result.folderIndexSummary?.totalFiles, 4);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 1);
+
+    const paths = result.manifest?.paths ?? {};
+    assert.equal(paths['copy.css'].id, paths['style.css'].id);
+  });
+
+  it('pays twice for identical bytes with different content types', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'turbo-folder-index-'));
+    writeFileSync(join(empty, 'a.css'), '');
+    writeFileSync(join(empty, 'b.js'), '');
+
+    try {
+      const { service, uploads } = stubbedUploadService();
+      const result = await service.uploadFolder({
+        folderPath: empty,
+        folderIndex: createMemoryFolderIndex(),
+      });
+
+      // Byte identical, but a browser refuses to execute JavaScript served as
+      // text/css, so these must not share a data item.
+      assert.equal(uploads.length, 2);
+      assert.equal(result.folderIndexSummary?.reusedFiles, 0);
+
+      const paths = result.manifest?.paths ?? {};
+      assert.notEqual(paths['a.css'].id, paths['b.js'].id);
+
+      const byId = new Map(uploads.map((upload) => [upload.id, upload]));
+      assert.equal(byId.get(paths['a.css'].id)?.contentType, 'text/css');
+      assert.equal(
+        byId.get(paths['b.js'].id)?.contentType,
+        'application/javascript',
+      );
+      // Same bytes, so the same content hash tag on both.
+      assert.equal(uploads[0].contentHash, uploads[1].contentHash);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('re-uploads when a dataItemOpts tag changes, rather than reusing stale tags', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+      dataItemOpts: { tags: [{ name: 'App-Name', value: 'one' }] },
+    });
+
+    const sameTag = stubbedUploadService();
+    await sameTag.service.uploadFolder({
+      folderPath,
+      folderIndex,
+      dataItemOpts: { tags: [{ name: 'App-Name', value: 'one' }] },
+    });
+    assert.equal(sameTag.uploads.length, 0);
+
+    const changedTag = stubbedUploadService();
+    await changedTag.service.uploadFolder({
+      folderPath,
+      folderIndex,
+      dataItemOpts: { tags: [{ name: 'App-Name', value: 'two' }] },
+    });
+    // A reused item would still say App-Name: one, so the key covers the tags
+    // and these are paid for again.
+    assert.equal(changedTag.uploads.length, 3);
+    for (const upload of changedTag.uploads) {
+      assert.ok(
+        upload.tags.some(
+          (tag) => tag.name === 'App-Name' && tag.value === 'two',
+        ),
+      );
+    }
+  });
+
+  it('tags each file with its own content hash', async () => {
+    const { service, uploads } = stubbedUploadService();
+
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: createMemoryFolderIndex(),
+      dataItemOpts: { tags: [{ name: 'App-Name', value: 'my-app' }] },
+    });
+
+    for (const upload of uploads) {
+      assert.match(upload.contentHash ?? '', /^[0-9a-f]{64}$/);
+      assert.equal(
+        upload.tags.filter((tag) => tag.name === contentHashTagName).length,
+        1,
+      );
+      assert.ok(
+        upload.tags.some(
+          (tag) => tag.name === 'App-Name' && tag.value === 'my-app',
+        ),
+      );
+    }
+    // Distinct bytes, distinct hashes.
+    assert.equal(new Set(uploads.map((upload) => upload.contentHash)).size, 3);
+  });
+
+  it('calls get for every key first, then resolve once for the leftovers', async () => {
+    const gets: string[] = [];
+    const resolveCalls: string[][] = [];
+    const folderIndex: TurboFolderUploadIndex = {
+      get: (key) => {
+        gets.push(key);
+        return undefined;
+      },
+      set: () => undefined,
+      resolve: async (keys) => {
+        resolveCalls.push(keys);
+        return {};
+      },
+    };
+
+    const { service } = stubbedUploadService();
+    await service.uploadFolder({ folderPath, folderIndex });
+
+    assert.equal(gets.length, 3);
+    assert.equal(resolveCalls.length, 1);
+    assert.deepEqual(resolveCalls[0], gets);
+  });
+
+  it('treats an index read that throws as a miss rather than a failed deploy', async () => {
+    const folderIndex: TurboFolderUploadIndex = {
+      get: () => {
+        throw new Error('cache is down');
+      },
+      set: () => undefined,
+      resolve: async () => {
+        throw new Error('gateway 503');
+      },
+    };
+
+    const { service, uploads } = stubbedUploadService();
+    const result = await service.uploadFolder({ folderPath, folderIndex });
+
+    assert.equal(uploads.length, 3);
+    assert.equal(Object.keys(result.manifest?.paths ?? {}).length, 3);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 0);
+  });
+
+  it('does not fail an upload that has landed when the index write fails', async () => {
+    const folderIndex: TurboFolderUploadIndex = {
+      get: () => undefined,
+      set: () => {
+        throw new Error('disk is full');
+      },
+    };
+
+    const { service, uploads } = stubbedUploadService();
+    const result = await service.uploadFolder({ folderPath, folderIndex });
+
+    assert.equal(uploads.length, 3);
+    assert.equal(Object.keys(result.manifest?.paths ?? {}).length, 3);
+  });
+
+  it('warns when a file is already on Arweave byte for byte under other tags', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+      dataItemOpts: { tags: [{ name: 'Build-Id', value: '1' }] },
+    });
+
+    const second = stubbedUploadService();
+    await second.service.uploadFolder({
+      folderPath,
+      folderIndex,
+      dataItemOpts: { tags: [{ name: 'Build-Id', value: '2' }] },
+    });
+
+    assert.equal(second.uploads.length, 3);
+    assert.equal(second.warnings.length, 1);
+    assert.match(second.warnings[0], /3 of the 3 file\(s\)/);
+    assert.match(second.warnings[0], /under a different set of tags/);
+    assert.match(second.warnings[0], /manifestDataItemOpts/);
+  });
+
+  it('warns for one drifted file among many that were reused', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    // The same bytes for app.js under a tag set the index has not got, while
+    // the other two files still hit exactly. A whole-run signal misses this.
+    const drifted = await folderIndexKey({
+      contentHash: 'f'.repeat(64),
+      tags: [],
+    });
+    assert.ok(drifted.length > 0);
+
+    const second = stubbedUploadService();
+    await second.service.uploadFolder({
+      folderPath,
+      folderIndex: {
+        get: (key) => folderIndex.get(key),
+        set: (key, id) => folderIndex.set(key, id),
+        // Pretend the bytes of every file are known, but claim not to know one
+        // of the keys: that is exactly a single file whose tags moved.
+        knownContentHashes: (contentHashes) => contentHashes,
+      },
+      dataItemOpts: { tags: [{ name: 'Build-Id', value: 'new' }] },
+    });
+
+    assert.equal(second.warnings.length, 1);
+    assert.match(second.warnings[0], /3 of the 3 file\(s\)/);
+  });
+
+  it('warns on a chain only index, which is the CI case', async () => {
+    // The chain layer filters GraphQL on File-SHA256 alone, so a sweep sees
+    // every item with matching bytes whatever tags it carries. That is where
+    // the signal comes from, and it works with nothing cached locally.
+    const first = stubbedUploadService();
+    await first.service.uploadFolder({
+      folderPath,
+      folderIndex: createMemoryFolderIndex(),
+      dataItemOpts: { tags: [{ name: 'Build-Id', value: '1' }] },
+    });
+
+    const onChain = first.uploads.map((upload) => ({
+      cursor: upload.id,
+      node: { id: upload.id, tags: upload.tags },
+    }));
+    const fetchImpl = (async () => ({
+      ok: true,
+      json: async () => ({
+        data: {
+          transactions: { pageInfo: { hasNextPage: false }, edges: onChain },
+        },
+      }),
+    })) as unknown as typeof fetch;
+
+    const second = stubbedUploadService();
+    await second.service.uploadFolder({
+      folderPath,
+      folderIndex: createChainFolderIndex({
+        owner: { address: 'owner'.padEnd(43, 'x') },
+        fetchImpl,
+      }),
+      dataItemOpts: { tags: [{ name: 'Build-Id', value: '2' }] },
+    });
+
+    assert.equal(second.uploads.length, 3);
+    assert.equal(second.warnings.length, 1);
+    assert.match(second.warnings[0], /already on Arweave byte for byte/);
+  });
+
+  it('does not warn when an existing index is pointed at a different folder', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    const elsewhere = mkdtempSync(join(tmpdir(), 'turbo-folder-index-'));
+    writeFileSync(join(elsewhere, 'other.html'), '<h1>unrelated</h1>');
+    try {
+      const second = stubbedUploadService();
+      await second.service.uploadFolder({
+        folderPath: elsewhere,
+        folderIndex,
+      });
+
+      assert.equal(second.uploads.length, 1);
+      assert.deepEqual(second.warnings, []);
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+
+  it('does not warn when the index could not be reached', async () => {
+    // A swallowed read failure must not get blamed on dataItemOpts.
+    const { service, uploads, warnings } = stubbedUploadService();
+
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: composeFolderIndex([
+        createChainFolderIndex({
+          owner: { address: 'owner'.padEnd(43, 'x') },
+          fetchImpl: (async () => {
+            throw new Error('gateway is unreachable');
+          }) as unknown as typeof fetch,
+        }),
+      ]),
+    });
+
+    assert.equal(uploads.length, 3);
+    assert.deepEqual(warnings, []);
+  });
+
+  it('does not warn on a first ever deploy, when the index is simply empty', async () => {
+    const { service, uploads, warnings } = stubbedUploadService();
+
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: createMemoryFolderIndex(),
+    });
+
+    assert.equal(uploads.length, 3);
+    assert.deepEqual(warnings, []);
+  });
+
+  it('does not warn when only the content of a file changed', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex,
+    });
+
+    writeFileSync(join(folderPath, 'app.js'), 'console.log(2);');
+
+    const second = stubbedUploadService();
+    await second.service.uploadFolder({ folderPath, folderIndex });
+
+    assert.equal(second.uploads.length, 1);
+    assert.deepEqual(second.warnings, []);
+  });
+
+  it('stays quiet when the index cannot report what bytes it holds', async () => {
+    const folderIndex: TurboFolderUploadIndex = {
+      get: () => undefined,
+      set: () => undefined,
+    };
+
+    const { service, uploads, warnings } = stubbedUploadService();
+    await service.uploadFolder({ folderPath, folderIndex });
+
+    assert.equal(uploads.length, 3);
+    assert.deepEqual(warnings, []);
+  });
+
+  it('counts what landed, not what was planned, when an upload fails', async () => {
+    const { service, uploads } = stubbedUploadService({ failOn: 'javascript' });
+
+    const result = await service.uploadFolder({
+      folderPath,
+      folderIndex: createMemoryFolderIndex(),
+      throwOnFailure: false,
+    });
+
+    assert.equal(uploads.length, 2);
+    assert.equal(result.errors?.length, 1);
+    assert.equal(result.folderIndexSummary?.totalFiles, 3);
+    assert.equal(result.folderIndexSummary?.uploadedFiles, 2);
+    assert.equal(result.folderIndexSummary?.uploadedBytes, 18);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 0);
+    // app.js never landed, so it has no manifest entry.
+    assert.deepEqual(Object.keys(result.manifest?.paths ?? {}).sort(), [
+      'index.html',
+      'style.css',
+    ]);
+  });
+
+  it('accepts a deploy varying tag on manifestDataItemOpts', async () => {
+    const { service, uploads, manifestUploads } = stubbedUploadService();
+
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: createMemoryFolderIndex(),
+      manifestDataItemOpts: {
+        tags: [{ name: 'Git-Commit', value: 'deadbeef' }],
+      },
+    });
+
+    assert.equal(manifestUploads.length, 1);
+    assert.ok(
+      manifestUploads[0].tags.some(
+        (tag) => tag.name === 'Git-Commit' && tag.value === 'deadbeef',
+      ),
+    );
+    for (const upload of uploads) {
+      assert.equal(
+        upload.tags.some((tag) => tag.name === 'Git-Commit'),
+        false,
+      );
+    }
+  });
+});
+
+describe('uploadFolder without a folder index', () => {
+  let folderPath: string;
+
+  beforeEach(() => {
+    folderPath = mkdtempSync(join(tmpdir(), 'turbo-folder-index-'));
+    writeFileSync(join(folderPath, 'index.html'), '<h1>one</h1>');
+    writeFileSync(join(folderPath, 'style.css'), 'body{}');
+    writeFileSync(join(folderPath, 'copy.css'), 'body{}');
+  });
+
+  afterEach(() => {
+    rmSync(folderPath, { recursive: true, force: true });
+  });
+
+  it('sends exactly the tag set it sent before, File-SHA256 included', async () => {
+    const { service, uploads } = stubbedUploadService();
+
+    const callerTags = [
+      { name: 'Git-Commit', value: 'deadbeef' },
+      // A caller who was already computing their own hashes keeps their tag.
+      { name: contentHashTagName, value: 'whatever-they-had' },
+      { name: 'App-Name', value: 'my-app' },
+    ];
+    const result = await service.uploadFolder({
+      folderPath,
+      dataItemOpts: { tags: callerTags },
+    });
+
+    // Identical bytes are still uploaded twice, as they always were.
+    assert.equal(uploads.length, 3);
+    assert.equal(result.folderIndexSummary, undefined);
+
+    const byId = new Map(uploads.map((upload) => [upload.id, upload]));
+    const paths = result.manifest?.paths ?? {};
+    assert.deepEqual(byId.get(paths['style.css'].id)?.tags, [
+      { name: 'Git-Commit', value: 'deadbeef' },
+      { name: contentHashTagName, value: 'whatever-they-had' },
+      { name: 'App-Name', value: 'my-app' },
+      { name: 'Content-Type', value: 'text/css' },
+    ]);
+    assert.deepEqual(byId.get(paths['index.html'].id)?.tags, [
+      { name: 'Git-Commit', value: 'deadbeef' },
+      { name: contentHashTagName, value: 'whatever-they-had' },
+      { name: 'App-Name', value: 'my-app' },
+      { name: 'Content-Type', value: 'text/html' },
+    ]);
+  });
+});
+
+describe('createFileFolderIndex', () => {
+  let folderPath: string;
+  let cachePath: string;
+  let indexPath: string;
+
+  const records = (path: string) =>
+    readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line));
+
+  const entriesOnDisk = (path: string) =>
+    Object.fromEntries(
+      records(path)
+        .filter((record) => record.k !== undefined)
+        .map((record) => [record.k, record.i]),
+    );
+
+  beforeEach(() => {
+    folderPath = mkdtempSync(join(tmpdir(), 'turbo-folder-index-'));
+    // Outside the uploaded folder, or the index would upload itself.
+    cachePath = mkdtempSync(join(tmpdir(), 'turbo-folder-cache-'));
+    indexPath = join(cachePath, 'nested', 'turbo-index.jsonl');
+    writeFileSync(join(folderPath, 'index.html'), '<h1>one</h1>');
+    writeFileSync(join(folderPath, 'app.js'), 'console.log(1);');
+  });
+
+  afterEach(() => {
+    rmSync(folderPath, { recursive: true, force: true });
+    rmSync(cachePath, { recursive: true, force: true });
+  });
+
+  it('persists after every upload, so a killed run keeps what it paid for', async () => {
+    const { service, uploads } = stubbedUploadService();
+
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: createFileFolderIndex({ filePath: indexPath }),
+      manifestOptions: { disableManifest: true },
+    });
+
+    assert.deepEqual(
+      Object.values(entriesOnDisk(indexPath)).sort(),
+      uploads.map((upload) => upload.id).sort(),
+    );
+    assert.equal(records(indexPath)[0].folderIndex, 2);
+    assert.equal(existsSync(`${indexPath}.tmp`), false);
+  });
+
+  it('appends rather than rewriting, so a bulk load is linear', () => {
+    const folderIndex = createFileFolderIndex({ filePath: indexPath });
+
+    // Rewriting the whole file per entry is quadratic: measured at 4,000
+    // entries it was ~9.8s and ~1.4 GiB written, purely on bookkeeping, and it
+    // is first deploys and migrations that pay it.
+    const sizes: number[] = [];
+    let prefix = '';
+    for (let n = 0; n < 200; n++) {
+      folderIndex.set(
+        `${n.toString(16).padStart(64, '0')}.${'0'.repeat(64)}`,
+        `id${n}`.padEnd(43, 'x'),
+      );
+      const contents = readFileSync(indexPath, 'utf-8');
+      if (n === 0) {
+        prefix = contents;
+      } else {
+        // Every earlier byte is untouched: this is an append, not a rewrite.
+        assert.equal(contents.startsWith(prefix), true);
+        prefix = contents;
+      }
+      sizes.push(contents.length);
+    }
+
+    // Each write costs one record, so total bytes are linear in entries.
+    const perEntry = sizes[199] / 200;
+    assert.ok(perEntry < 200, `expected ~1 record per entry, got ${perEntry}`);
+    assert.equal(Object.keys(entriesOnDisk(indexPath)).length, 200);
+  });
+
+  it('survives a torn write, losing one record rather than all of them', async () => {
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex: createFileFolderIndex({ filePath: indexPath }),
+      manifestOptions: { disableManifest: true },
+    });
+
+    // A process killed mid write. A whole-file rewrite would leave nothing
+    // loadable here; an append can only damage its last line.
+    const contents = readFileSync(indexPath, 'utf-8');
+    writeFileSync(
+      indexPath,
+      contents.slice(0, Math.floor(contents.length * 0.9)),
+    );
+
+    const folderIndex = createFileFolderIndex({ filePath: indexPath });
+    const survivors = Object.keys((await folderIndex.entries?.()) ?? {});
+    assert.equal(survivors.length, 1);
+  });
+
+  it('compacts a log that has accumulated repeats when it is loaded', async () => {
+    const key = `${'a'.repeat(64)}.${'b'.repeat(64)}`;
+    const first = createFileFolderIndex({ filePath: indexPath });
+    for (let n = 0; n < 5; n++) {
+      first.set(key, `id${n}`.padEnd(43, 'x'));
+    }
+    assert.equal(records(indexPath).length, 6); // header + 5 appends
+
+    const reloaded = createFileFolderIndex({ filePath: indexPath });
+    // Last write wins, and the log is rewritten to one record.
+    assert.equal(await reloaded.get(key), 'id4'.padEnd(43, 'x'));
+    assert.equal(records(indexPath).length, 2);
+    assert.equal(existsSync(`${indexPath}.tmp`), false);
+  });
+
+  it('is read back on the next run, so nothing is uploaded twice', async () => {
+    await stubbedUploadService().service.uploadFolder({
+      folderPath,
+      folderIndex: createFileFolderIndex({ filePath: indexPath }),
+    });
+
+    const second = stubbedUploadService();
+    const result = await second.service.uploadFolder({
+      folderPath,
+      folderIndex: createFileFolderIndex({ filePath: indexPath }),
+    });
+
+    assert.equal(second.uploads.length, 0);
+    assert.equal(result.folderIndexSummary?.reusedFiles, 2);
+  });
+
+  it('drops malformed records rather than publishing a manifest pointing at nothing', async () => {
+    const { service } = stubbedUploadService();
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: createFileFolderIndex({ filePath: indexPath }),
+    });
+
+    const onDisk = entriesOnDisk(indexPath);
+    const [goodKey] = Object.keys(onDisk);
+    const otherKey = `${'c'.repeat(64)}.${'d'.repeat(64)}`;
+    appendFileSync(
+      indexPath,
+      [
+        JSON.stringify({ k: otherKey, i: 'truncated-id' }),
+        JSON.stringify({ k: 'not-a-key', i: 'idZ'.padEnd(43, 'x') }),
+        '{ not json at all',
+      ].join('\n') + '\n',
+    );
+
+    const folderIndex = createFileFolderIndex({ filePath: indexPath });
+    // Neither malformed record is loadable...
+    assert.equal(await folderIndex.get(otherKey), undefined);
+    assert.equal(await folderIndex.get('not-a-key'), undefined);
+    // ...and neither one destroys an id the run already paid for.
+    assert.equal(await folderIndex.get(goodKey), onDisk[goodKey]);
+  });
+
+  it('rebuilds itself when nothing in the file is readable', async () => {
+    const corruptPath = join(cachePath, 'corrupt-index.jsonl');
+    writeFileSync(corruptPath, 'not json\nnor this\n');
+
+    const folderIndex = createFileFolderIndex({ filePath: corruptPath });
+    assert.deepEqual(await folderIndex.entries?.(), {});
+  });
+
+  it('reports bytes it holds under any tag set', async () => {
+    const { service, uploads } = stubbedUploadService();
+    await service.uploadFolder({
+      folderPath,
+      folderIndex: createFileFolderIndex({ filePath: indexPath }),
+      manifestOptions: { disableManifest: true },
+    });
+
+    const folderIndex = createFileFolderIndex({ filePath: indexPath });
+    const contentHashes = uploads.map((upload) => upload.contentHash as string);
+    assert.deepEqual(
+      (await folderIndex.knownContentHashes?.([
+        ...contentHashes,
+        'f'.repeat(64),
+      ])) ?? [],
+      contentHashes,
+    );
+  });
+});

--- a/packages/turbo-sdk/src/node/upload.ts
+++ b/packages/turbo-sdk/src/node/upload.ts
@@ -15,6 +15,8 @@
  */
 import { createReadStream, promises, statSync } from 'fs';
 import { lookup } from 'mime-types';
+import { createHash } from 'node:crypto';
+import { pipeline } from 'node:stream/promises';
 import { join } from 'path';
 import { Readable } from 'stream';
 
@@ -116,5 +118,11 @@ export class TurboAuthenticatedUploadService extends TurboAuthenticatedBaseUploa
 
   createManifestStream(manifestBuffer: Buffer): Readable {
     return Readable.from(manifestBuffer);
+  }
+
+  protected async computeContentHash(file: string): Promise<string> {
+    const hash = createHash('sha256');
+    await pipeline(createReadStream(file), hash);
+    return hash.digest('hex');
   }
 }

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -462,10 +462,153 @@ type FinalizedStatusResponse = {
   receipt: TurboUploadDataItemResponse;
 };
 
+/**
+ * A map from a folder index key to a data item id, used by `uploadFolder` to
+ * skip files that are already on Arweave.
+ *
+ * A key is `<sha-256 of the bytes>.<sha-256 of the tags>`. Both halves matter:
+ * an empty `a.css` and an empty `b.js` have identical bytes but must not share
+ * a data item, or one of them is served with the other's `Content-Type`. Keying
+ * on the tags too means a reused item is always exactly the item this call
+ * would otherwise have created. Treat keys as opaque.
+ *
+ * Implement this to back an index with any store. Ready made layers ship with
+ * the SDK: `createMemoryFolderIndex`, `createChainFolderIndex`,
+ * `createFileFolderIndex` (NodeJS only) and `composeFolderIndex`.
+ *
+ * An index is a cache. `uploadFolder` treats a read that throws as a miss and
+ * carries on, so a layer is free to fail rather than degrade.
+ */
+export type TurboFolderUploadIndex = {
+  /** Human readable name for the layer, used in debug logs. */
+  name?: string;
+  /** When true the layer is never written to. Defaults to false. */
+  readOnly?: boolean;
+  /** The data item id previously uploaded for this key, if it is known. */
+  get(key: string): Promise<string | undefined> | string | undefined;
+  /** Record that `key` was uploaded as `id`. */
+  set(key: string, id: string): Promise<void> | void;
+  /**
+   * Optional bulk lookup, so a layer backed by a network can answer in one
+   * round trip instead of one request per file. `uploadFolder` calls `get` for
+   * every key first and then `resolve` once with whatever is still unknown,
+   * passing through the caller's `signal`.
+   */
+  resolve?(
+    keys: string[],
+    options?: { signal?: AbortSignal },
+  ): Promise<Record<string, string>>;
+  /**
+   * Optional, diagnostics only. Of these content hashes -- the bytes half of a
+   * key -- which does the layer hold under *some* tag set?
+   *
+   * A file whose bytes are already on Arweave but whose key is not is the exact
+   * signature of a per file tag that changes between deploys, and it is the one
+   * thing `uploadFolder` can say about a cost cliff that is otherwise silent.
+   * Never consulted to decide what to upload.
+   */
+  knownContentHashes?(contentHashes: string[]): Promise<string[]> | string[];
+  /** Optional snapshot of everything the layer currently knows. */
+  entries?(): Promise<Record<string, string>> | Record<string, string>;
+};
+
+/**
+ * Whose past uploads a chain folder index sweeps.
+ *
+ * Tagged rather than a bare string on purpose. A gateway indexes an upload
+ * under the base64url sha-256 of the signer's public key, and a raw 32 byte
+ * ed25519 public key base64urls to exactly 43 characters -- the same shape as
+ * that address. There is no way to tell the two apart by inspection, and
+ * guessing wrong means the sweep matches nothing and the whole folder is
+ * re-uploaded at full price with no error at all.
+ *
+ * `await turbo.signer.getPublicKey()` is the one form every signer type can
+ * produce, so it is passed directly.
+ */
+export type ChainFolderUploadIndexOwner =
+  | Uint8Array
+  | { publicKey: Uint8Array | string; address?: undefined }
+  | { address: string; publicKey?: undefined };
+
+export type ChainFolderUploadIndexParams = {
+  /**
+   * Whose past uploads to sweep. Pass `await turbo.signer.getPublicKey()`,
+   * which works for every signer type, or tag what you have as
+   * `{ publicKey }` or `{ address }`. A bare string is rejected: see
+   * {@link ChainFolderUploadIndexOwner}.
+   */
+  owner: ChainFolderUploadIndexOwner;
+  /** Optional `App-Name` tag value, to narrow the sweep to one application. */
+  appName?: string;
+  /** Gateway to query. Defaults to `https://arweave.net`. */
+  gatewayUrl?: string;
+  /** Tag holding each file's content hash. Defaults to `File-SHA256`. */
+  hashTagName?: string;
+  /** Maximum GraphQL pages to walk before giving up. Defaults to 20. */
+  maxPages?: number;
+  /** GraphQL page size. Defaults to 100. */
+  pageSize?: number;
+  /** Per request timeout in milliseconds. Defaults to 30_000. */
+  timeoutMs?: number;
+  /** Override the fetch implementation, e.g. in tests. */
+  fetchImpl?: typeof fetch;
+};
+
+export type ComposeFolderUploadIndexParams = {
+  /** Optional logger, used to report a layer that failed and was skipped. */
+  logger?: TurboLogger;
+};
+
+export type FileFolderUploadIndexParams = {
+  /** Path of the JSON file holding the index. Created if it does not exist. */
+  filePath: string;
+  /** Optional logger, used to report an unreadable index file. */
+  logger?: TurboLogger;
+};
+
+/**
+ * What an index-backed `uploadFolder` reused rather than paid for again.
+ *
+ * `uploadedFiles` counts data items that actually landed, so with
+ * `throwOnFailure: false` the three counts do not have to sum to `totalFiles`
+ * -- the difference is what failed.
+ */
+export type TurboFolderUploadIndexSummary = {
+  /** Every file in the folder, uploaded, reused or failed. */
+  totalFiles: number;
+  totalBytes: number;
+  /** Files that were paid for and landed. */
+  uploadedFiles: number;
+  uploadedBytes: number;
+  /** Files served from the index, or duplicated within this folder. */
+  reusedFiles: number;
+  reusedBytes: number;
+};
+
 type UploadFolderParams = {
   dataItemOpts?: DataItemOptions;
   maxConcurrentUploads?: number;
   throwOnFailure?: boolean;
+
+  /**
+   * A folder index. When provided, every file is hashed and only the files
+   * whose bytes and tags are not already on Arweave are signed, uploaded and
+   * paid for. The manifest is assembled from the ids that were already known
+   * plus the ids of whatever this run uploaded.
+   *
+   * Files uploaded with an index in place carry an extra `File-SHA256` tag.
+   */
+  folderIndex?: TurboFolderUploadIndex;
+
+  /**
+   * `dataItemOpts` for the manifest only. Defaults to `dataItemOpts`.
+   *
+   * The manifest is rewritten on every deploy, so it is where deploy varying
+   * tags such as a commit sha belong. A per file tag that changes between
+   * deploys changes every `folderIndex` key, and so re-uploads the whole
+   * folder.
+   */
+  manifestDataItemOpts?: DataItemOptions;
 
   manifestOptions?: {
     disableManifest?: boolean;
@@ -506,11 +649,18 @@ export type TurboRevokeCreditsParams = {
 };
 
 export type TurboUploadFolderResponse = {
+  /**
+   * One response per data item this call uploaded. With a `folderIndex` in
+   * place, files that were reused have no response here -- they are in the
+   * manifest and counted in `folderIndexSummary` instead.
+   */
   fileResponses: TurboUploadDataItemResponse[];
   manifestResponse?: TurboUploadDataItemResponse;
   manifest?: ArweaveManifest;
   errors?: Error[];
   cryptoFundResult?: TurboCryptoFundResponse;
+  /** Only present when `folderIndex` was provided. */
+  folderIndexSummary?: TurboFolderUploadIndexSummary;
 };
 
 export type ArweaveManifest = {

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -484,6 +484,14 @@ export type TurboFolderUploadIndex = {
   name?: string;
   /** When true the layer is never written to. Defaults to false. */
   readOnly?: boolean;
+  /**
+   * The tag name this layer expects a file's content hash under.
+   *
+   * `uploadFolder` writes whatever the index declares here, so a layer that
+   * reads a non-default tag is aligned with the uploader rather than silently
+   * unable to match anything. Defaults to `File-SHA256`.
+   */
+  hashTagName?: string;
   /** The data item id previously uploaded for this key, if it is known. */
   get(key: string): Promise<string | undefined> | string | undefined;
   /** Record that `key` was uploaded as `id`. */
@@ -542,7 +550,13 @@ export type ChainFolderUploadIndexParams = {
   appName?: string;
   /** Gateway to query. Defaults to `https://arweave.net`. */
   gatewayUrl?: string;
-  /** Tag holding each file's content hash. Defaults to `File-SHA256`. */
+  /**
+   * Tag holding each file's content hash. Defaults to `File-SHA256`.
+   *
+   * `uploadFolder` writes this same tag when this index is passed to it, so the
+   * sweep and the uploader cannot drift apart. Every layer in a
+   * {@link composeFolderIndex} stack that declares one must agree.
+   */
   hashTagName?: string;
   /** Maximum GraphQL pages to walk before giving up. Defaults to 20. */
   maxPages?: number;
@@ -552,6 +566,11 @@ export type ChainFolderUploadIndexParams = {
   timeoutMs?: number;
   /** Override the fetch implementation, e.g. in tests. */
   fetchImpl?: typeof fetch;
+  /**
+   * Optional logger. Used to report a sweep that ran out of pages before it ran
+   * out of files, which otherwise costs money silently.
+   */
+  logger?: TurboLogger;
 };
 
 export type ComposeFolderUploadIndexParams = {

--- a/packages/turbo-sdk/src/utils/folderIndex.ts
+++ b/packages/turbo-sdk/src/utils/folderIndex.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internals shared by the folder index layers and by `uploadFolder`. Not part
+ * of the package's public surface.
+ */
+
+/** Tag carrying the sha-256 of a file's own bytes, as lowercase hex. */
+export const contentHashTagName = 'File-SHA256';
+
+const contentHashRegex = /^[0-9a-f]{64}$/;
+const folderIndexKeyRegex = /^[0-9a-f]{64}\.[0-9a-f]{64}$/;
+
+/** True for a lowercase hex sha-256 digest of a file's bytes. */
+export function isValidContentHash(hash: string | undefined): hash is string {
+  return hash !== undefined && contentHashRegex.test(hash);
+}
+
+/**
+ * A folder index key is `<sha-256 of the bytes>.<sha-256 of the tags>`.
+ *
+ * Both halves matter. Keying on the bytes alone would reuse an item whose tags
+ * are not the ones the caller asked for: an empty `a.css` and an empty `b.js`
+ * hash identically, and reusing one for the other would serve JavaScript as
+ * `text/css`. Keying on the tags as well means a reused data item is always
+ * exactly the data item this call would otherwise have created.
+ *
+ * The bytes half is kept in the clear so a layer that queries a gateway can
+ * recover it and filter on the `File-SHA256` tag.
+ */
+export function isValidFolderIndexKey(key: string | undefined): key is string {
+  return key !== undefined && folderIndexKeyRegex.test(key);
+}
+
+/** The bytes half of a folder index key. */
+export function contentHashFromFolderIndexKey(key: string): string {
+  return key.slice(0, 64);
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Buffer.from(digest).toString('hex');
+}
+
+/**
+ * Canonical encoding of a tag set: the same tags in a different order encode
+ * identically, because two data items that differ only in tag order are the
+ * same item as far as reuse goes.
+ *
+ * The sort compares code units rather than using `localeCompare`, which is not
+ * a total order over distinct strings and depends on the host's ICU data --
+ * NFC and NFD spellings of the same word compare equal without being equal, and
+ * two locales disagree on where an accented letter sorts. Either would let one
+ * tag set hash differently on two machines, which costs a reuse.
+ *
+ * The encoding has to be injective, not merely stable. An ANS-104 tag name and
+ * value are arbitrary byte arrays, so a delimiter-joined string collides: with
+ * a 0x00/0x01 join, a single tag whose value embeds both delimiters encodes
+ * exactly like two separate tags. A collision here is a wrong reuse, which is
+ * the one failure the composite key exists to make impossible. JSON escapes
+ * the delimiters, so no value can forge a record boundary.
+ */
+function canonicalTags(tags: { name: string; value: string }[]): Uint8Array {
+  const pairs = tags
+    .map((tag) => [tag.name, tag.value])
+    .sort(([aName, aValue], [bName, bValue]) => {
+      const [a, b] = aName === bName ? [aValue, bValue] : [aName, bName];
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+  return new TextEncoder().encode(JSON.stringify(pairs));
+}
+
+/** The folder index key for a file with these bytes and these final tags. */
+export async function folderIndexKey({
+  contentHash,
+  tags,
+}: {
+  contentHash: string;
+  tags: { name: string; value: string }[];
+}): Promise<string> {
+  return `${contentHash}.${await sha256Hex(canonicalTags(tags))}`;
+}

--- a/packages/turbo-sdk/src/web/upload.folderIndex.test.ts
+++ b/packages/turbo-sdk/src/web/upload.folderIndex.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { createMemoryFolderIndex } from '../common/folderIndex.js';
+import {
+  TurboUploadDataItemResponse,
+  TurboUploadFileParams,
+} from '../types.js';
+import { contentHashTagName } from '../utils/folderIndex.js';
+import { TurboAuthenticatedUploadService } from './index.js';
+
+const manifestContentType = 'application/x.arweave-manifest+json';
+
+let dataItemCounter = 0;
+
+type RecordedUpload = {
+  id: string;
+  tags: { name: string; value: string }[];
+  contentHash: string | undefined;
+};
+
+function stubbedUploadService() {
+  const service = new TurboAuthenticatedUploadService({
+    signer: {} as never,
+    paymentService: {} as never,
+  });
+
+  const uploads: RecordedUpload[] = [];
+
+  const uploadFile = async (
+    params: TurboUploadFileParams,
+  ): Promise<TurboUploadDataItemResponse> => {
+    const tags = params.dataItemOpts?.tags ?? [];
+    const id = `web${dataItemCounter++}`.padEnd(43, 'x');
+    const isManifest = tags.some(
+      (tag) => tag.name === 'Content-Type' && tag.value === manifestContentType,
+    );
+    if (!isManifest) {
+      uploads.push({
+        id,
+        tags,
+        contentHash: tags.find((tag) => tag.name === contentHashTagName)?.value,
+      });
+    }
+    return { id } as TurboUploadDataItemResponse;
+  };
+
+  (service as unknown as { uploadFile: typeof uploadFile }).uploadFile =
+    uploadFile;
+
+  return { service, uploads };
+}
+
+const newFiles = () => [
+  new File(['<h1>one</h1>'], 'index.html', { type: 'text/html' }),
+  new File(['console.log(1);'], 'app.js', { type: 'text/javascript' }),
+];
+
+describe('web uploadFolder with a folder index', () => {
+  it('hashes each File and tags it with its content hash', async () => {
+    const { service, uploads } = stubbedUploadService();
+
+    await service.uploadFolder({
+      files: newFiles(),
+      folderIndex: createMemoryFolderIndex(),
+    });
+
+    assert.equal(uploads.length, 2);
+    for (const upload of uploads) {
+      assert.match(upload.contentHash ?? '', /^[0-9a-f]{64}$/);
+    }
+    // Distinct bytes, distinct hashes.
+    assert.equal(new Set(uploads.map((upload) => upload.contentHash)).size, 2);
+  });
+
+  it('uploads nothing when the same bytes are offered again', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    const first = await stubbedUploadService().service.uploadFolder({
+      files: newFiles(),
+      folderIndex,
+    });
+
+    const second = stubbedUploadService();
+    const result = await second.service.uploadFolder({
+      files: newFiles(),
+      folderIndex,
+    });
+
+    assert.equal(second.uploads.length, 0);
+    assert.deepEqual(result.folderIndexSummary, {
+      totalFiles: 2,
+      totalBytes: 27,
+      uploadedFiles: 0,
+      uploadedBytes: 0,
+      reusedFiles: 2,
+      reusedBytes: 27,
+    });
+    assert.deepEqual(result.manifest?.paths, first.manifest?.paths);
+  });
+
+  it('uploads only the File whose bytes changed', async () => {
+    const folderIndex = createMemoryFolderIndex();
+
+    const first = await stubbedUploadService().service.uploadFolder({
+      files: newFiles(),
+      folderIndex,
+    });
+
+    const second = stubbedUploadService();
+    const result = await second.service.uploadFolder({
+      files: [
+        new File(['<h1>one</h1>'], 'index.html', { type: 'text/html' }),
+        new File(['console.log(2);'], 'app.js', { type: 'text/javascript' }),
+      ],
+      folderIndex,
+    });
+
+    assert.equal(second.uploads.length, 1);
+    assert.equal(
+      result.manifest?.paths['index.html'].id,
+      first.manifest?.paths['index.html'].id,
+    );
+    assert.equal(result.manifest?.paths['app.js'].id, second.uploads[0].id);
+  });
+
+  it('pays twice for identical bytes with different content types', async () => {
+    const { service, uploads } = stubbedUploadService();
+
+    const result = await service.uploadFolder({
+      files: [
+        new File([''], 'a.css', { type: 'text/css' }),
+        new File([''], 'b.js', { type: 'text/javascript' }),
+      ],
+      folderIndex: createMemoryFolderIndex(),
+    });
+
+    assert.equal(uploads.length, 2);
+    const paths = result.manifest?.paths ?? {};
+    assert.notEqual(paths['a.css'].id, paths['b.js'].id);
+    assert.equal(uploads[0].contentHash, uploads[1].contentHash);
+  });
+
+  it('treats an index read that throws as a miss rather than a failed upload', async () => {
+    const { service, uploads } = stubbedUploadService();
+
+    const result = await service.uploadFolder({
+      files: newFiles(),
+      folderIndex: {
+        get: () => {
+          throw new Error('cache is down');
+        },
+        set: () => undefined,
+      },
+    });
+
+    assert.equal(uploads.length, 2);
+    assert.equal(Object.keys(result.manifest?.paths ?? {}).length, 2);
+  });
+});


### PR DESCRIPTION
## Measured effect

Against the live Turbo service, using the reference implementation this is a port of:

- **Production bundle** — 143 files / 15.46 MiB uploaded for 124,820,529,305 winc. An immediate re-check reported `reusing 143, uploading 0, quote 0 winc`. Live result: <https://arweave.net/GeMni2e9upBJyDPKzPpVkT3mRuW0La1j28LBPpVXUhs/>
- **4-file fixture** — run 1 uploaded 4; an unchanged run 2 uploaded 0 and reused 4; a one-byte edit uploaded exactly 1, reused 3, and the gateway served the edited content.

## The problem

`turbo.uploadFolder` re-signs and re-pays for every file on every run. An Arweave upload is permanent, so paying a second time for byte-identical files buys nothing. Most build tools content-hash their output, so between two deploys of a real site only a couple of entry chunks actually change — yet today the whole bundle is signed, uploaded and billed again.

## The design

Pass a `folderIndex` and `uploadFolder`:

1. hashes every file in the folder (sha-256) and derives its index key;
2. asks the index which of those keys already have a data item id;
3. signs and uploads only the rest, recording each id the instant it lands;
4. builds the `arweave/paths` manifest from the remembered ids plus the new ones.

```typescript
import {
  composeFolderIndex,
  createChainFolderIndex,
  createFileFolderIndex,
} from '@ardrive/turbo-sdk/node';

const folderIndex = composeFolderIndex([
  createFileFolderIndex({ filePath: '.turbo/folder-index.jsonl' }),
  // getPublicKey() is the one form every signer type can produce.
  createChainFolderIndex({ owner: await turbo.signer.getPublicKey() }),
]);

const { manifest, folderIndexSummary } = await turbo.uploadFolder({
  folderPath: './dist',
  folderIndex,
  manifestDataItemOpts: {
    tags: [{ name: 'Git-Commit', value: process.env.GITHUB_SHA }],
  },
});
// folderIndexSummary -> { totalFiles: 143, uploadedFiles: 2, reusedFiles: 141, ... }
```

## What a reused file is matched on

**An index key is `<sha-256 of the bytes>.<sha-256 of the tags>`, and both halves matter.**

Keying on the bytes alone reuses a data item whose tags are not the ones you asked for. An empty `a.css` and an empty `b.js` hash identically, so a bytes-only index uploads one item tagged `text/css` and points both manifest paths at it — and `/b.js` is then served as `text/css`, which a browser refuses to execute. Covering the tags means a reused data item is always exactly the data item the call would otherwise have created: same bytes, same `Content-Type`, same `dataItemOpts` tags.

The tags digest is `JSON.stringify` of the name/value pairs, sorted by code unit rather than `localeCompare` (which is not a total order over distinct strings and varies with the host's ICU data, so the same tag set could hash differently on two machines), and not a delimiter join. Tag values are arbitrary bytes, so a `\u0000`/`\u0001` join collides — `[{a, "b\u0001c\u0000d"}]` and `[{a,b},{c,d}]` encode identically — and a collision here is a *wrong reuse*, the one failure this design exists to rule out.

Files uploaded with an index carry one extra tag, `File-SHA256`, holding the sha-256 of their own bytes. That tag is what `createChainFolderIndex` filters on; it recomputes the full key from the tags a returned node carries.

## The trade-off this buys, and how you find out

Covering the tags has a real cost cliff, and it is the first thing a reviewer should push on.

**A per-file tag whose value changes between deploys changes every key, and re-uploads the whole folder at full price.** A commit sha, build number or timestamp in `dataItemOpts` means nothing is ever reused — and the deploy still succeeds, so nothing about the run looks wrong except the bill.

That is deliberate. The alternative, keying on bytes alone, reuses an item tagged with a *previous* deploy's commit sha, so the tags on chain quietly stop describing what is on chain. A wrong bill is recoverable; a data item that misdescribes itself is permanent. The index errs towards paying again.

To stop the cliff being silent, `uploadFolder` logs a warning — through the logger it already has — when a file it is about to upload has bytes the index already holds **under a different set of tags**:

```
3 of the 3 file(s) this run is about to upload are already on Arweave byte for
byte, under a different set of tags. Their content has not changed but their tags
have, so they are being paid for again. A folder index key covers the tags on a
file as well as its bytes. That is usually a tag in dataItemOpts whose value
changes between deploys -- a commit sha, a build number, a timestamp -- in which
case move it to manifestDataItemOpts rather than paying for these files again. It
can also be a file that kept its content but changed its Content-Type, through a
rename or a new extension, which is expected and costs one upload.
```

The signal is derived, not guessed: a key is `<bytes>.<tags>`, so a file whose *bytes half* the index knows under some other tags half is precisely a file whose content is already paid for and whose tags moved. A folder the index has never seen has unknown bytes and does not trigger it; a layer that could not be reached reports nothing known and does not trigger it; and it fires for one drifted file among a hundred reused ones, not only on a total miss. A file that kept its content but changed its `Content-Type` through a rename does trigger it, and the message says so. The chain layer supplies this for free, since its GraphQL filter is on `File-SHA256` values alone and therefore sees every item with matching bytes whatever tags it carries — so it works on a CI runner with nothing cached. A layer that does not implement the optional `knownContentHashes` cannot answer and stays quiet. Seven tests cover the four firing and non-firing cases.

## API surface, and why

Additive options on the existing `uploadFolder` rather than a parallel method:

| Option / field                           | Where    | What it does                                                                                                                     |
| ---------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
| `folderIndex?: TurboFolderUploadIndex`   | param    | Turns on content-addressed reuse.                                                                                                  |
| `manifestDataItemOpts?: DataItemOptions` | param    | `dataItemOpts` for the manifest only. Defaults to `dataItemOpts`.                                                                  |
| `folderIndexSummary?`                    | response | `{ totalFiles, totalBytes, uploadedFiles, uploadedBytes, reusedFiles, reusedBytes }`, present only when `folderIndex` was passed. |

A parallel `uploadFolderIncremental` would have had to duplicate the whole of `uploadFolder` — funding modes, chunking, the folder/file event bridge, manifest generation — and would have drifted on the next change to any of those. Reuse is one decision inside the existing flow, so it is one option on the existing flow. It is `folderIndex` rather than `index` because `uploadFolder` already has `manifestOptions.indexFile` and an Arweave manifest's own `index` field means the landing page.

**With no new options, behaviour is unchanged**: nothing is hashed, no tag is added or removed, `manifestDataItemOpts` falls back to `dataItemOpts`, and `folderIndexSummary` is absent. A test pins the complete tag set of two uploads in the no-index path — including a caller-supplied `File-SHA256` tag surviving untouched — plus assertions that duplicate bytes are still uploaded twice and no summary is produced.

Three behaviours *do* change when `folderIndex` is passed, all documented and tested:

- `fileResponses` holds a response only for the files this run actually uploaded — reused files appear in the manifest and in `folderIndexSummary`;
- progress events count that same subset, since that is all the call is doing;
- manifest `paths` are built in folder order rather than completion order, so an unchanged folder produces byte-identical manifest bytes (and a stable manifest data item id) run after run.

`folderIndexSummary.uploadedFiles` counts what **landed**, not what was planned, so with `throwOnFailure: false` the counts deliberately do not sum to `totalFiles` — the difference is what failed.

## Index layers

Anything with `get`/`set` is a valid `TurboFolderUploadIndex`. Keys are opaque. Four layers ship:

| Layer                                                      | Where it lives   | Survives a fresh checkout |
| ---------------------------------------------------------- | ---------------- | ------------------------- |
| `createMemoryFolderIndex(seed?)`                           | memory           | no                        |
| `createFileFolderIndex({ filePath })` *(NodeJS)*           | a JSON lines log | only if the file is kept  |
| `createChainFolderIndex({ owner, appName?, gatewayUrl? })` | gateway GraphQL  | yes                       |
| `composeFolderIndex([...], { logger? })`                   | layers the above | —                         |

`createFileFolderIndex` is an **append-only log compacted on load**. It has to be written after every single upload — an upload paid for but forgotten is money burnt, and a deploy killed part-way through is the normal case — and appending is constant work where rewriting the whole file per upload is quadratic (measured: 4,000 entries cost ~9.8 s and ~1.4 GiB of writes, all bookkeeping, on first deploys and migrations). It is also strictly more crash-safe than a rewrite: a process killed mid-write can only damage the last line, which is dropped on load, where a torn rewrite loses every id in the file. Compaction goes through a temp file and a rename.

**A layer that throws is skipped, not propagated.** That is the point of stacking them: a full disk under the file layer must not stop the memory layer from holding ids the run has already paid for, and an unreachable gateway must not stop the local cache from answering. `get`, `set`, `resolve`, `entries` and `knownContentHashes` each isolate per layer and log which one was skipped.

An index is a cache at the `uploadFolder` level too: a `get` or `resolve` that throws is logged and treated as a miss, so an unreachable gateway costs a re-upload rather than failing the deploy. The chain index also refuses to trust the gateway's reply shape — a missing `transactions`, a non-array `edges`, a node with no id or no tags array are each handled — breaks on a page with no edges (since `after` only advances from an edge), validates `pageSize`, `maxPages` and `timeoutMs`, and threads the caller's `signal` so aborting the upload aborts the sweep. The timeout and the caller's signal cover the **whole** request including the body read, not just the headers: a gateway that flushes headers and then stalls would otherwise hang the sweep forever, and `uploadFolder` awaits it inline.

### Telling a gateway whose uploads to sweep

`owner` is a **tagged union, not a string**, and this is the one API decision here worth arguing about. A gateway matches `owners:` on the base64url sha-256 of the signer's public key. A raw 32-byte ed25519 public key base64urls to exactly 43 characters — the same shape as that address — so no amount of inspection can tell them apart, and guessing wrong sends the key unhashed, matches nothing, and re-uploads the whole folder with no error anywhere. Exactly the failure this PR exists to prevent.

So: pass `await turbo.signer.getPublicKey()` (bytes, works for every signer type) and the SDK derives the address, or say which you have with `{ publicKey }` / `{ address }`. A bare string is rejected with an explanation, and a declared public key is length-checked against the sizes the supported signers actually produce (32 / 65 / 512) — otherwise an empty or truncated buffer still hashes to a well-formed address that matches nothing, which is the same silent re-upload one level in. A 32-byte value declared as a `publicKey` is taken at its word, since an owner address is also 32 bytes and nothing can distinguish them; that is exactly why the caller has to declare. An `0x…` or base58 address is rejected, because `owners:` does not match those. Verified against `arweave.net`: `owners` matches the 43-character address and returns **0 edges** for the raw public key, so the conversion must happen client-side.

### Trust model

The sweep is scoped to `owners: [your own address]`, so it can only find items you signed. Within that scope `File-SHA256` is **self-asserted** — a tag your own past uploads wrote, not something a gateway verifies against the bytes — and the index trusts it. That is safe for uploads this SDK made, since it only ever writes a hash it computed from the file in front of it. It stops being safe if `hashTagName` is pointed at a tag you were already using for something else: any of your own items carrying 64 hex characters under that name becomes a candidate, and one whose tag set happens to match would put a manifest path in front of unrelated bytes. Documented in the README.

## Web

Both entry points are supported. NodeJS overrides the digest with a streaming `node:crypto` hash so a large file is never held in memory. The browser has no streaming WebCrypto digest, so each `File` is buffered whole before hashing — a very large `File` can exhaust the tab, and the README says so. `createFileFolderIndex` is NodeJS-only and exported only from `@ardrive/turbo-sdk/node`.

## Honest limitation

A gateway indexes an upload minutes after it lands. Two machines deploying the same **brand new** file at the same moment can therefore each pay for it once. Only the bill is affected, and only for genuinely new bytes — it never produces a wrong manifest. A local file index in front of the chain index removes the window for the common single-runner case.

## Tests

67 new tests across three files, in the existing `node:test` + injected-fake style used by `payment.freeStatus.test.ts` and friends:

- `src/common/folderIndex.test.ts` — key composition (different content types produce different keys; tag order does not matter; the delimiter-collision regression); the memory index; compose fall-through, write-back, and a throwing layer being skipped by `get`, `set`, `resolve` and `knownContentHashes`; owner derivation asserted **against an independently computed address** for 32-byte ed25519, 65-byte secp256k1 and 512-byte RSA keys, plus the bare-string and native-address rejections; and the chain index over a stubbed `fetch` — reconstructing a key from a node's tags, *not* matching a node whose tags differ while still remembering its bytes, skipping malformed edges/nodes, stopping on an empty page, aborting on the caller's signal, timing out and aborting a **stalled response body**, and rejecting unusable `pageSize`/`maxPages`/`timeoutMs` and public-key lengths.
- `src/node/upload.folderIndex.test.ts` — `uploadFolder` end-to-end against a stubbed `uploadFile` and a captured logger: unchanged re-run uploads nothing and produces a byte-identical manifest; a one-file edit uploads exactly one; identical bytes with the same content type pay once; **identical bytes with different content types pay twice and keep their own `Content-Type`**; a changed tag re-uploads rather than reusing stale tags; the stale-tag warning fires on a whole-folder drift, on one file among many, and on a chain-only index, and stays silent on a new folder, an unreachable gateway, a first deploy, a content-only change, and a layer without `knownContentHashes`; counts report what landed when an upload fails; the no-index tag set is pinned exactly. Plus the file index: append-only writes verified byte-wise, a torn write losing one record instead of all, compaction on load, malformed records dropped without destroying good ones.
- `src/web/upload.folderIndex.test.ts` — the same core cases over `File` objects, exercising the WebCrypto digest path.

## Checks

- `yarn lint` — clean.
- `yarn build` — clean (web bundle, esm, cjs, types).
- `prettier --check .` — clean.
- `yarn test:unit` — 156 tests, 149 pass, 7 fail. All 7 failures are pre-existing and unrelated: on Windows, `tests/helpers.ts` builds a wallet path with `new URL(...).pathname`, which yields `/C:/…` and then `ENOENT: open 'C:\C:\…'`. The same 7 files fail identically on a clean checkout of `alpha`. Every new test passes.
- `yarn test:docker` — **not run.** `docker compose pull` fails with `unauthorized` for `ghcr.io/ardriveapp/upload-service` and `payment-service`. The integration suites in `tests/` are unverified locally and will need CI.

## Deliberately left out

- **No CLI flag.** Wiring `--folder-index-file` and friends into `src/cli/options.ts` is a follow-up — happy to do it in this PR if you would rather the API ship with a real caller.
- **No change to manifest behaviour under `throwOnFailure: false`.** Files that failed are omitted from `paths`, exactly as today.
- **`target`, `anchor` and `paidBy` are not part of the index key** — only the bytes and the tags. They do not affect what a gateway serves for a manifest path.

Happy to split this, rename anything, or move the index factories elsewhere in the tree.
