### PR TITLE
feat(arns): add record metadata and record transfer actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,11 +1128,18 @@ Revoking is always available and always free.
 
 ### Not covered — these still cost you SOL
 
-`primary-name`, `release-name`, `reassign` and ANT metadata
-(name/description/keywords/logo) are **not sponsored**. They stay on the
-direct-signer path via [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk).
-Don't tell users they can "manage a name forever without SOL" — scope the claim
-to the nine actions above.
+Sponsorship covers the **twelve actions above and nothing else**. Everything
+else in the ArNS, ANT and core programs stays on the direct-signer path via
+[`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk) and costs the user SOL —
+notably **buying a returned name** (auctions, deliberately excluded: the
+premium is unbounded), claiming a reserved name, the **primary-name** flow
+(which lives in the ario _core_ program), release/reassign, and **ANT-level**
+metadata.
+
+Note ANT-level metadata (the ANT's own name/ticker/description/keywords/logo)
+is distinct from RECORD-level metadata, which `setArNSRecordMetadata` does
+sponsor. Don't tell users they can "manage a name forever without SOL" — scope
+the claim to the twelve actions above.
 
 ### Pricing — quote the total
 

--- a/packages/turbo-sdk/src/common/arnsActions.ts
+++ b/packages/turbo-sdk/src/common/arnsActions.ts
@@ -31,10 +31,40 @@ import { toB64Url } from '../utils/base64.js';
  * revert a record to an older value).
  */
 export function buildArNSCustodyMessage(
-  action: 'set-record' | 'remove-record',
+  action:
+    | 'set-record'
+    | 'remove-record'
+    | 'set-record-metadata'
+    | 'remove-record-metadata'
+    | 'transfer-record',
   fields: string[],
 ): string {
   return ['arns', action, ...fields].join('\n');
+}
+
+/**
+ * A metadata field's ABSENT/EMPTY distinction, as the bundler binds it.
+ *
+ * `null` (clear the field) must not sign the same message as `''` (set it to
+ * empty), or a signature authorizing one would authorize the other. NUL can
+ * never appear in a value that reached here — the route rejects control
+ * characters — so it is a safe sentinel.
+ */
+export function arNSMetadataField(value: string | null | undefined): string {
+  return value === null || value === undefined ? '\u0000' : value;
+}
+
+/**
+ * Keywords joined on a separator the route rejects INSIDE a keyword, so
+ * `['a,b']` and `['a','b']` cannot be re-partitioned into one another with the
+ * same signature.
+ */
+export function arNSKeywordsField(
+  keywords: readonly string[] | null | undefined,
+): string {
+  return keywords === null || keywords === undefined
+    ? '\u0000'
+    : keywords.join('\u0001');
 }
 
 /** Solana's signature-type discriminator in Turbo's signed-request scheme. */

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -551,6 +551,126 @@ describe('public export surface', () => {
   });
 });
 
+describe('ArNS record-scoped actions', () => {
+  const completed = (action: string) => ({
+    nonce: 'n',
+    action,
+    status: 'completed',
+    messageId: 'm',
+  });
+
+  /** Does the owner proof verify against this candidate message? */
+  const signedMessage = (headers: Record<string, string>, candidate: string) =>
+    nacl.sign.detached.verify(
+      Uint8Array.from(Buffer.from(candidate + headers['x-owner-nonce'])),
+      fromB64Url(headers['x-owner-signature']),
+      ownerKeypair.publicKey.toBytes(),
+    );
+
+  const NUL = '\u0000';
+  const SEP = '\u0001';
+
+  it('binds every metadata field into the owner proof', async () => {
+    const http = new FakeHttp();
+    http.responses = [completed('set-record-metadata')];
+    await serviceWith(http).setArNSRecordMetadata({
+      antId: 'ant1',
+      owner,
+      displayName: 'My Blog',
+      recordDescription: 'hello',
+      recordKeywords: ['a', 'b'],
+    });
+    const expected = [
+      'arns',
+      'set-record-metadata',
+      'ant1',
+      '@',
+      'My Blog',
+      NUL, // recordLogo omitted -> absent sentinel
+      'hello',
+      ['a', 'b'].join(SEP),
+    ].join('\n');
+    assert.ok(
+      signedMessage(http.last.headers, expected),
+      'proof is bound to every field',
+    );
+  });
+
+  it('sends CLEAR (null) and EMPTY (empty string) distinguishably', async () => {
+    const http = new FakeHttp();
+    http.responses = [
+      completed('set-record-metadata'),
+      completed('set-record-metadata'),
+    ];
+    const svc = serviceWith(http);
+    await svc.setArNSRecordMetadata({
+      antId: 'a',
+      owner,
+      recordDescription: null,
+    });
+    assert.equal(body(http.last).recordDescription, null);
+    await svc.setArNSRecordMetadata({
+      antId: 'a',
+      owner,
+      recordDescription: '',
+    });
+    assert.equal(body(http.last).recordDescription, '');
+  });
+
+  it('omits an undefined field entirely, so it is left unchanged', async () => {
+    const http = new FakeHttp();
+    http.responses = [completed('set-record-metadata')];
+    await serviceWith(http).setArNSRecordMetadata({
+      antId: 'a',
+      owner,
+      displayName: 'only this',
+    });
+    const sent = body(http.last);
+    assert.ok(!('recordLogo' in sent), 'untouched fields are not sent');
+    assert.equal(sent.displayName, 'only this');
+  });
+
+  it('removeArNSRecordMetadata binds antId + undername', async () => {
+    const http = new FakeHttp();
+    http.responses = [completed('remove-record-metadata')];
+    await serviceWith(http).removeArNSRecordMetadata({
+      antId: 'ant1',
+      owner,
+      undername: 'docs',
+    });
+    assert.equal(http.last.endpoint, '/arns/actions/remove-record-metadata');
+    assert.ok(
+      signedMessage(
+        http.last.headers,
+        ['arns', 'remove-record-metadata', 'ant1', 'docs'].join('\n'),
+      ),
+    );
+  });
+
+  it('transferArNSRecord cannot be replayed as a whole-ANT transfer', async () => {
+    const http = new FakeHttp();
+    http.responses = [completed('transfer-record')];
+    await serviceWith(http).transferArNSRecord({
+      antId: 'ant1',
+      owner,
+      undername: 'docs',
+      target: 'dest1',
+    });
+    const h = http.last.headers;
+    assert.ok(
+      signedMessage(
+        h,
+        ['arns', 'transfer-record', 'ant1', 'docs', 'dest1'].join('\n'),
+      ),
+      'signs the record-transfer message',
+    );
+    assert.ok(
+      !signedMessage(h, ['arns', 'transfer', 'ant1', 'dest1'].join('\n')),
+      'the whole-ANT transfer message must NOT verify against this proof',
+    );
+  });
+});
+
 /**
  * A real unsigned v0 transaction, base64, shaped like one Turbo prepares:
  * a separate FEE PAYER plus the ANT owner as an additional required signer.

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -81,6 +81,8 @@ import {
 } from '../utils/errors.js';
 import { uuidV4 } from '../utils/uuid.js';
 import {
+  arNSKeywordsField,
+  arNSMetadataField,
   arNSOwnerProofHeaders,
   buildArNSCustodyMessage,
 } from './arnsActions.js';
@@ -1098,6 +1100,115 @@ export class TurboAuthenticatedPaymentService
       owner,
       { onNonce },
       buildArNSCustodyMessage('remove-record', [antId, undername]),
+    );
+  }
+
+  /**
+   * Edit a RECORD's metadata — its display name, logo, description, keywords.
+   *
+   * Free, and owner-or-controller on chain, so it behaves exactly like
+   * {@link setArNSRecord}: Turbo-alone while it is a controller, owner-signed
+   * after a revoke.
+   *
+   * Fields are TRI-STATE. Omit one to leave it unchanged; pass `null` to clear
+   * it. Those are bound distinctly by the owner proof, so "clear the
+   * description" and "set it to empty" are different authorizations.
+   *
+   * Note this is RECORD metadata. ANT-level metadata (the ANT's own name,
+   * ticker, description, keywords, logo) is NOT sponsored and stays on the
+   * direct-signer path via `@ar.io/sdk`.
+   */
+  public async setArNSRecordMetadata({
+    antId,
+    owner,
+    undername = '@',
+    displayName,
+    recordLogo,
+    recordDescription,
+    recordKeywords,
+    onNonce,
+  }: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername?: string;
+    displayName?: string | null;
+    recordLogo?: string | null;
+    recordDescription?: string | null;
+    recordKeywords?: string[] | null;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted> {
+    return this.completeArNSAction(
+      'set-record-metadata',
+      {
+        antId,
+        ownerAddress: await owner.getAddress(),
+        undername,
+        // Sent explicitly, including `null`, so the server sees the same
+        // tri-state the proof was signed over.
+        ...(displayName !== undefined ? { displayName } : {}),
+        ...(recordLogo !== undefined ? { recordLogo } : {}),
+        ...(recordDescription !== undefined ? { recordDescription } : {}),
+        ...(recordKeywords !== undefined ? { recordKeywords } : {}),
+      },
+      owner,
+      { onNonce },
+      buildArNSCustodyMessage('set-record-metadata', [
+        antId,
+        undername,
+        arNSMetadataField(displayName),
+        arNSMetadataField(recordLogo),
+        arNSMetadataField(recordDescription),
+        arNSKeywordsField(recordKeywords),
+      ]),
+    );
+  }
+
+  /** Clear a record's metadata. Free; same two-shape rules. */
+  public async removeArNSRecordMetadata({
+    antId,
+    owner,
+    undername,
+    onNonce,
+  }: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted> {
+    return this.completeArNSAction(
+      'remove-record-metadata',
+      { antId, ownerAddress: await owner.getAddress(), undername },
+      owner,
+      { onNonce },
+      buildArNSCustodyMessage('remove-record-metadata', [antId, undername]),
+    );
+  }
+
+  /**
+   * Hand ONE record to another address.
+   *
+   * Distinct from {@link transferArNSAnt}, which hands over the whole ANT and
+   * every record on it. Confusing the two gives away far more than intended.
+   */
+  public async transferArNSRecord({
+    antId,
+    owner,
+    undername,
+    target,
+    onNonce,
+  }: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+    target: string;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted> {
+    return this.completeArNSAction(
+      'transfer-record',
+      { antId, ownerAddress: await owner.getAddress(), undername, target },
+      owner,
+      { onNonce },
+      buildArNSCustodyMessage('transfer-record', [antId, undername, target]),
     );
   }
 

--- a/packages/turbo-sdk/src/common/turbo.test.ts
+++ b/packages/turbo-sdk/src/common/turbo.test.ts
@@ -97,3 +97,146 @@ describe('TurboAuthenticatedClient', () => {
     });
   });
 });
+
+describe('TurboAuthenticatedClient — ArNS action delegation', () => {
+  // These are one-line pass-throughs, but "one line" is exactly where a wrong
+  // param name or a dropped argument hides: nothing fails until the service
+  // 400s at runtime. The unit suite otherwise drives the payment service
+  // directly, so the client surface consumers actually call was untested.
+  const forwarded: { method: string; params: unknown }[] = [];
+
+  const recording = new Proxy({} as Record<string, unknown>, {
+    get:
+      (_t, method: string) =>
+      async (...args: unknown[]) => {
+        forwarded.push({ method, params: args[0] });
+        return {
+          nonce: 'n',
+          action: method,
+          status: 'completed',
+          messageId: 'm',
+        };
+      },
+  }) as unknown as TurboAuthenticatedPaymentServiceInterface;
+
+  const client = new TurboAuthenticatedClient({
+    paymentService: recording,
+    uploadService: {} as unknown as TurboAuthenticatedUploadServiceInterface,
+    signer: {} as unknown as TurboDataItemSigner,
+  });
+
+  const owner = { getAddress: () => 'OWNER' } as never;
+
+  it('forwards every ArNS action to the payment service unchanged', async () => {
+    const cases: [string, () => Promise<unknown>, Record<string, unknown>][] = [
+      [
+        'buyArNSName',
+        () => client.buyArNSName({ name: 'n', owner, type: 'lease', years: 1 }),
+        { name: 'n', owner, type: 'lease', years: 1 },
+      ],
+      [
+        'extendArNSLease',
+        () => client.extendArNSLease({ name: 'n', years: 2 }),
+        { name: 'n', years: 2 },
+      ],
+      [
+        'upgradeArNSName',
+        () => client.upgradeArNSName({ name: 'n' }),
+        { name: 'n' },
+      ],
+      [
+        'increaseArNSUndernameLimit',
+        () => client.increaseArNSUndernameLimit({ name: 'n', increaseQty: 5 }),
+        { name: 'n', increaseQty: 5 },
+      ],
+      [
+        'setArNSRecord',
+        () => client.setArNSRecord({ antId: 'a', owner, transactionId: 't' }),
+        { antId: 'a', owner, transactionId: 't' },
+      ],
+      [
+        'removeArNSRecord',
+        () => client.removeArNSRecord({ antId: 'a', owner, undername: 'u' }),
+        { antId: 'a', owner, undername: 'u' },
+      ],
+      [
+        'addArNSController',
+        () => client.addArNSController({ antId: 'a', owner }),
+        { antId: 'a', owner },
+      ],
+      [
+        'removeArNSController',
+        () => client.removeArNSController({ antId: 'a', owner }),
+        { antId: 'a', owner },
+      ],
+      [
+        'transferArNSAnt',
+        () => client.transferArNSAnt({ antId: 'a', owner, target: 'd' }),
+        { antId: 'a', owner, target: 'd' },
+      ],
+      [
+        'setArNSRecordMetadata',
+        () =>
+          client.setArNSRecordMetadata({ antId: 'a', owner, displayName: 'D' }),
+        { antId: 'a', owner, displayName: 'D' },
+      ],
+      [
+        'removeArNSRecordMetadata',
+        () =>
+          client.removeArNSRecordMetadata({
+            antId: 'a',
+            owner,
+            undername: 'u',
+          }),
+        { antId: 'a', owner, undername: 'u' },
+      ],
+      [
+        'transferArNSRecord',
+        () =>
+          client.transferArNSRecord({
+            antId: 'a',
+            owner,
+            undername: 'u',
+            target: 'd',
+          }),
+        { antId: 'a', owner, undername: 'u', target: 'd' },
+      ],
+    ];
+
+    for (const [method, call, expected] of cases) {
+      forwarded.length = 0;
+      await call();
+      assert.equal(
+        forwarded.length,
+        1,
+        `${method} called the service exactly once`,
+      );
+      assert.equal(
+        forwarded[0].method,
+        method,
+        `${method} routed to the right service method`,
+      );
+      assert.deepEqual(
+        forwarded[0].params,
+        expected,
+        `${method} forwarded its params unchanged`,
+      );
+    }
+  });
+
+  it('forwards the raw action trio too', async () => {
+    forwarded.length = 0;
+    await client.createArNSAction('buy-name', { name: 'n' });
+    assert.equal(forwarded[0].method, 'createArNSAction');
+
+    forwarded.length = 0;
+    await client.signArNSAction('nonce-1', 'BASE64');
+    assert.equal(forwarded[0].method, 'signArNSAction');
+    assert.equal(forwarded[0].params, 'nonce-1');
+
+    forwarded.length = 0;
+    await client.getArNSActionStatus('nonce-1');
+    assert.equal(forwarded[0].method, 'getArNSActionStatus');
+    assert.equal(forwarded[0].params, 'nonce-1');
+  });
+});

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -536,6 +536,45 @@ export class TurboAuthenticatedClient
     return this.paymentService.removeArNSController(params);
   }
 
+  /**
+   * Edit a RECORD's metadata (display name, logo, description, keywords).
+   * Free; handles both shapes. Fields are tri-state — omit to leave unchanged,
+   * pass `null` to clear.
+   */
+  setArNSRecordMetadata(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername?: string;
+    displayName?: string | null;
+    recordLogo?: string | null;
+    recordDescription?: string | null;
+    recordKeywords?: string[] | null;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted> {
+    return this.paymentService.setArNSRecordMetadata(params);
+  }
+
+  /** Clear a record's metadata. Free; handles both shapes. */
+  removeArNSRecordMetadata(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted> {
+    return this.paymentService.removeArNSRecordMetadata(params);
+  }
+
+  /** Hand ONE record over — not the whole ANT. Free; handles both shapes. */
+  transferArNSRecord(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+    target: string;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted> {
+    return this.paymentService.transferArNSRecord(params);
+  }
+
   /** Hand the ANT to a new owner. Irreversible. Free. */
   transferArNSAnt(params: {
     antId: string;

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -1118,9 +1118,13 @@ export type ArNSPriceResponse = {
 /**
  * The nine sponsored ArNS actions.
  *
- * NOT included, because the bundler does not sponsor them: `primary-name`,
- * `release-name`, `reassign`, and ANT metadata (name/description/keywords/logo).
- * Those stay on the direct-signer path and cost the user SOL.
+ * Sponsorship covers these twelve and NOTHING else. Everything else in the
+ * ArNS, ANT and core programs stays on the direct-signer path and costs the
+ * user SOL — notably `BuyReturnedName` (auctions, deliberately excluded: the
+ * premium is unbounded), `ClaimReservedName`, the primary-name flow (which
+ * lives in the ario core program), release/reassign, and ANT-LEVEL metadata.
+ * Note ANT-level metadata is distinct from RECORD-level metadata, which
+ * `set-record-metadata` does sponsor.
  */
 export const arNSActions = [
   'buy-name',
@@ -1132,6 +1136,11 @@ export const arNSActions = [
   'add-controller',
   'remove-controller',
   'transfer',
+  // Record-scoped. Owner-or-controller on chain, so these follow set-record's
+  // degrade-on-revoke shape rather than needing a signature every time.
+  'set-record-metadata',
+  'remove-record-metadata',
+  'transfer-record',
 ] as const;
 export type ArNSAction = (typeof arNSActions)[number];
 
@@ -1539,6 +1548,29 @@ export interface TurboAuthenticatedPaymentServiceInterface
   transferArNSAnt(params: {
     antId: string;
     owner: ArNSOwnerSigner;
+    target: string;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted>;
+  setArNSRecordMetadata(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername?: string;
+    displayName?: string | null;
+    recordLogo?: string | null;
+    recordDescription?: string | null;
+    recordKeywords?: string[] | null;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted>;
+  removeArNSRecordMetadata(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+    onNonce?: (nonce: string) => void | Promise<void>;
+  }): Promise<ArNSActionCompleted>;
+  transferArNSRecord(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
     target: string;
     onNonce?: (nonce: string) => void | Promise<void>;
   }): Promise<ArNSActionCompleted>;

--- a/packages/turbo-sdk/tests/e2e/arns-actions.e2e.mjs
+++ b/packages/turbo-sdk/tests/e2e/arns-actions.e2e.mjs
@@ -145,6 +145,47 @@ try {
     'record actions cost the customer NOTHING',
   );
 
+  head('6d', 'Record metadata - set, then clear, both free and Turbo-alone');
+  const beforeMeta = await winc();
+  const metaSet = await turbo.setArNSRecordMetadata({
+    antId,
+    owner,
+    displayName: 'My Blog',
+    recordDescription: 'written by the SDK e2e',
+    recordKeywords: ['arweave', 'ar-io'],
+  });
+  check(
+    metaSet.status === 'completed',
+    'set-record-metadata completed Turbo-alone',
+  );
+  const metaGone = await turbo.removeArNSRecordMetadata({
+    antId,
+    owner,
+    undername: '@',
+  });
+  check(metaGone.status === 'completed', 'remove-record-metadata completed');
+  check(
+    (await winc()) === beforeMeta,
+    'record metadata cost the customer NOTHING',
+  );
+
+  head('6e', 'transfer-record - hand ONE record over, not the whole ANT');
+  await turbo.setArNSRecord({
+    antId,
+    owner,
+    undername: 'blog',
+    transactionId: VALID_TX_ID,
+    ttlSeconds: 900,
+  });
+  const recMoved = await turbo.transferArNSRecord({
+    antId,
+    owner,
+    undername: 'blog',
+    target: Keypair.generate().publicKey.toBase58(),
+  });
+  check(recMoved.status === 'completed', 'record ownership moved on chain');
+  check(!!recMoved.messageId, `messageId ${recMoved.messageId}`);
+
   head(7, 'Revoke Turbo - the escape hatch, owner-signed and free');
   const revoked = await turbo.removeArNSController({ antId, owner });
   check(revoked.status === 'completed', 'Turbo revoked on chain');


### PR DESCRIPTION
Follows the bundler taking its sponsored surface from nine actions to twelve (ar-io/ar-io-bundler#299): `setArNSRecordMetadata`, `removeArNSRecordMetadata`, `transferArNSRecord`.

All three are **owner-or-controller on chain**, so they behave exactly like `setArNSRecord` — Turbo-alone while it is a controller, owner-signed after a revoke — and the existing two-shape branch handles both with no change.

## Tri-state metadata, preserved end to end

Omitting a field leaves it unchanged; `null` clears it. These are bound **distinctly** in the owner proof, so a signature authorizing *"clear the description"* does not authorize *"set it to empty string"*.

Keywords join on a separator the route rejects inside a keyword, so `['a,b']` and `['a','b']` cannot be re-partitioned into one another under the same signature.

## Tests assert the binding, not just the shape

The proof signature is verified against the exact expected message. And a record transfer is checked **not** to verify against the whole-ANT transfer message — that replay would give away far more than intended, so it gets an explicit negative rather than being assumed impossible.

## Verified on chain

Through the **built** SDK against a live bundler (Solana devnet, owner key never funded):

- `set-record-metadata` completes **Turbo-alone**
- `remove-record-metadata` completes
- both cost the customer **zero** — balance asserted unchanged
- `transfer-record` lands with a real `messageId`
- every pre-existing stage still passes

Plus **163 unit tests**, lint, build and format clean.

## Scope

The README now states sponsorship **positively** — twelve actions and nothing else — and calls out that RECORD-level metadata is sponsored while **ANT-level** metadata is not. The two are easy to confuse and sit beside each other in the program.

Notably still excluded: buying a returned name (auctions — the premium is unbounded, so sponsoring it is an open-ended treasury exposure rather than a fixed rent cost), claiming a reserved name, the primary-name flow (ario *core* program), and release/reassign.

**Merge after ar-io/ar-io-bundler#299**, which ships the routes these call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTi1Pd388d9Kh11oU98aES
