### PR TITLE
docs(arns): record, controller and transfer actions are no longer free

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,8 @@ await turbo.extendArNSLease({ name: 'my-name', years: 2 });
 await turbo.upgradeArNSName({ name: 'my-name' });
 await turbo.increaseArNSUndernameLimit({ name: 'my-name', increaseQty: 5 });
 
-// Records — free, and handled whichever shape the server picks.
+// Records — handled whichever shape the server picks. Costs credits (a small
+// margin), never SOL.
 await turbo.setArNSRecord({
   antId,
   owner,
@@ -1106,7 +1107,7 @@ await turbo.setArNSRecord({
 });
 await turbo.removeArNSRecord({ antId, owner, undername: 'docs' });
 
-// Controllers and transfer — owner-signed, free.
+// Controllers and transfer — owner-signed. Cost credits, never SOL.
 await turbo.addArNSController({ antId, owner }); // omit target => Turbo
 await turbo.removeArNSController({ antId, owner }); // the revoke
 await turbo.transferArNSAnt({ antId, owner, target: newOwnerAddress });
@@ -1119,12 +1120,15 @@ await turbo.transferArNSAnt({ antId, owner, target: newOwnerAddress });
 | `setArNSRecord` / `removeArNSRecord`                                 | no            | only after you revoke Turbo |
 | `addArNSController` / `removeArNSController` / `transferArNSAnt`     | no            | yes                         |
 
-Only the four purchase actions debit credits. Records, controllers and transfer
-are free — Turbo sponsors the SOL.
+**Every action debits credits.** The four purchase actions pay for the name
+itself; the other eight carry a small margin covering the Solana fees and rent
+Turbo fronts. Record, controller and transfer actions used to be free — that
+changed, because a zero-cost action could be turned into value through the
+refund path. The customer still never needs SOL.
 
 `buyArNSName` grants Turbo controller rights **inside the same transaction you
 sign**, which is why `setArNSRecord` needs no transaction signature afterwards.
-Revoking is always available and always free.
+Revoking is always available, and costs a small credit margin rather than SOL.
 
 ### Not covered — these still cost you SOL
 

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -1037,7 +1037,7 @@ export class TurboAuthenticatedPaymentService
   /**
    * Point a name (or undername) at an Arweave transaction.
    *
-   * Free — Turbo sponsors the Solana fee. Completes in one call while Turbo is
+   * Costs a small credit margin — never SOL, which Turbo sponsors. Completes in one call while Turbo is
    * a controller of the ANT, and returns `awaiting-signature` once the customer
    * has revoked Turbo, at which point `owner` signs it themselves. Both paths
    * are handled here.
@@ -1082,7 +1082,7 @@ export class TurboAuthenticatedPaymentService
     );
   }
 
-  /** Remove a record (an undername). Free; same two-shape rules as setArNSRecord. */
+  /** Remove a record (an undername). Costs credits, never SOL. */
   public async removeArNSRecord({
     antId,
     owner,
@@ -1106,7 +1106,8 @@ export class TurboAuthenticatedPaymentService
   /**
    * Edit a RECORD's metadata — its display name, logo, description, keywords.
    *
-   * Free, and owner-or-controller on chain, so it behaves exactly like
+   * Costs a small credit margin (never SOL), and is owner-or-controller on
+   * chain, so it behaves exactly like
    * {@link setArNSRecord}: Turbo-alone while it is a controller, owner-signed
    * after a revoke.
    *
@@ -1163,7 +1164,7 @@ export class TurboAuthenticatedPaymentService
     );
   }
 
-  /** Clear a record's metadata. Free; same two-shape rules. */
+  /** Clear a record's metadata. Costs credits, never SOL; same two-shape rules. */
   public async removeArNSRecordMetadata({
     antId,
     owner,
@@ -1217,7 +1218,8 @@ export class TurboAuthenticatedPaymentService
    * is what makes `setArNSRecord` a single call.
    *
    * Owner-signed: changing an ANT's access control is an owner-only
-   * instruction. Free to the customer — Turbo funds the ACL page growth.
+   * instruction. Costs a small credit margin; Turbo funds the ACL page growth
+   * in SOL.
    */
   public async addArNSController({
     antId,
@@ -1246,7 +1248,8 @@ export class TurboAuthenticatedPaymentService
    * Revoke controller rights — the escape hatch that keeps "Turbo is not a
    * custodian" honest.
    *
-   * Always available, always free, and needs nothing from Turbo but the fee.
+   * Always available, and needs nothing from Turbo but the fee. Costs a small
+   * credit margin rather than SOL.
    * After revoking, `setArNSRecord` keeps working: it simply starts returning
    * `awaiting-signature` so the owner signs their own record writes.
    */

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -516,7 +516,7 @@ export class TurboAuthenticatedClient
     return this.paymentService.removeArNSRecord(params);
   }
 
-  /** Grant controller rights — omit `target` for Turbo itself. Free. */
+  /** Grant controller rights — omit `target` for Turbo itself. Costs credits. */
   addArNSController(params: {
     antId: string;
     owner: ArNSOwnerSigner;
@@ -526,7 +526,7 @@ export class TurboAuthenticatedClient
     return this.paymentService.addArNSController(params);
   }
 
-  /** Revoke controller rights. Always available, always free. */
+  /** Revoke controller rights. Always available; costs credits, never SOL. */
   removeArNSController(params: {
     antId: string;
     owner: ArNSOwnerSigner;
@@ -554,7 +554,7 @@ export class TurboAuthenticatedClient
     return this.paymentService.setArNSRecordMetadata(params);
   }
 
-  /** Clear a record's metadata. Free; handles both shapes. */
+  /** Clear a record's metadata. Costs credits, never SOL; handles both shapes. */
   removeArNSRecordMetadata(params: {
     antId: string;
     owner: ArNSOwnerSigner;
@@ -564,7 +564,7 @@ export class TurboAuthenticatedClient
     return this.paymentService.removeArNSRecordMetadata(params);
   }
 
-  /** Hand ONE record over — not the whole ANT. Free; handles both shapes. */
+  /** Hand ONE record over — not the whole ANT. Costs credits, never SOL. */
   transferArNSRecord(params: {
     antId: string;
     owner: ArNSOwnerSigner;
@@ -575,7 +575,7 @@ export class TurboAuthenticatedClient
     return this.paymentService.transferArNSRecord(params);
   }
 
-  /** Hand the ANT to a new owner. Irreversible. Free. */
+  /** Hand the ANT to a new owner. Irreversible. Costs credits, never SOL. */
   transferArNSAnt(params: {
     antId: string;
     owner: ArNSOwnerSigner;


### PR DESCRIPTION
The bundler changed ([ar-io/ar-io-bundler#303](https://github.com/ar-io/ar-io-bundler/pull/303)): **every ArNS action now debits credits.** The eight non-purchase actions carry a small margin covering the Solana fees and rent Turbo fronts — because a zero-cost action could be turned into value through the refund path.

The SDK told a different story in **eight places**: README examples annotated `free`, the per-action table, and JSDoc on `setArNSRecord`, `removeArNSRecord`, the metadata pair, `transferArNSRecord` and both controller methods. Anyone building UI copy from those would tell users these operations are free.

Corrected to what is actually true, and the more useful claim anyway: **they cost Turbo Credits, never SOL.** The customer still never holds SOL — that property is unchanged and is the whole point.

165 tests, lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTi1Pd388d9Kh11oU98aES