### PR TITLE
docs(arns): fix 6 stale "free" claims after ar-io-bundler PR #303

### DIFF
--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -1037,7 +1037,8 @@ export class TurboAuthenticatedPaymentService
   /**
    * Point a name (or undername) at an Arweave transaction.
    *
-   * Free — Turbo sponsors the Solana fee. Completes in one call while Turbo is
+   * Recovers a small credits margin (never a lamport of SOL from the
+   * customer — Turbo sponsors that). Completes in one call while Turbo is
    * a controller of the ANT, and returns `awaiting-signature` once the customer
    * has revoked Turbo, at which point `owner` signs it themselves. Both paths
    * are handled here.
@@ -1082,7 +1083,7 @@ export class TurboAuthenticatedPaymentService
     );
   }
 
-  /** Remove a record (an undername). Free; same two-shape rules as setArNSRecord. */
+  /** Remove a record (an undername). Recovers a small margin; same two-shape rules as setArNSRecord. */
   public async removeArNSRecord({
     antId,
     owner,
@@ -1106,9 +1107,9 @@ export class TurboAuthenticatedPaymentService
   /**
    * Edit a RECORD's metadata — its display name, logo, description, keywords.
    *
-   * Free, and owner-or-controller on chain, so it behaves exactly like
-   * {@link setArNSRecord}: Turbo-alone while it is a controller, owner-signed
-   * after a revoke.
+   * Recovers a small margin, and owner-or-controller on chain, so it behaves
+   * exactly like {@link setArNSRecord}: Turbo-alone while it is a controller,
+   * owner-signed after a revoke.
    *
    * Fields are TRI-STATE. Omit one to leave it unchanged; pass `null` to clear
    * it. Those are bound distinctly by the owner proof, so "clear the
@@ -1163,7 +1164,7 @@ export class TurboAuthenticatedPaymentService
     );
   }
 
-  /** Clear a record's metadata. Free; same two-shape rules. */
+  /** Clear a record's metadata. Recovers a small margin; same two-shape rules. */
   public async removeArNSRecordMetadata({
     antId,
     owner,
@@ -1217,7 +1218,8 @@ export class TurboAuthenticatedPaymentService
    * is what makes `setArNSRecord` a single call.
    *
    * Owner-signed: changing an ANT's access control is an owner-only
-   * instruction. Free to the customer — Turbo funds the ACL page growth.
+   * instruction. Recovers a small credits margin — never a lamport of SOL
+   * from the customer, Turbo still funds the ACL page growth itself.
    */
   public async addArNSController({
     antId,
@@ -1246,9 +1248,11 @@ export class TurboAuthenticatedPaymentService
    * Revoke controller rights — the escape hatch that keeps "Turbo is not a
    * custodian" honest.
    *
-   * Always available, always free, and needs nothing from Turbo but the fee.
-   * After revoking, `setArNSRecord` keeps working: it simply starts returning
-   * `awaiting-signature` so the owner signs their own record writes.
+   * Always available — never a lamport of SOL from the customer — but not
+   * free of credits either: "not a custodian" is about never OWNING the
+   * name, not about leaving being free. After revoking, `setArNSRecord`
+   * keeps working: it simply starts returning `awaiting-signature` so the
+   * owner signs their own record writes.
    */
   public async removeArNSController({
     antId,


### PR DESCRIPTION
## Summary

`ar-io/ar-io-bundler#303` made every ArNS action charge a small margin — unmetered sponsorship (8 of 12 actions were free) was a real wallet-drain vector Phil flagged directly. This SDK's own doc comments on `setArNSRecord`, `removeArNSRecord`, `setArNSRecordMetadata`, `removeArNSRecordMetadata`, `addArNSController`, and `removeArNSController` still said "Free"/"free" — no longer true.

Corrected each to state what's actually still true (never a lamport of SOL directly from the customer — Turbo still sponsors that) versus what changed (a small credits margin is now recovered on every action). **No functional change** — every method already routes through the generic `createArNSAction`/`completeArNSAction` plumbing, which never hardcoded pricing; this is comment drift only.

Found while auditing SDK coverage for the bundler-side change. Worth noting: the SDK client itself is already complete — all 12 actions have a dedicated method (`buyArNSName`, `extendArNSLease`, `upgradeArNSName`, `increaseArNSUndernameLimit`, `setArNSRecord`, `removeArNSRecord`, `setArNSRecordMetadata`, `removeArNSRecordMetadata`, `transferArNSRecord`, `addArNSController`, `removeArNSController`, `transferArNSAnt`), each mapping 1:1 to the server's action names — confirmed by reading every method, not assumed. This doc fix was the only gap found.

Separately, not part of this PR: the CLI (`cli/commands/arns.ts`) only has subcommands for 7 of the 12 actions (missing add-controller/remove-controller/set-record-metadata/remove-record-metadata/transfer-record) — a pre-existing, unrelated gap, flagging for awareness only.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn build:types` clean
- [x] No functional/method-signature changes — verified via diff (comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t9a8p8Be2Dz9vZ5M5kXR4