### PR TITLE
fix(arns): export the ANT-owner helpers from the package entry point

### DIFF
--- a/packages/turbo-sdk/src/common/index.ts
+++ b/packages/turbo-sdk/src/common/index.ts
@@ -15,6 +15,9 @@
  */
 export * from './upload.js';
 export * from './payment.js';
+// The ANT-owner helpers. Without this the documented
+// `import { solanaOwnerSigner } from '@ardrive/turbo-sdk'` does not resolve.
+export * from './arnsActions.js';
 export * from './turbo.js';
 export * from './currency.js';
 export * from './token/index.js';

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -500,6 +500,57 @@ describe('emptySignatureSlots', () => {
   });
 });
 
+describe('public export surface', () => {
+  // A regression guard. `solanaOwnerSigner` shipped in 1.42.0-alpha.9 built but
+  // NOT re-exported from the package index, so the documented
+  // `import { solanaOwnerSigner } from '@ardrive/turbo-sdk'` did not resolve.
+  // The unit suite could not catch it because it imports module paths directly;
+  // only installing the tarball did. These assert the barrel, not the module.
+  it('re-exports the ANT-owner helpers the README tells callers to import', async () => {
+    const index = await import('./index.js');
+    for (const name of [
+      'solanaOwnerSigner',
+      'emptySignatureSlots',
+      'buildArNSCustodyMessage',
+    ]) {
+      assert.equal(
+        typeof (index as Record<string, unknown>)[name],
+        'function',
+        `${name} must be reachable from the package entry point`,
+      );
+    }
+  });
+
+  it('exposes every sponsored action on the authenticated client', async () => {
+    const { TurboAuthenticatedClient } = await import('./turbo.js');
+    for (const method of [
+      'createArNSAction',
+      'signArNSAction',
+      'getArNSActionStatus',
+      'buyArNSName',
+      'extendArNSLease',
+      'upgradeArNSName',
+      'increaseArNSUndernameLimit',
+      'setArNSRecord',
+      'removeArNSRecord',
+      'addArNSController',
+      'removeArNSController',
+      'transferArNSAnt',
+    ]) {
+      assert.equal(
+        typeof (
+          TurboAuthenticatedClient.prototype as unknown as Record<
+            string,
+            unknown
+          >
+        )[method],
+        'function',
+        `${method} missing from the authenticated client`,
+      );
+    }
+  });
+});
+
 /**
  * A real unsigned v0 transaction, base64, shaped like one Turbo prepares:
  * a separate FEE PAYER plus the ANT owner as an additional required signer.


### PR DESCRIPTION
**`1.42.0-alpha.9` is unusable for the documented import.** Found by installing the published tarball into a scratch project rather than trusting the build.

```js
const sdk = require('@ardrive/turbo-sdk');
sdk.solanaOwnerSigner;   // undefined
```

The README (and the console integration brief) both tell callers to write `import { solanaOwnerSigner } from '@ardrive/turbo-sdk'`. That import does not resolve.

## Why every existing check missed it

`arnsActions.ts` built, typechecked, and had 100% unit coverage — but it was never re-exported from `common/index.ts`.

- The **unit suite** imports `./arnsActions.js` directly.
- The **on-chain e2e** imports `lib/esm/common/arnsActions.js`.

Both reach the module without going through the barrel, so neither could see the gap. Only an install-and-require caught it.

## Fix

Re-export `solanaOwnerSigner`, `emptySignatureSlots` and `buildArNSCustodyMessage` from `common/index.ts`.

## Guards

Two tests that assert the **barrel**, not the module:

1. the helpers are reachable from the package entry point
2. all twelve sponsored actions are present on `TurboAuthenticatedClient.prototype`

I verified the first actually fails when the export line is removed (`# fail 1`, naming `solanaOwnerSigner`) and passes when restored — so it isn't a guard that can't fail.

158 unit tests pass, lint and format clean.

**This needs a fresh alpha publish** before the console can use the documented import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTi1Pd388d9Kh11oU98aES
