### PR TITLE
feat(arns): full SDK/CLI coverage for the 8 non-purchase actions + price preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,12 +1077,14 @@ const owner = {
 They are allowed to be different wallets, and routinely are: one account pays
 while another owns.
 
-### The nine sponsored actions
+### The twelve sponsored actions
 
 ```typescript
 const turbo = TurboFactory.authenticated({ privateKey: jwk });
 
-// Buy — the ONE signature in the whole lifecycle.
+// Buy — the ONE signature in the whole lifecycle. Grants Turbo controller
+// rights in this SAME transaction, which is why everything below needs no
+// signature of its own until you revoke it.
 const { antId, messageId } = await turbo.buyArNSName({
   name: 'my-name',
   owner,
@@ -1091,13 +1093,13 @@ const { antId, messageId } = await turbo.buyArNSName({
   onNonce: (nonce) => persist(nonce), // fires BEFORE the wallet prompt
 });
 
-// Lifecycle — no signature at all.
+// Lifecycle — no signature at all, spends ARIO.
 await turbo.extendArNSLease({ name: 'my-name', years: 2 });
 await turbo.upgradeArNSName({ name: 'my-name' });
 await turbo.increaseArNSUndernameLimit({ name: 'my-name', increaseQty: 5 });
 
-// Records — handled whichever shape the server picks. Costs credits (a small
-// margin), never SOL.
+// Records — a small flat/derived credits margin recovers the sponsored SOL
+// rent. Handled whichever shape the server picks.
 await turbo.setArNSRecord({
   antId,
   owner,
@@ -1107,28 +1109,65 @@ await turbo.setArNSRecord({
 });
 await turbo.removeArNSRecord({ antId, owner, undername: 'docs' });
 
-// Controllers and transfer — owner-signed. Cost credits, never SOL.
+// Record metadata — display name, logo, description, keywords. Same margin,
+// same shape rules as setArNSRecord. `null` clears a field; omit to leave it.
+await turbo.setArNSRecordMetadata({
+  antId,
+  owner,
+  undername: '@',
+  displayName: 'My Docs',
+  recordDescription: null, // clear it
+});
+await turbo.removeArNSRecordMetadata({ antId, owner, undername: 'docs' });
+
+// Hand ONE record to another address — distinct from transferring the ANT.
+await turbo.transferArNSRecord({
+  antId,
+  owner,
+  undername: 'docs',
+  target: newOwnerAddress,
+});
+
+// Controllers and transfer — owner-signed, same flat/derived margin.
+// addArNSController is for RE-granting after a revoke, or granting some
+// OTHER address — Turbo already has it from the buy above.
 await turbo.addArNSController({ antId, owner }); // omit target => Turbo
 await turbo.removeArNSController({ antId, owner }); // the revoke
 await turbo.transferArNSAnt({ antId, owner, target: newOwnerAddress });
 ```
 
-| Action                                                               | Costs credits | Owner signature             |
-| -------------------------------------------------------------------- | ------------- | --------------------------- |
-| `buyArNSName`                                                        | yes           | **always**, once            |
-| `extendArNSLease` / `upgradeArNSName` / `increaseArNSUndernameLimit` | yes           | no                          |
-| `setArNSRecord` / `removeArNSRecord`                                 | no            | only after you revoke Turbo |
-| `addArNSController` / `removeArNSController` / `transferArNSAnt`     | no            | yes                         |
+| Action                                                                                                             | Costs credits                        | Owner signature             |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------ | --------------------------- |
+| `buyArNSName`                                                                                                      | yes — ARIO purchase + ANT spawn rent | **always**, once            |
+| `extendArNSLease` / `upgradeArNSName` / `increaseArNSUndernameLimit`                                               | yes — ARIO purchase                  | no                          |
+| `setArNSRecord` / `removeArNSRecord` / `setArNSRecordMetadata` / `removeArNSRecordMetadata` / `transferArNSRecord` | yes — small flat/derived margin      | only after you revoke Turbo |
+| `addArNSController` / `removeArNSController` / `transferArNSAnt`                                                   | yes — small flat/derived margin      | yes                         |
 
-**Every action debits credits.** The four purchase actions pay for the name
-itself; the other eight carry a small margin covering the Solana fees and rent
-Turbo fronts. Record, controller and transfer actions used to be free — that
-changed, because a zero-cost action could be turned into value through the
-refund path. The customer still never needs SOL.
+Every action costs credits — gas sponsorship was never meant to be _free_
+sponsorship. The four purchase actions charge the ARIO cost (plus, for
+`buyArNSName`, a rent-derived surcharge for the ANT it mints); the other eight
+charge a small margin that recovers the Solana rent/fees Turbo fronts on your
+behalf, computed the same `max(rent-derived, flat floor)` way as the ANT spawn
+surcharge. Preview it before you pay:
+
+```typescript
+const { wincQty } = await turbo.getArNSActionPrice('remove-controller');
+```
+
+`getArNSActionPrice` covers the eight non-purchase actions, by their route
+name (`set-record`, `remove-record`, `set-record-metadata`,
+`remove-record-metadata`, `transfer-record`, `add-controller`,
+`remove-controller`, `transfer`) — use `getArNSPriceForName` for the four
+purchase actions instead, since their cost is dominated by the ARIO purchase,
+not this margin.
 
 `buyArNSName` grants Turbo controller rights **inside the same transaction you
-sign**, which is why `setArNSRecord` needs no transaction signature afterwards.
-Revoking is always available, and costs a small credit margin rather than SOL.
+sign** — the `add-controller(Turbo)` instruction rides along with the mint, so
+there is no separate step. That's why `setArNSRecord` and the rest complete in
+a single call immediately after buying, with no signature of their own.
+`addArNSController` is for re-granting after a revoke, or adding a different
+controller — not something you call after a fresh buy. Revoking is always
+available — but, like every other action here, not free of credits.
 
 ### Not covered — these still cost you SOL
 
@@ -1806,9 +1845,11 @@ turbo list-shares --address 2cor...VUa --wallet-file ../path/to/my/wallet
 
 Buy and manage [ArNS](#arns-names) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-purchase-status`.
 
-All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. The write commands (`buy-arns-name`, `extend-arns-lease`, `increase-arns-undernames`, `upgrade-arns-name`, `transfer-arns-ant`, `set-arns-record`, `remove-arns-record`) require a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`); the read-only commands (`arns-price`, `arns-purchase-status`, `arns-fiat-quote`) do not.
+All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. Every write command requires a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`) to pay; the ANT-scoped ones (`transfer-arns-ant`, `set-arns-record`, `remove-arns-record`, `set-arns-record-metadata`, `remove-arns-record-metadata`, `transfer-arns-record`, `add-arns-controller`, `remove-arns-controller`) also require `--owner-key` for the owner proof. The read-only commands (`arns-price`, `arns-action-price`, `arns-purchase-status`, `arns-fiat-quote`) need neither.
 
 When a purchase is rejected for lack of Turbo Credits (HTTP 402), the command prints a clear "insufficient credits — top up your balance and retry" message and exits non-zero.
+
+Every write command debits credits now — see [the pricing table](#the-twelve-sponsored-actions) for what each one charges. Preview the eight non-purchase commands' cost with `arns-action-price` before running them.
 
 ##### `arns-fiat-quote`
 
@@ -1997,6 +2038,108 @@ e.g:
 
 ```shell
 turbo remove-arns-record --ant-id ant-123 --undername docs --wallet-file ../path/to/my/wallet.json
+```
+
+##### `set-arns-record-metadata`
+
+Set a record's display name, logo, description, or keywords on a Turbo-custodied ANT. This is RECORD-level metadata — distinct from the ANT's own name/ticker/description/keywords/logo, which is not sponsored. Fields are tri-state: pass `--display-name`/`--record-logo`/`--record-description`/`--record-keywords` to set a field, `--clear-*` to explicitly clear it, or omit both to leave it unchanged.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID to set record metadata on
+- `--undername <undername>` - Undername record to set metadata on (defaults to `@`, the apex record)
+- `--display-name <displayName>` / `--clear-display-name`
+- `--record-logo <transactionId>` / `--clear-record-logo`
+- `--record-description <description>` / `--clear-record-description`
+- `--record-keywords <keywords...>` / `--clear-record-keywords`
+
+e.g:
+
+```shell
+turbo set-arns-record-metadata --ant-id ant-123 --undername docs \
+  --display-name "My Docs" --record-keywords arweave permaweb \
+  --wallet-file ../path/to/my/wallet.json
+```
+
+```shell
+# Clear the description, leave everything else unchanged
+turbo set-arns-record-metadata --ant-id ant-123 --undername docs \
+  --clear-record-description --wallet-file ../path/to/my/wallet.json
+```
+
+##### `remove-arns-record-metadata`
+
+Clear all of a record's metadata on a Turbo-custodied ANT.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID to remove record metadata from
+- `--undername <undername>` - Undername record whose metadata to clear
+
+e.g:
+
+```shell
+turbo remove-arns-record-metadata --ant-id ant-123 --undername docs --wallet-file ../path/to/my/wallet.json
+```
+
+##### `transfer-arns-record`
+
+Hand ONE record to another address — distinct from `transfer-arns-ant`, which hands over the whole ANT and every record on it.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID whose record to transfer
+- `--undername <undername>` - Undername record to transfer
+- `--target <address>` - Target Solana pubkey to transfer the record to
+
+e.g:
+
+```shell
+turbo transfer-arns-record --ant-id ant-123 --undername docs --target 7xKX...gAsU --wallet-file ../path/to/my/wallet.json
+```
+
+##### `add-arns-controller`
+
+Grant controller rights on a Turbo-custodied ANT. Owner-signed — changing an ANT's access control is an owner-only instruction. Not needed after a fresh `buy-arns-name`: the grant already rides in that same signed transaction. Use this to re-grant after a revoke, or to add a different address as controller.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID to add a controller to
+- `--target <address>` - Solana pubkey to grant controller rights to (omit for Turbo itself, which is what makes `set-arns-record` a single call)
+
+e.g:
+
+```shell
+turbo add-arns-controller --ant-id ant-123 --wallet-file ../path/to/my/wallet.json
+```
+
+##### `remove-arns-controller`
+
+Revoke controller rights on a Turbo-custodied ANT — the escape hatch that keeps "Turbo is not a custodian" honest. Always available, but not free of credits: after revoking, `set-arns-record` keeps working, it just starts requiring the owner's signature.
+
+Command Options:
+
+- `--ant-id <antId>` - ANT ID to remove a controller from
+- `--target <address>` - Solana pubkey to revoke (omit to revoke Turbo)
+
+e.g:
+
+```shell
+turbo remove-arns-controller --ant-id ant-123 --wallet-file ../path/to/my/wallet.json
+```
+
+##### `arns-action-price`
+
+Preview the Turbo Credit price of one of the eight non-purchase actions, without creating it. Rejects the four ARIO-purchase actions (`buy-name`, `extend-lease`, `upgrade-name`, `increase-undername-limit`) — use `arns-price` for those instead, since their cost is dominated by the ARIO purchase, not this flat/derived margin. Needs no wallet.
+
+Command Options:
+
+- `--action <action>` - One of `set-record`, `remove-record`, `set-record-metadata`, `remove-record-metadata`, `transfer-record`, `add-controller`, `remove-controller`, `transfer`
+
+e.g:
+
+```shell
+turbo arns-action-price --action remove-controller --payment-url http://localhost:4001
 ```
 
 ## Turbo Credit Sharing

--- a/packages/turbo-sdk/src/cli/cli.ts
+++ b/packages/turbo-sdk/src/cli/cli.ts
@@ -23,15 +23,21 @@ import { readFileSync, readdirSync } from 'fs';
 
 import { version } from '../version.js';
 import {
+  addArNSController,
+  arnsActionPrice,
   arnsFiatQuote,
   arnsPrice,
   arnsPurchaseStatus,
   buyArNSName,
   extendArNSLease,
   increaseArNSUndernames,
+  removeArNSController,
   removeArNSRecord,
+  removeArNSRecordMetadata,
   setArNSRecord,
+  setArNSRecordMetadata,
   transferArNSAnt,
+  transferArNSRecord,
   upgradeArNSName,
 } from './commands/arns.js';
 import { fiatEstimate } from './commands/fiatEstimate.js';
@@ -51,6 +57,8 @@ import { shareCredits } from './commands/shareCredits.js';
 import { tokenPrice } from './commands/tokenPrice.js';
 import { x402UploadUnsignedFile } from './commands/x402UploadUnsignedData.js';
 import {
+  addArNSControllerOptions,
+  arnsActionPriceOptions,
   arnsFiatQuoteOptions,
   arnsPriceOptions,
   arnsPurchaseStatusOptions,
@@ -60,11 +68,15 @@ import {
   increaseArNSUndernamesOptions,
   listSharesOptions,
   optionMap,
+  removeArNSControllerOptions,
+  removeArNSRecordMetadataOptions,
   removeArNSRecordOptions,
   revokeCreditsOptions,
+  setArNSRecordMetadataOptions,
   setArNSRecordOptions,
   shareCreditsOptions,
   transferArNSAntOptions,
+  transferArNSRecordOptions,
   upgradeArNSNameOptions,
   uploadFileOptions,
   uploadFolderOptions,
@@ -310,6 +322,67 @@ applyOptions(
   removeArNSRecordOptions,
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, removeArNSRecord);
+});
+
+applyOptions(
+  program
+    .command('add-arns-controller')
+    .description('Grant controller rights on a Turbo-custodied ANT'),
+  addArNSControllerOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, addArNSController);
+});
+
+applyOptions(
+  program
+    .command('remove-arns-controller')
+    .description('Revoke controller rights on a Turbo-custodied ANT'),
+  removeArNSControllerOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, removeArNSController);
+});
+
+applyOptions(
+  program
+    .command('transfer-arns-record')
+    .description(
+      'Transfer one record (undername) on a Turbo-custodied ANT to another address',
+    ),
+  transferArNSRecordOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, transferArNSRecord);
+});
+
+applyOptions(
+  program
+    .command('set-arns-record-metadata')
+    .description(
+      "Set a record's display name, logo, description, or keywords on a Turbo-custodied ANT",
+    ),
+  setArNSRecordMetadataOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, setArNSRecordMetadata);
+});
+
+applyOptions(
+  program
+    .command('remove-arns-record-metadata')
+    .description("Clear a record's metadata on a Turbo-custodied ANT"),
+  removeArNSRecordMetadataOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, removeArNSRecordMetadata);
+});
+
+applyOptions(
+  program
+    .command('arns-action-price')
+    .description(
+      'Preview the Turbo Credit price of a non-purchase ArNS action (set-record, remove-record, ' +
+        'set-record-metadata, remove-record-metadata, transfer-record, add-controller, remove-controller, transfer)',
+    ),
+  arnsActionPriceOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, arnsActionPrice);
 });
 
 applyOptions(

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -142,6 +142,51 @@ class FakeTurbo
       messageId: 'm',
     } as never);
   }
+  addArNSController(params: unknown) {
+    return this.record('addArNSController', params, {
+      nonce: 'nonce-123',
+      action: 'add-controller',
+      status: 'completed',
+      antId: 'ant-1',
+      messageId: 'm',
+    } as never);
+  }
+  removeArNSController(params: unknown) {
+    return this.record('removeArNSController', params, {
+      nonce: 'nonce-123',
+      action: 'remove-controller',
+      status: 'completed',
+      antId: 'ant-1',
+      messageId: 'm',
+    } as never);
+  }
+  setArNSRecordMetadata(params: unknown) {
+    return this.record('setArNSRecordMetadata', params, {
+      nonce: 'nonce-123',
+      action: 'set-record-metadata',
+      status: 'completed',
+      antId: 'ant-1',
+      messageId: 'm',
+    } as never);
+  }
+  removeArNSRecordMetadata(params: unknown) {
+    return this.record('removeArNSRecordMetadata', params, {
+      nonce: 'nonce-123',
+      action: 'remove-record-metadata',
+      status: 'completed',
+      antId: 'ant-1',
+      messageId: 'm',
+    } as never);
+  }
+  transferArNSRecord(params: unknown) {
+    return this.record('transferArNSRecord', params, {
+      nonce: 'nonce-123',
+      action: 'transfer-record',
+      status: 'completed',
+      antId: 'ant-1',
+      messageId: 'm',
+    } as never);
+  }
 }
 
 // A fixed Solana key so the owner ADDRESS is stable across runs. The owner

--- a/packages/turbo-sdk/src/cli/commands/arns.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.ts
@@ -18,6 +18,8 @@ import { BigNumber } from 'bignumber.js';
 import { solanaOwnerSigner } from '../../common/arnsActions.js';
 import { TurboFactory } from '../../node/factory.js';
 import {
+  ArNSAction,
+  ArNSActionPriceResponse,
   ArNSFiatPurchaseQuoteParams,
   ArNSFiatPurchaseQuoteResponse,
   ArNSNameType,
@@ -25,6 +27,7 @@ import {
   ArNSPriceResponse,
   ArNSPurchaseStatusResponse,
   Currency,
+  arNSActions,
 } from '../../types.js';
 import { ArNSActionCompleted, ArNSOwnerSigner } from '../../types.js';
 import {
@@ -33,13 +36,19 @@ import {
 } from '../../utils/errors.js';
 import { wincPerCredit } from '../constants.js';
 import {
+  AddArNSControllerOptions,
+  ArNSActionPriceOptions,
   ArNSFiatQuoteOptions,
   ArNSPriceOptions,
   ArNSPurchaseOptions,
   ArNSPurchaseStatusOptions,
+  RemoveArNSControllerOptions,
+  RemoveArNSRecordMetadataOptions,
   RemoveArNSRecordOptions,
+  SetArNSRecordMetadataOptions,
   SetArNSRecordOptions,
   TransferArNSAntOptions,
+  TransferArNSRecordOptions,
 } from '../types.js';
 import { configFromOptions, turboFromOptions } from '../utils.js';
 
@@ -114,6 +123,48 @@ export type ArNSCustodyClient = {
     owner: ArNSOwnerSigner;
     undername: string;
   }): Promise<ArNSActionCompleted>;
+  addArNSController(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    target?: string;
+  }): Promise<ArNSActionCompleted>;
+  removeArNSController(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    target?: string;
+  }): Promise<ArNSActionCompleted>;
+  setArNSRecordMetadata(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername?: string;
+    displayName?: string | null;
+    recordLogo?: string | null;
+    recordDescription?: string | null;
+    recordKeywords?: string[] | null;
+  }): Promise<ArNSActionCompleted>;
+  removeArNSRecordMetadata(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+  }): Promise<ArNSActionCompleted>;
+  transferArNSRecord(params: {
+    antId: string;
+    owner: ArNSOwnerSigner;
+    undername: string;
+    target: string;
+  }): Promise<ArNSActionCompleted>;
+};
+
+/** The four ARIO-purchase actions are priced via `arnsPrice`, not this route. */
+const ARNS_PURCHASE_ACTIONS = new Set<ArNSAction>([
+  'buy-name',
+  'extend-lease',
+  'upgrade-name',
+  'increase-undername-limit',
+]);
+
+export type ArNSActionPriceClient = {
+  getArNSActionPrice(action: ArNSAction): Promise<ArNSActionPriceResponse>;
 };
 
 export function requiredNameFromOptions(options: { name?: string }): string {
@@ -142,6 +193,34 @@ export function typeFromOptions(value: string | undefined): ArNSNameType {
     throw new Error("Must provide --type of 'lease' or 'permabuy'");
   }
   return value;
+}
+
+/** Parses `--action` for `arns-action-price`, rejecting the four purchase actions. */
+export function actionFromOptions(options: { action?: string }): ArNSAction {
+  const { action } = options;
+  if (action === undefined || action.length === 0) {
+    throw new Error(`Must provide --action. One of: ${arNSActions.join(', ')}`);
+  }
+  if (!(arNSActions as readonly string[]).includes(action)) {
+    throw new Error(
+      `Invalid --action '${action}'. One of: ${arNSActions.join(', ')}`,
+    );
+  }
+  if (ARNS_PURCHASE_ACTIONS.has(action as ArNSAction)) {
+    throw new Error(
+      `'${action}' is priced via \`turbo arns-price\`, not \`arns-action-price\` — ` +
+        'it spends ARIO, not just the flat credits margin this route quotes.',
+    );
+  }
+  return action as ArNSAction;
+}
+
+/** `null` clears the field (Set-Record-Metadata's tri-state), `undefined` leaves it unchanged. */
+function metadataFieldFromOptions<T>(
+  value: T | undefined,
+  clear: boolean,
+): T | null | undefined {
+  return clear ? null : value;
 }
 
 export function paidByFromArNSOptions(
@@ -514,5 +593,163 @@ export async function removeArNSRecord(
 
   console.log(
     JSON.stringify({ message: 'ArNS record removed!', ...result }, null, 2),
+  );
+}
+
+export async function addArNSController(
+  options: AddArNSControllerOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to add a controller to');
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.addArNSController({
+    antId: options.antId,
+    owner: ownerFromOptions(options),
+    target: options.target,
+  });
+
+  console.log(
+    JSON.stringify({ message: 'ArNS controller added!', ...result }, null, 2),
+  );
+}
+
+export async function removeArNSController(
+  options: RemoveArNSControllerOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to remove a controller from');
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.removeArNSController({
+    antId: options.antId,
+    owner: ownerFromOptions(options),
+    target: options.target,
+  });
+
+  console.log(
+    JSON.stringify({ message: 'ArNS controller removed!', ...result }, null, 2),
+  );
+}
+
+export async function transferArNSRecord(
+  options: TransferArNSRecordOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id whose record to transfer');
+  }
+  if (options.undername === undefined || options.undername.length === 0) {
+    throw new Error('Must provide an --undername to transfer');
+  }
+  if (options.target === undefined) {
+    throw new Error(
+      'Must provide a --target address to transfer the record to',
+    );
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.transferArNSRecord({
+    antId: options.antId,
+    owner: ownerFromOptions(options),
+    undername: options.undername,
+    target: options.target,
+  });
+
+  console.log(
+    JSON.stringify({ message: 'ArNS record transferred!', ...result }, null, 2),
+  );
+}
+
+export async function setArNSRecordMetadata(
+  options: SetArNSRecordMetadataOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to set record metadata on');
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.setArNSRecordMetadata({
+    antId: options.antId,
+    owner: ownerFromOptions(options),
+    undername: options.undername ?? '@',
+    displayName: metadataFieldFromOptions(
+      options.displayName,
+      options.clearDisplayName,
+    ),
+    recordLogo: metadataFieldFromOptions(
+      options.recordLogo,
+      options.clearRecordLogo,
+    ),
+    recordDescription: metadataFieldFromOptions(
+      options.recordDescription,
+      options.clearRecordDescription,
+    ),
+    recordKeywords: metadataFieldFromOptions(
+      options.recordKeywords,
+      options.clearRecordKeywords,
+    ),
+  });
+
+  console.log(
+    JSON.stringify(
+      { message: 'ArNS record metadata set!', ...result },
+      null,
+      2,
+    ),
+  );
+}
+
+export async function removeArNSRecordMetadata(
+  options: RemoveArNSRecordMetadataOptions,
+  turbo?: ArNSCustodyClient,
+): Promise<void> {
+  if (options.antId === undefined) {
+    throw new Error('Must provide an --ant-id to remove record metadata from');
+  }
+  if (options.undername === undefined || options.undername.length === 0) {
+    throw new Error('Must provide an --undername');
+  }
+
+  const client = turbo ?? (await turboFromOptions(options));
+  const result = await client.removeArNSRecordMetadata({
+    antId: options.antId,
+    owner: ownerFromOptions(options),
+    undername: options.undername,
+  });
+
+  console.log(
+    JSON.stringify(
+      { message: 'ArNS record metadata removed!', ...result },
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * Preview what one of the eight non-purchase actions will debit, without
+ * creating it.
+ */
+export async function arnsActionPrice(
+  options: ArNSActionPriceOptions,
+  turbo?: ArNSActionPriceClient,
+): Promise<void> {
+  const action = actionFromOptions(options);
+  const client =
+    turbo ?? TurboFactory.unauthenticated(configFromOptions(options));
+  const { wincQty } = await client.getArNSActionPrice(action);
+
+  console.log(
+    JSON.stringify(
+      { action, wincQty, credits: creditsFromWinc(wincQty) },
+      null,
+      2,
+    ),
   );
 }

--- a/packages/turbo-sdk/src/cli/options.ts
+++ b/packages/turbo-sdk/src/cli/options.ts
@@ -246,6 +246,50 @@ export const optionMap = {
     alias: '--ttl-seconds <ttlSeconds>',
     description: 'TTL in seconds for the ArNS record',
   },
+  arnsDisplayName: {
+    alias: '--display-name <displayName>',
+    description: 'Display name for the record (Set-Record-Metadata)',
+  },
+  arnsClearDisplayName: {
+    alias: '--clear-display-name',
+    description: 'Clear the record display name (Set-Record-Metadata)',
+    default: false,
+  },
+  arnsRecordLogo: {
+    alias: '--record-logo <transactionId>',
+    description:
+      'Arweave transaction ID for the record logo (Set-Record-Metadata)',
+  },
+  arnsClearRecordLogo: {
+    alias: '--clear-record-logo',
+    description: 'Clear the record logo (Set-Record-Metadata)',
+    default: false,
+  },
+  arnsRecordDescription: {
+    alias: '--record-description <description>',
+    description: 'Description for the record (Set-Record-Metadata)',
+  },
+  arnsClearRecordDescription: {
+    alias: '--clear-record-description',
+    description: 'Clear the record description (Set-Record-Metadata)',
+    default: false,
+  },
+  arnsRecordKeywords: {
+    alias: '--record-keywords <keywords...>',
+    description: 'Keywords for the record (Set-Record-Metadata)',
+    type: 'array',
+  },
+  arnsClearRecordKeywords: {
+    alias: '--clear-record-keywords',
+    description: 'Clear the record keywords (Set-Record-Metadata)',
+    default: false,
+  },
+  arnsAction: {
+    alias: '--action <action>',
+    description:
+      'ArNS action to price: set-record, remove-record, set-record-metadata, ' +
+      'remove-record-metadata, transfer-record, add-controller, remove-controller, or transfer',
+  },
   // ---- Payment history ----
   limit: {
     alias: '--limit <limit>',
@@ -400,3 +444,44 @@ export const removeArNSRecordOptions = [
   optionMap.arnsAntId,
   optionMap.arnsUndername,
 ];
+
+export const addArNSControllerOptions = [
+  ...walletOptions,
+  optionMap.arnsOwnerKey,
+  optionMap.arnsAntId,
+  optionMap.arnsTarget,
+];
+
+export const removeArNSControllerOptions = addArNSControllerOptions;
+
+export const transferArNSRecordOptions = [
+  ...walletOptions,
+  optionMap.arnsOwnerKey,
+  optionMap.arnsAntId,
+  optionMap.arnsUndername,
+  optionMap.arnsTarget,
+];
+
+export const setArNSRecordMetadataOptions = [
+  ...walletOptions,
+  optionMap.arnsOwnerKey,
+  optionMap.arnsAntId,
+  optionMap.arnsUndername,
+  optionMap.arnsDisplayName,
+  optionMap.arnsClearDisplayName,
+  optionMap.arnsRecordLogo,
+  optionMap.arnsClearRecordLogo,
+  optionMap.arnsRecordDescription,
+  optionMap.arnsClearRecordDescription,
+  optionMap.arnsRecordKeywords,
+  optionMap.arnsClearRecordKeywords,
+];
+
+export const removeArNSRecordMetadataOptions = [
+  ...walletOptions,
+  optionMap.arnsOwnerKey,
+  optionMap.arnsAntId,
+  optionMap.arnsUndername,
+];
+
+export const arnsActionPriceOptions = [optionMap.arnsAction];

--- a/packages/turbo-sdk/src/cli/types.ts
+++ b/packages/turbo-sdk/src/cli/types.ts
@@ -158,3 +158,43 @@ export type RemoveArNSRecordOptions = ArNSOwnerKeyOption &
     antId: string | undefined;
     undername: string | undefined;
   };
+
+export type AddArNSControllerOptions = ArNSOwnerKeyOption &
+  WalletOptions & {
+    antId: string | undefined;
+    target: string | undefined;
+  };
+
+export type RemoveArNSControllerOptions = AddArNSControllerOptions;
+
+export type TransferArNSRecordOptions = ArNSOwnerKeyOption &
+  WalletOptions & {
+    antId: string | undefined;
+    undername: string | undefined;
+    target: string | undefined;
+  };
+
+export type SetArNSRecordMetadataOptions = ArNSOwnerKeyOption &
+  WalletOptions & {
+    antId: string | undefined;
+    undername: string | undefined;
+    displayName: string | undefined;
+    clearDisplayName: boolean;
+    recordLogo: string | undefined;
+    clearRecordLogo: boolean;
+    recordDescription: string | undefined;
+    clearRecordDescription: boolean;
+    recordKeywords: string[] | undefined;
+    clearRecordKeywords: boolean;
+  };
+
+export type RemoveArNSRecordMetadataOptions = ArNSOwnerKeyOption &
+  WalletOptions & {
+    antId: string | undefined;
+    undername: string | undefined;
+  };
+
+/** `--action` names one of the eight non-purchase actions to price. */
+export type ArNSActionPriceOptions = GlobalOptions & {
+  action: string | undefined;
+};

--- a/packages/turbo-sdk/src/common/payment.arns.test.ts
+++ b/packages/turbo-sdk/src/common/payment.arns.test.ts
@@ -285,6 +285,32 @@ describe('ArNS actions', () => {
       assert.equal(price.wincTotal, '123');
     });
   });
+
+  describe('getArNSActionPrice', () => {
+    it('GETs /arns/actions/{action}/price and returns the response as-is', async () => {
+      const http = new FakeHttp();
+      http.responses = [
+        { action: 'remove-controller', wincQty: '50000000000' },
+      ];
+      const price =
+        await serviceWith(http).getArNSActionPrice('remove-controller');
+      assert.equal(http.last.method, 'GET');
+      assert.equal(http.last.endpoint, '/arns/actions/remove-controller/price');
+      assert.deepEqual(price, {
+        action: 'remove-controller',
+        wincQty: '50000000000',
+      });
+    });
+
+    it('threads the action through unmodified for every non-purchase action', async () => {
+      for (const action of ['set-record', 'transfer-record', 'transfer']) {
+        const http = new FakeHttp();
+        http.responses = [{ action, wincQty: '1' }];
+        await serviceWith(http).getArNSActionPrice(action as never);
+        assert.equal(http.last.endpoint, `/arns/actions/${action}/price`);
+      }
+    });
+  });
 });
 
 describe('ArNS actions - the thin wrappers', () => {

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -18,6 +18,7 @@ import { BigNumber } from 'bignumber.js';
 import {
   ArNSAction,
   ArNSActionCompleted,
+  ArNSActionPriceResponse,
   ArNSActionResult,
   ArNSFiatPurchaseQuoteParams,
   ArNSFiatPurchaseQuoteResponse,
@@ -257,6 +258,27 @@ export class TurboUnauthenticatedPaymentService
       ...price,
       wincTotal: price.wincTotalWithAntSpawn ?? price.winc,
     };
+  }
+
+  /**
+   * Preview the flat credits margin one of the eight non-purchase actions
+   * (everything except Buy-Name/Extend-Lease/Upgrade-Name/
+   * Increase-Undername-Limit) will debit, without creating it. Those four
+   * purchase actions are priced by `getArNSPriceForName` instead — their
+   * cost is dominated by the ARIO purchase, not this margin, so this route
+   * rejects them.
+   *
+   * No signature required: this mirrors `getArNSPriceForName`'s read-only,
+   * unauthenticated shape rather than `getArNSActionStatus`'s (which happens
+   * to live on the authenticated client today despite needing no signature
+   * either).
+   */
+  public async getArNSActionPrice(
+    action: ArNSAction,
+  ): Promise<ArNSActionPriceResponse> {
+    return this.httpService.get<ArNSActionPriceResponse>({
+      endpoint: `/arns/actions/${action}/price`,
+    });
   }
 
   /**

--- a/packages/turbo-sdk/src/common/turbo.test.ts
+++ b/packages/turbo-sdk/src/common/turbo.test.ts
@@ -61,6 +61,30 @@ describe('TurboUnauthenticatedClient', () => {
       assert.equal(calledWith, 'delegate-test-address');
     });
   });
+
+  describe('getArNSActionPrice()', () => {
+    it('delegates to paymentService.getArNSActionPrice with the given action', async () => {
+      const expectedResponse = { action: 'remove-controller', wincQty: '1' };
+      let calledWith: unknown;
+      const fakePaymentService = {
+        getArNSActionPrice: async (action: string) => {
+          calledWith = action;
+          return expectedResponse;
+        },
+      } as unknown as TurboUnauthenticatedPaymentServiceInterface;
+
+      const client = new TurboUnauthenticatedClient({
+        paymentService: fakePaymentService,
+        uploadService:
+          {} as unknown as TurboUnauthenticatedUploadServiceInterface,
+      });
+
+      const result = await client.getArNSActionPrice('remove-controller');
+
+      assert.deepEqual(result, expectedResponse);
+      assert.equal(calledWith, 'remove-controller');
+    });
+  });
 });
 
 describe('TurboAuthenticatedClient', () => {

--- a/packages/turbo-sdk/src/common/turbo.ts
+++ b/packages/turbo-sdk/src/common/turbo.ts
@@ -18,6 +18,7 @@ import { BigNumber } from 'bignumber.js';
 import {
   ArNSAction,
   ArNSActionCompleted,
+  ArNSActionPriceResponse,
   ArNSActionResult,
   ArNSFiatPurchaseQuoteParams,
   ArNSFiatPurchaseQuoteResponse,
@@ -172,6 +173,15 @@ export class TurboUnauthenticatedClient
    */
   getArNSPriceForName(params: ArNSPriceParams): Promise<ArNSPriceResponse> {
     return this.paymentService.getArNSPriceForName(params);
+  }
+
+  /**
+   * Previews what one of the eight non-purchase ArNS actions will debit,
+   * without creating it. Use {@link getArNSPriceForName} for the four
+   * ARIO-purchase actions instead.
+   */
+  getArNSActionPrice(action: ArNSAction): Promise<ArNSActionPriceResponse> {
+    return this.paymentService.getArNSActionPrice(action);
   }
 
   /**

--- a/packages/turbo-sdk/src/types.ts
+++ b/packages/turbo-sdk/src/types.ts
@@ -1116,7 +1116,7 @@ export type ArNSPriceResponse = {
 // ===== ArNS actions (sponsored — the current bundler surface) =====
 
 /**
- * The nine sponsored ArNS actions.
+ * The twelve sponsored ArNS actions.
  *
  * Sponsorship covers these twelve and NOTHING else. Everything else in the
  * ArNS, ANT and core programs stays on the direct-signer path and costs the
@@ -1188,6 +1188,21 @@ export type ArNSActionAwaitingSignature = {
 export type ArNSActionResult =
   | ArNSActionCompleted
   | ArNSActionAwaitingSignature;
+
+/**
+ * The flat-margin credits price for one of the eight actions that don't
+ * spend ARIO (everything except Buy-Name/Extend-Lease/Upgrade-Name/
+ * Increase-Undername-Limit, which are priced by {@link getArNSPriceForName}
+ * instead since their cost is dominated by the ARIO purchase, not the margin).
+ * No signature required — this is a read-only preview of what
+ * `createArNSAction` will debit.
+ */
+export type ArNSActionPriceResponse = {
+  action: ArNSAction;
+  /** What creating this action will debit, in Winston credits. */
+  wincQty: string;
+  [key: string]: unknown;
+};
 
 /**
  * The ANT owner's key — a **Solana** wallet, distinct from the Turbo payer.
@@ -1381,6 +1396,13 @@ export interface TurboUnauthenticatedPaymentServiceInterface {
   getBalance: (address: string) => Promise<TurboBalanceResponse>;
   getFreeStatus: (address: string) => Promise<TurboFreeStatusResponse>;
   getArNSPriceForName(params: ArNSPriceParams): Promise<ArNSPriceResponse>;
+  /**
+   * Preview what one of the eight non-purchase actions will debit, without
+   * creating it. `action` must not be one of the four ARIO-purchase actions
+   * (`buy-name`, `extend-lease`, `upgrade-name`, `increase-undername-limit`)
+   * — use {@link getArNSPriceForName} for those.
+   */
+  getArNSActionPrice(action: ArNSAction): Promise<ArNSActionPriceResponse>;
   getArNSPurchaseStatus(p: {
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse>;


### PR DESCRIPTION
## Summary

Auditing whether the SDK matched what the bundler backend actually supports for ArNS turned up two gaps:

- The **CLI** only wrapped 7 of the 12 ArNS action methods — `add-arns-controller`, `remove-arns-controller`, `set-arns-record-metadata`, `remove-arns-record-metadata`, and `transfer-arns-record` had no command, even though `common/payment.ts` already had the client methods for all 12.
- The bundler's new price-preview route (`GET /arns/actions/:action/price`, ar-io-bundler PR #306, not yet merged/deployed) had no SDK client method or CLI command at all.
- The **README** still described 9 actions, called 5 of them "free", and had no mention of the price-preview capability — stale since ar-io-bundler PR #303 flipped all 8 non-purchase actions to charge a small margin.

## Changes

- `types.ts` / `common/payment.ts` / `common/turbo.ts`: add `getArNSActionPrice(action)` (unauthenticated, mirrors `getArNSPriceForName`'s shape) and `ArNSActionPriceResponse`. Fix a stray "nine sponsored actions" doc comment to "twelve".
- `cli/types.ts` / `cli/options.ts` / `cli/commands/arns.ts` / `cli/cli.ts`: add the 5 missing CLI commands plus `arns-action-price`. Metadata fields on `set-arns-record-metadata` are tri-state (`--display-name` sets, `--clear-display-name` clears, omitting both leaves unchanged), matching the SDK method's `string | null | undefined` contract.
- `README.md`: rewrite the "ArNS Names" and "ArNS Commands" sections for all 12 actions with correct current pricing (every action costs credits now — no more "free"), and document `getArNSActionPrice` / `arns-action-price`.

Branched off `fix/arns-actions-pricing-docs` (#462) to avoid duplicating its doc fixes; this PR's own README/CLI changes are additive on top of it.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn lint` clean
- [x] `yarn test:unit` — 129/129 passing (no existing CLI test suite to extend; sibling `arns.ts` commands have none either)
- [ ] Manual CLI smoke test against a running bundler once ar-io-bundler PR #306 (the price-preview route) is deployed