### PR TITLE
feat(x402): allow chunked uploads to be paid for with x402

### DIFF
--- a/packages/turbo-sdk/src/common/chunked.ts
+++ b/packages/turbo-sdk/src/common/chunked.ts
@@ -24,6 +24,7 @@ import {
   TurboMultiPartStatusResponse,
   TurboUploadDataItemResponse,
   UploadSignedDataItemParams,
+  X402RequestCredentials,
   multipartFailedStatus,
   validChunkingModes,
 } from '../types.js';
@@ -56,12 +57,35 @@ export class ChunkedUploader {
   private chunkByteCount: number;
   private readonly maxChunkConcurrency: number;
   private readonly maxFinalizeMs: number | undefined;
+
+  /**
+   * The upload id of an x402 upload we have ALREADY PAID FOR.
+   *
+   * `uploadFile` retries a failed upload up to 6 times, and a retry re-enters
+   * `upload()` on this same instance. Without this memo each retry opens a
+   * NEW paid upload, so one 12 MiB upload whose finalization timed out billed
+   * the customer five times over — observed, not theoretical. The payment is
+   * bound to an upload id, so a retry must resume THAT upload, never buy
+   * another. Deliberately not reset on failure: re-paying is never the right
+   * recovery, and an upload that cannot be resumed is refunded server-side.
+   */
+  private paidUploadId: string | undefined;
   private readonly http: TurboHTTPService;
   private readonly token: string;
   private readonly logger: TurboLogger;
 
   public readonly shouldUseChunkUploader: boolean;
   private maxBacklogQueue: number;
+  private x402: X402RequestCredentials | undefined;
+  private x402RefundIdentity:
+    | { address: string; signatureType: number }
+    | undefined;
+  /**
+   * The size declared at create. For x402 this is what gets PAID FOR, so it
+   * must be the real serialized size — the service reconciles against the bytes
+   * that actually arrive and penalises an under-declaration.
+   */
+  private dataItemByteCount: ByteCount;
 
   constructor({
     http,
@@ -72,6 +96,8 @@ export class ChunkedUploader {
     logger = Logger.default,
     chunkingMode = 'auto',
     dataItemByteCount,
+    x402,
+    x402RefundIdentity,
   }: {
     maxFinalizeMs?: number;
     http: TurboHTTPService;
@@ -81,6 +107,16 @@ export class ChunkedUploader {
     maxChunkConcurrency?: number;
     chunkingMode?: TurboChunkingMode;
     dataItemByteCount: ByteCount;
+    /** Pay for this upload with x402 instead of Turbo Credits. */
+    x402?: X402RequestCredentials;
+    /**
+     * The TURBO wallet credited if the upload delivers fewer bytes than were
+     * paid for. Deliberately not derived from the x402 signer: the wallet that
+     * PAYS in USDC and the wallet that receives Turbo Credits are allowed to
+     * differ, and silently conflating them would send a refund to the wrong
+     * place.
+     */
+    x402RefundIdentity?: { address: string; signatureType: number };
   }) {
     this.assertChunkParams({
       chunkByteCount,
@@ -100,6 +136,9 @@ export class ChunkedUploader {
       dataItemByteCount,
     });
     this.maxBacklogQueue = this.maxChunkConcurrency * backlogQueueFactor;
+    this.x402 = x402;
+    this.x402RefundIdentity = x402RefundIdentity;
+    this.dataItemByteCount = dataItemByteCount;
   }
 
   private shouldChunkUpload({
@@ -181,7 +220,61 @@ export class ChunkedUploader {
   /**
    * Initialize or resume an upload session, returning the upload ID.
    */
+  /**
+   * Open a multipart upload paid for with x402.
+   *
+   * The bundler settles the payment at CREATE, before accepting a single chunk
+   * — so an unpaid upload never consumes storage. That is why the size is
+   * declared here and the money moves here, not at finalize.
+   *
+   * The 402 handshake is delegated to `wrapFetchWithPayment`, the same
+   * mechanism the single-shot x402 POST already uses, so the signer and the
+   * spend cap behave identically on both paths.
+   */
+  private async initPaidUpload(x402: X402RequestCredentials): Promise<string> {
+    if (this.paidUploadId !== undefined) {
+      this.logger.debug('Resuming the already-paid chunked upload', {
+        uploadId: this.paidUploadId,
+      });
+      return this.paidUploadId;
+    }
+    if (this.x402RefundIdentity === undefined) {
+      throw new Error(
+        'An x402-paid chunked upload needs a refund identity — it is the Turbo wallet credited if the upload delivers fewer bytes than were paid for.',
+      );
+    }
+    const { address, signatureType } = this.x402RefundIdentity;
+    const endpoint =
+      `/chunks/${this.token}/-1/-1?chunkSize=${this.chunkByteCount}` +
+      `&totalBytes=${this.dataItemByteCount}` +
+      `&address=${encodeURIComponent(address)}` +
+      `&signatureType=${signatureType}`;
+
+    this.logger.debug('Opening an x402-paid chunked upload', {
+      totalBytes: this.dataItemByteCount,
+    });
+
+    const res = await this.http.get<{ id: string; chunkSize?: number }>({
+      endpoint: endpoint as `/${string}`,
+      headers: chunkingHeader,
+      x402Options: x402,
+    });
+
+    if (res.chunkSize !== undefined && res.chunkSize !== this.chunkByteCount) {
+      this.logger.warn('Chunk size mismatch! Overriding with server value.', {
+        clientExpected: this.chunkByteCount,
+        serverReturned: res.chunkSize,
+      });
+      this.chunkByteCount = res.chunkSize;
+    }
+    this.paidUploadId = res.id;
+    return res.id;
+  }
+
   private async initUpload(): Promise<string> {
+    if (this.x402 !== undefined) {
+      return this.initPaidUpload(this.x402);
+    }
     const res = await this.http.get<{
       id: string;
       min: number;

--- a/packages/turbo-sdk/src/common/chunked.x402.test.ts
+++ b/packages/turbo-sdk/src/common/chunked.x402.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { ChunkedUploader } from './chunked.js';
+import { TurboHTTPService } from './http.js';
+import { Logger } from './logger.js';
+
+/**
+ * An x402-paid chunked upload is paid for AT CREATE, so "how many times did we
+ * call create" is literally "how many times did the customer pay".
+ *
+ * `uploadFile` retries a failed upload up to 6 times and a retry re-enters
+ * `upload()` on the SAME uploader instance. Before the fix below, a 12 MiB
+ * upload whose finalization timed out opened a new paid upload on every retry
+ * and billed five separate payments of 369,798 USDC base units for one
+ * upload — caught only by watching a real Base Sepolia balance, because every
+ * individual request was perfectly well-formed.
+ */
+describe('x402-paid chunked uploads', () => {
+  const originalFetch = globalThis.fetch;
+  let createRequests: string[];
+  let nextId: number;
+
+  beforeEach(() => {
+    createRequests = [];
+    nextId = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/-1/-1')) {
+        createRequests.push(url);
+      }
+      return new Response(JSON.stringify({ id: `upload-${nextId++}` }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const uploader = (x402: boolean) =>
+    new ChunkedUploader({
+      http: new TurboHTTPService({
+        url: 'https://upload.example.com/v1',
+        logger: Logger.default,
+        retryConfig: {
+          retries: 1,
+          retryDelay: () => 0,
+          onRetry: () => undefined,
+        },
+      }),
+      token: 'base-usdc',
+      logger: Logger.default,
+      dataItemByteCount: 12 * 1024 * 1024,
+      chunkingMode: 'force',
+      ...(x402
+        ? {
+            x402: { signer: {} as never, unsignedData: false },
+            x402RefundIdentity: { address: '0xabc', signatureType: 3 },
+          }
+        : {}),
+    });
+
+  // The private init is the payment boundary, so the invariant is asserted
+  // there rather than through a fully-stubbed upload().
+  const init = (u: ChunkedUploader) =>
+    (u as unknown as { initUpload(): Promise<string> }).initUpload();
+
+  it('pays once, no matter how many times a retry re-enters the upload', async () => {
+    const u = uploader(true);
+
+    const first = await init(u);
+    const second = await init(u);
+    const third = await init(u);
+
+    assert.equal(
+      createRequests.length,
+      1,
+      `expected exactly one paid create, got ${createRequests.length} — each one is a separate charge`,
+    );
+    assert.equal(
+      second,
+      first,
+      'a retry must resume the upload already paid for',
+    );
+    assert.equal(third, first);
+  });
+
+  it('declares the real byte count and a refund identity when it pays', async () => {
+    await init(uploader(true));
+
+    const url = createRequests[0];
+    assert.ok(
+      url.includes(`totalBytes=${12 * 1024 * 1024}`),
+      `create must declare the size being paid for: ${url}`,
+    );
+    assert.ok(
+      url.includes('address=0xabc'),
+      `create must name the refund wallet: ${url}`,
+    );
+    assert.ok(url.includes('signatureType=3'), url);
+  });
+
+  it('refuses to pay without a refund identity, rather than stranding the money', async () => {
+    const u = new ChunkedUploader({
+      http: new TurboHTTPService({
+        url: 'https://upload.example.com/v1',
+        logger: Logger.default,
+        retryConfig: {
+          retries: 1,
+          retryDelay: () => 0,
+          onRetry: () => undefined,
+        },
+      }),
+      token: 'base-usdc',
+      logger: Logger.default,
+      dataItemByteCount: 12 * 1024 * 1024,
+      chunkingMode: 'force',
+      x402: { signer: {} as never, unsignedData: false },
+    });
+
+    await assert.rejects(() => init(u), /refund identity/);
+    assert.equal(createRequests.length, 0, 'must not have paid');
+  });
+
+  // The memo is specific to the paid path; an unpaid upload has no reason to
+  // reuse a stale id and every reason to get a fresh one.
+  it('does not reuse the upload id when the upload is not paid for', async () => {
+    const u = uploader(false);
+
+    const first = await init(u);
+    const second = await init(u);
+
+    assert.equal(createRequests.length, 2);
+    assert.notEqual(second, first);
+  });
+});

--- a/packages/turbo-sdk/src/common/chunked.x402.test.ts
+++ b/packages/turbo-sdk/src/common/chunked.x402.test.ts
@@ -16,6 +16,9 @@
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
+import { testEthWallet } from '../../tests/helpers.js';
+import { TurboFactory } from '../node/factory.js';
+import { X402Funding } from '../types.js';
 import { ChunkedUploader } from './chunked.js';
 import { TurboHTTPService } from './http.js';
 import { Logger } from './logger.js';
@@ -150,5 +153,68 @@ describe('x402-paid chunked uploads', () => {
 
     assert.equal(createRequests.length, 2);
     assert.notEqual(second, first);
+  });
+});
+
+/**
+ * The regression this whole path exists for: `uploadFile` used to refuse to
+ * chunk an x402 upload at all. It skipped the chunked branch whenever the
+ * funding mode was `X402Funding`, and threw outright on `chunkingMode:
+ * 'force'` — so an x402 upload was capped at a single request no matter how
+ * the caller configured chunking. Nothing asserted the routing, only the
+ * uploader internals, so removing the exclusion could silently regress.
+ */
+describe('x402 upload routing', () => {
+  const originalFetch = globalThis.fetch;
+  let paths: string[];
+
+  beforeEach(() => {
+    paths = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      paths.push(new URL(url).pathname + new URL(url).search);
+      const body = url.includes('/status')
+        ? {
+            status: 'FINALIZED',
+            receipt: { id: 'data-item-id', owner: 'owner' },
+          }
+        : { id: 'upload-1' };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sends an x402 upload through the chunked path instead of a single request', async () => {
+    const turbo = TurboFactory.authenticated({
+      privateKey: testEthWallet,
+      token: 'base-usdc',
+      uploadServiceConfig: { url: 'https://upload.example.com' },
+    });
+
+    await turbo.upload({
+      data: Buffer.alloc(64),
+      fundingMode: new X402Funding({}),
+      chunkingMode: 'force',
+    });
+
+    const createdChunkedUpload = paths.some((p) => p.includes('/-1/-1'));
+    assert.ok(
+      createdChunkedUpload,
+      `an x402 upload with chunkingMode 'force' must open a chunked upload; requests were:\n${paths.join(
+        '\n',
+      )}`,
+    );
+
+    const create = paths.find((p) => p.includes('/-1/-1')) as string;
+    assert.ok(
+      create.includes('totalBytes='),
+      `the chunked create must declare the size being paid for: ${create}`,
+    );
   });
 });

--- a/packages/turbo-sdk/src/common/http.ts
+++ b/packages/turbo-sdk/src/common/http.ts
@@ -85,12 +85,43 @@ export class TurboHTTPService implements TurboHTTPServiceInterface {
     signal,
     allowedStatuses = [200, 202],
     headers,
+    x402Options,
   }: {
     endpoint: `/${string}`;
     signal?: AbortSignal;
     allowedStatuses?: number[];
     headers?: Partial<TurboSignedRequestHeaders> & Record<string, string>;
+    /**
+     * Pay for this GET with x402. Used by the chunked uploader's create call,
+     * which the bundler answers with a 402 because a multipart upload is paid
+     * for BEFORE any chunk is accepted.
+     *
+     * Delegates to the same `wrapFetchWithPayment` the POST path uses, so the
+     * signer, the spend cap and the retry semantics are identical rather than
+     * a second implementation that can drift.
+     */
+    x402Options?: X402RequestCredentials;
   }): Promise<T> {
+    if (x402Options !== undefined) {
+      const maxMUSDCAmount =
+        x402Options.maxMUSDCAmount !== undefined
+          ? BigInt(x402Options.maxMUSDCAmount.toString())
+          : undefined;
+      const fetchWithPay = wrapFetchWithPayment(
+        fetch,
+        x402Options.signer,
+        maxMUSDCAmount,
+      );
+      return this.tryRequest(
+        async () =>
+          fetchWithPay(this.baseURL + endpoint, {
+            method: 'GET',
+            headers: { ...defaultHeaders, ...headers },
+            signal,
+          }),
+        allowedStatuses,
+      ) as Promise<T>;
+    }
     return this.withRetry<T>(
       () =>
         fetch(this.baseURL + endpoint, {

--- a/packages/turbo-sdk/src/common/upload.ts
+++ b/packages/turbo-sdk/src/common/upload.ts
@@ -361,12 +361,6 @@ export abstract class TurboAuthenticatedBaseUploadService
       );
     }
 
-    if (params.chunkingMode === 'force' && fundingMode instanceof X402Funding) {
-      throw new Error(
-        "Chunking mode 'force' is not supported when x402 is enabled",
-      );
-    }
-
     this.logger.debug('Starting file upload', { params });
 
     let retries = 0;
@@ -413,30 +407,13 @@ export abstract class TurboAuthenticatedBaseUploadService
       // this result due to the wrapped retry logic of this method.
       try {
         const { chunkByteCount, maxChunkConcurrency } = params;
-        const chunkedUploader = new ChunkedUploader({
-          http: this.httpService,
-          token: this.token,
-          maxChunkConcurrency,
-          chunkByteCount,
-          logger: this.logger,
-          dataItemByteCount: dataItemSizeFactory(),
-          chunkingMode: params.chunkingMode,
-          maxFinalizeMs: params.maxFinalizeMs,
-        });
-        if (
-          chunkedUploader.shouldUseChunkUploader &&
-          !(fundingMode instanceof X402Funding)
-        ) {
-          const response = await chunkedUploader.upload({
-            dataItemStreamFactory,
-            dataItemSizeFactory,
-            dataItemOpts,
-            signal,
-            events,
-          });
-          return { ...response, cryptoFundResult };
-        }
 
+        // Built here rather than after the chunked branch so BOTH paths can
+        // pay with it. Chunked x402 uploads used to be impossible — the
+        // bundler had no way to charge for a multipart upload — so this branch
+        // deliberately fell back to a single request, which capped x402 at the
+        // single-item limit no matter how the client chunked. The bundler now
+        // settles at create, so the fallback is no longer needed.
         const x402Options =
           fundingMode instanceof X402Funding
             ? {
@@ -446,6 +423,36 @@ export abstract class TurboAuthenticatedBaseUploadService
                 maxMUSDCAmount: fundingMode.maxMUSDCAmount,
               }
             : undefined;
+
+        const chunkedUploader = new ChunkedUploader({
+          http: this.httpService,
+          token: this.token,
+          maxChunkConcurrency,
+          chunkByteCount,
+          logger: this.logger,
+          dataItemByteCount: dataItemSizeFactory(),
+          chunkingMode: params.chunkingMode,
+          maxFinalizeMs: params.maxFinalizeMs,
+          ...(x402Options ? { x402: x402Options } : {}),
+          ...(x402Options
+            ? {
+                x402RefundIdentity: {
+                  address: await this.signer.getNativeAddress(),
+                  signatureType: this.signer.signer.signatureType,
+                },
+              }
+            : {}),
+        });
+        if (chunkedUploader.shouldUseChunkUploader) {
+          const response = await chunkedUploader.upload({
+            dataItemStreamFactory,
+            dataItemSizeFactory,
+            dataItemOpts,
+            signal,
+            events,
+          });
+          return { ...response, cryptoFundResult };
+        }
 
         const response = await this.uploadSignedDataItem({
           dataItemStreamFactory,

--- a/packages/turbo-sdk/tests/e2e/x402-chunked.e2e.mjs
+++ b/packages/turbo-sdk/tests/e2e/x402-chunked.e2e.mjs
@@ -1,0 +1,149 @@
+/**
+ * x402-paid CHUNKED upload, end to end, through the built SDK.
+ *
+ * Before this change the SDK refused to chunk an x402 upload — upload.ts
+ * explicitly skipped the chunked path for X402Funding, because the bundler had
+ * no way to charge for a multipart upload. That capped x402 at the single-item
+ * limit no matter how the caller configured chunking.
+ *
+ * This uploads MORE than that limit over multiple chunks, paying with real
+ * Base Sepolia USDC.
+ *
+ * Usage:
+ *   node tests/e2e/x402-chunked.e2e.mjs \
+ *     --upload-url http://localhost:3001 \
+ *     --key ops-test-wallet-base-sepolia.json
+ */
+import { randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+import { TurboFactory, X402Funding } from '../../lib/esm/node/index.js';
+
+const arg = (f, d) => {
+  const i = process.argv.indexOf(f);
+  return i !== -1 ? process.argv[i + 1] : d;
+};
+const UPLOAD_URL = arg('--upload-url', 'http://localhost:3001');
+const KEY = arg(
+  '--key',
+  '/opt/ar-io-bundler/ops-test-wallet-base-sepolia.json',
+);
+const PAYMENT_URL = arg('--payment-url', 'http://localhost:4001');
+
+let failures = 0;
+const ok = (m) => console.log(`   PASS  ${m}`);
+const bad = (m) => {
+  failures++;
+  console.log(`   FAIL  ${m}`);
+};
+const check = (c, g, b) => (c ? ok(g) : bad(b ?? g));
+
+const keyfile = JSON.parse(readFileSync(KEY, 'utf8'));
+const privateKey = keyfile.privateKey;
+const wallet = keyfile.address;
+
+console.log('============================================================');
+console.log('x402 CHUNKED upload — real Base Sepolia USDC');
+console.log(`upload: ${UPLOAD_URL}`);
+console.log('============================================================');
+
+try {
+  const turbo = TurboFactory.authenticated({
+    privateKey,
+    token: 'base-usdc',
+    uploadServiceConfig: { url: UPLOAD_URL },
+  });
+
+  // Comfortably over the 5 MiB minimum chunk size, so this MUST chunk, and
+  // over the old single-request x402 ceiling.
+  const bytes = 8 * 1024 * 1024;
+  const payload = randomBytes(bytes);
+
+  // What the bundler says this costs, so we can assert we were charged that
+  // and not something else. A chunked upload settles at CREATE, on the
+  // declared byte count, so the quote must line up with the real charge.
+  //
+  // Quote from the PAYMENT service, which is what the multipart create and the
+  // single-shot x402 post both settle against. The upload service also exposes
+  // /price/x402/data-item/..., but that is a public estimate on different math
+  // (it read ~19% higher here) and drifts between calls with the AR/USD rate —
+  // asserting against it fails a correct charge.
+  const quote = await fetch(
+    `${PAYMENT_URL}/v1/x402/price/3/${wallet}?bytes=${bytes + 150}`,
+  ).then((r) => r.json());
+  const quoted = BigInt(quote.accepts[0].maxAmountRequired);
+  console.log(
+    `   quote: ${quoted} base units ($${(Number(quoted) / 1e6).toFixed(4)})`,
+  );
+
+  const usdc = async () => {
+    const res = await fetch('https://sepolia.base.org', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+            data:
+              '0x70a08231000000000000000000000000' +
+              wallet.slice(2).toLowerCase(),
+          },
+          'latest',
+        ],
+      }),
+    }).then((r) => r.json());
+    return BigInt(res.result);
+  };
+  const before = await usdc();
+  console.log(`   USDC before: ${before}`);
+
+  console.log(
+    `\n-- uploading ${(bytes / 1024 / 1024).toFixed(
+      0,
+    )} MiB with X402Funding --`,
+  );
+  const res = await turbo.upload({
+    data: payload,
+    // Above x402-fetch's 0.10 USDC default cap; 12 MiB quotes ~$0.44.
+    fundingMode: new X402Funding({ maxMUSDCAmount: 2_000_000 }),
+    chunkingMode: 'force',
+  });
+
+  check(!!res?.id, `upload completed, id ${String(res?.id).slice(0, 24)}...`);
+  check(!!res?.owner, `receipt owner ${String(res?.owner).slice(0, 16)}...`);
+
+  const after = await usdc();
+  const spent = before - after;
+  console.log(`   USDC after:  ${after}  (spent ${spent})`);
+  // The quote is taken on an estimated size (the exact data-item header length
+  // is not known here) and the AR/USD rate moves between calls, so a few
+  // percent is expected. The point of the assertion is the order of magnitude:
+  // it catches paying N times over (the retry loop re-buying the upload) and
+  // unit mistakes, which is where the real bugs have been.
+  const ratio = Number(spent) / Number(quoted);
+  check(
+    ratio > 0.9 && ratio < 1.1,
+    `charged once, within 10% of quote (${spent} vs ${quoted}, ${ratio.toFixed(
+      3,
+    )}x)`,
+    `charged ${spent} against a quote of ${quoted} (${ratio.toFixed(
+      3,
+    )}x) — a ratio near a whole number means the upload was paid for more than once`,
+  );
+  ok('-> an x402 upload past the single-request ceiling, over multiple chunks');
+} catch (error) {
+  bad(`threw: ${error?.message ?? error}`);
+  if (process.env.DEBUG) console.error(error);
+}
+
+console.log('\n============================================================');
+console.log(
+  failures === 0
+    ? 'PASSED - x402 chunked upload'
+    : `FAILED - ${failures} check(s)`,
+);
+console.log('============================================================');
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
An x402 upload could not be chunked.

`upload.ts` skipped the chunked path whenever the funding mode was `X402Funding`, and separately threw on `chunkingMode: 'force'` with x402. So an x402 upload was capped at whatever fits in a single request, no matter how the caller configured chunking. That was correct when the bundler had no way to charge for a multipart upload; it now settles at create, so both restrictions are removed.

## How it pays

A multipart upload is paid for **at create**, on the declared size. `http.get` gains an `x402Options` that reuses the same `wrapFetchWithPayment` the POST path already uses — same signer, same spend cap, rather than a second implementation that can drift.

The create call declares the size and carries a **refund identity**. The wallet that pays in USDC and the wallet credited on under-delivery are allowed to differ, so it is passed explicitly rather than derived from the x402 signer.

## The paid upload id is memoized — this is the important part

`uploadFile` retries a failed upload up to six times, and a retry re-enters `upload()` on the same instance. Without the memo, **each retry opened a new paid upload**.

That is not hypothetical. An upload against a bundler configured with a lower size ceiling failed at finalize and billed **five separate payments of 369,798 USDC base units for one upload**. Every individual request was perfectly well-formed, so nothing short of watching a real Base Sepolia balance would have caught it. A retry now resumes the upload already paid for.

The memo is deliberately not cleared on failure: re-paying is never the right recovery, and an upload that cannot be resumed is refunded server-side.

## Verification

Live Base Sepolia against a real bundler — an 8 MiB upload over multiple chunks completes and moves the balance by **exactly** the quoted 245,445 base units, **once**:

```
   quote: 245445 base units ($0.2454)
   USDC before: 12515523
   PASS  upload completed, id vgVfD9xDCVMog1J_CpWYNPOi...
   USDC after:  12270078  (spent 245445)
   PASS  charged once, within 10% of quote (245445 vs 245445, 1.000x)
```

New unit tests assert the buy-once invariant directly — with the memo removed they report three charges instead of one. `yarn lint` clean · build OK · 133 unit tests passing · prettier clean.

The bundler-side half (create allowing sizes finalize always rejects, and a terminal rejection that was never persisted — which is what made the client retry into five payments) is ar-io/ar-io-bundler#307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTi1Pd388d9Kh11oU98aES