### PR TITLE
test(payment): skip Stripe tests when there is no usable key

### DIFF
--- a/packages/turbo-sdk/tests/helpers.ts
+++ b/packages/turbo-sdk/tests/helpers.ts
@@ -213,3 +213,28 @@ export async function delayedBlockMining(
     blocksMined++;
   }
 }
+
+/**
+ * Stripe-backed tests need a real key, and skipping them without one is honest
+ * rather than lenient: the payment service cannot create a session at all, so
+ * there is nothing left to assert.
+ *
+ * `docker-compose.yml` defaults `STRIPE_SECRET_KEY` to the literal
+ * `secret-key`, which Stripe rejects with "Invalid API Key provided", and
+ * GitHub does not pass repository secrets to a workflow triggered by a pull
+ * request from a fork. Approving the run does not change that. So on every fork
+ * PR these tests fail for a reason the contributor can neither see nor fix, and
+ * they take the whole integration job red with them.
+ *
+ * Any run that has a real key still executes them: every same-repo pull
+ * request, and every run on `alpha` and `main`.
+ */
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+export const stripeTestOptions: { skip?: string } =
+  stripeSecretKey === undefined ||
+  stripeSecretKey === '' ||
+  stripeSecretKey === 'secret-key'
+    ? {
+        skip: 'no usable STRIPE_SECRET_KEY, so the payment service cannot create a Stripe session',
+      }
+    : {};

--- a/packages/turbo-sdk/tests/turbo.node.test.ts
+++ b/packages/turbo-sdk/tests/turbo.node.test.ts
@@ -64,6 +64,7 @@ import {
   mineArLocalBlock,
   sendFundTransaction,
   solanaUrlString,
+  stripeTestOptions,
   testArweave,
   testArweaveNativeB64Address,
   testEthAddressBase64,
@@ -486,86 +487,102 @@ describe('Node environment', () => {
     });
 
     describe('createCheckoutSession()', () => {
-      it('should properly get a checkout session', async () => {
-        const {
-          adjustments,
-          paymentAmount,
-          quotedPaymentAmount,
-          url,
-          client_secret,
-          id,
-          winc,
-        } = await turbo.createCheckoutSession({
-          amount: USD(10),
-          owner: '43-character-stub-arweave-address-000000000',
-        });
-        assert.deepEqual(adjustments, []);
-        assert.equal(paymentAmount, 1000);
-        assert.equal(quotedPaymentAmount, 1000);
-        assert.ok(typeof url === 'string');
-        assert.ok(typeof id === 'string');
-        assert.equal(client_secret, undefined);
-        assert.ok(typeof winc === 'string');
-      });
+      it(
+        'should properly get a checkout session',
+        stripeTestOptions,
+        async () => {
+          const {
+            adjustments,
+            paymentAmount,
+            quotedPaymentAmount,
+            url,
+            client_secret,
+            id,
+            winc,
+          } = await turbo.createCheckoutSession({
+            amount: USD(10),
+            owner: '43-character-stub-arweave-address-000000000',
+          });
+          assert.deepEqual(adjustments, []);
+          assert.equal(paymentAmount, 1000);
+          assert.equal(quotedPaymentAmount, 1000);
+          assert.ok(typeof url === 'string');
+          assert.ok(typeof id === 'string');
+          assert.equal(client_secret, undefined);
+          assert.ok(typeof winc === 'string');
+        },
+      );
 
-      it('should properly get a checkout session with a hosted ui mode and custom success and cancel urls', async () => {
-        const {
-          adjustments,
-          paymentAmount,
-          quotedPaymentAmount,
-          url,
-          id,
-          client_secret,
-          winc,
-        } = await turbo.createCheckoutSession({
-          amount: USD(20),
-          owner: '43-character-stub-arweave-address-000000000',
-          uiMode: 'hosted',
-          successUrl: 'https://example.com/success',
-          cancelUrl: 'https://example.com/cancel',
-        });
-        assert.deepEqual(adjustments, []);
-        assert.equal(paymentAmount, 2000);
-        assert.equal(quotedPaymentAmount, 2000);
-        assert.ok(typeof url === 'string');
-        assert.ok(typeof id === 'string');
-        assert.equal(client_secret, undefined);
-        assert.ok(typeof winc === 'string');
-      });
+      it(
+        'should properly get a checkout session with a hosted ui mode and custom success and cancel urls',
+        stripeTestOptions,
+        async () => {
+          const {
+            adjustments,
+            paymentAmount,
+            quotedPaymentAmount,
+            url,
+            id,
+            client_secret,
+            winc,
+          } = await turbo.createCheckoutSession({
+            amount: USD(20),
+            owner: '43-character-stub-arweave-address-000000000',
+            uiMode: 'hosted',
+            successUrl: 'https://example.com/success',
+            cancelUrl: 'https://example.com/cancel',
+          });
+          assert.deepEqual(adjustments, []);
+          assert.equal(paymentAmount, 2000);
+          assert.equal(quotedPaymentAmount, 2000);
+          assert.ok(typeof url === 'string');
+          assert.ok(typeof id === 'string');
+          assert.equal(client_secret, undefined);
+          assert.ok(typeof winc === 'string');
+        },
+      );
 
-      it('should properly get a checkout session with a embedded ui mode and custom return url', async () => {
-        const {
-          adjustments,
-          paymentAmount,
-          quotedPaymentAmount,
-          id,
-          client_secret,
-          winc,
-        } = await turbo.createCheckoutSession({
-          amount: USD(20),
-          owner: '43-character-stub-arweave-address-000000000',
-          uiMode: 'embedded',
-          returnUrl: 'https://example.com/return',
-        });
-        assert.deepEqual(adjustments, []);
-        assert.equal(paymentAmount, 2000);
-        assert.equal(quotedPaymentAmount, 2000);
-        assert.ok(typeof id === 'string');
-        assert.ok(typeof client_secret === 'string');
-        assert.ok(typeof winc === 'string');
-      });
+      it(
+        'should properly get a checkout session with a embedded ui mode and custom return url',
+        stripeTestOptions,
+        async () => {
+          const {
+            adjustments,
+            paymentAmount,
+            quotedPaymentAmount,
+            id,
+            client_secret,
+            winc,
+          } = await turbo.createCheckoutSession({
+            amount: USD(20),
+            owner: '43-character-stub-arweave-address-000000000',
+            uiMode: 'embedded',
+            returnUrl: 'https://example.com/return',
+          });
+          assert.deepEqual(adjustments, []);
+          assert.equal(paymentAmount, 2000);
+          assert.equal(quotedPaymentAmount, 2000);
+          assert.ok(typeof id === 'string');
+          assert.ok(typeof client_secret === 'string');
+          assert.ok(typeof winc === 'string');
+        },
+      );
     });
 
     describe('createPaymentIntent()', () => {
-      it('should properly create a payment intent', async () => {
-        const { id, client_secret, winc } = await turbo.createPaymentIntent({
-          amount: USD(10),
-          owner: '43-character-stub-arweave-address-000000000',
-        });
-        assert.ok(typeof id === 'string');
-        assert.ok(typeof client_secret === 'string');
-        assert.ok(typeof winc === 'string');
-      });
+      it(
+        'should properly create a payment intent',
+        stripeTestOptions,
+        async () => {
+          const { id, client_secret, winc } = await turbo.createPaymentIntent({
+            amount: USD(10),
+            owner: '43-character-stub-arweave-address-000000000',
+          });
+          assert.ok(typeof id === 'string');
+          assert.ok(typeof client_secret === 'string');
+          assert.ok(typeof winc === 'string');
+        },
+      );
     });
 
     describe('submitFundTransaction()', () => {
@@ -2286,19 +2303,23 @@ describe('Node environment', () => {
       assert.equal(uploadSuccessCalled, true);
     });
 
-    it('should get a checkout session with kyve token', async () => {
-      const { adjustments, paymentAmount, quotedPaymentAmount, url, id } =
-        await turbo.createCheckoutSession({
-          amount: USD(10), // 10 USD
-          owner: testKyveNativeAddress,
-        });
+    it(
+      'should get a checkout session with kyve token',
+      stripeTestOptions,
+      async () => {
+        const { adjustments, paymentAmount, quotedPaymentAmount, url, id } =
+          await turbo.createCheckoutSession({
+            amount: USD(10), // 10 USD
+            owner: testKyveNativeAddress,
+          });
 
-      assert.deepEqual(adjustments, []);
-      assert.equal(paymentAmount, 1000);
-      assert.equal(quotedPaymentAmount, 1000);
-      assert.ok(typeof url === 'string');
-      assert.ok(typeof id === 'string');
-    });
+        assert.deepEqual(adjustments, []);
+        assert.equal(paymentAmount, 1000);
+        assert.equal(quotedPaymentAmount, 1000);
+        assert.ok(typeof url === 'string');
+        assert.ok(typeof id === 'string');
+      },
+    );
 
     it.skip('should topUpWithTokens() to a KYVE wallet', async () => {
       const { id, quantity, owner, winc, target } = await turbo.topUpWithTokens(

--- a/packages/turbo-sdk/tests/turbo.web.test.ts
+++ b/packages/turbo-sdk/tests/turbo.web.test.ts
@@ -38,6 +38,7 @@ import {
   mineArLocalBlock,
   sendFundTransaction,
   solanaUrlString,
+  stripeTestOptions,
   testArweave,
   testArweaveNativeB64Address,
   testEthAddressBase64,
@@ -424,7 +425,37 @@ describe('Browser environment', () => {
       });
 
       describe('createCheckoutSession()', () => {
-        it('should properly get a checkout session', async () => {
+        it(
+          'should properly get a checkout session',
+          stripeTestOptions,
+          async () => {
+            const {
+              adjustments,
+              paymentAmount,
+              quotedPaymentAmount,
+              url,
+              id,
+              client_secret,
+              winc,
+            } = await turbo.createCheckoutSession({
+              amount: USD(10),
+              owner: '43-character-stub-arweave-address-000000000',
+            });
+            assert.deepEqual(adjustments, []);
+            assert.equal(paymentAmount, 1000);
+            assert.equal(quotedPaymentAmount, 1000);
+            assert.ok(typeof url === 'string');
+            assert.ok(typeof id === 'string');
+            assert.equal(client_secret, undefined);
+            assert.ok(typeof winc === 'string');
+          },
+        );
+      });
+
+      it(
+        'should properly get a checkout session with a embedded ui mode',
+        stripeTestOptions,
+        async () => {
           const {
             adjustments,
             paymentAmount,
@@ -434,41 +465,19 @@ describe('Browser environment', () => {
             client_secret,
             winc,
           } = await turbo.createCheckoutSession({
-            amount: USD(10),
+            amount: USD(20),
             owner: '43-character-stub-arweave-address-000000000',
+            uiMode: 'embedded',
           });
           assert.deepEqual(adjustments, []);
-          assert.equal(paymentAmount, 1000);
-          assert.equal(quotedPaymentAmount, 1000);
-          assert.ok(typeof url === 'string');
+          assert.equal(paymentAmount, 2000);
+          assert.equal(quotedPaymentAmount, 2000);
+          assert.equal(url, undefined);
           assert.ok(typeof id === 'string');
-          assert.equal(client_secret, undefined);
+          assert.ok(typeof client_secret === 'string');
           assert.ok(typeof winc === 'string');
-        });
-      });
-
-      it('should properly get a checkout session with a embedded ui mode', async () => {
-        const {
-          adjustments,
-          paymentAmount,
-          quotedPaymentAmount,
-          url,
-          id,
-          client_secret,
-          winc,
-        } = await turbo.createCheckoutSession({
-          amount: USD(20),
-          owner: '43-character-stub-arweave-address-000000000',
-          uiMode: 'embedded',
-        });
-        assert.deepEqual(adjustments, []);
-        assert.equal(paymentAmount, 2000);
-        assert.equal(quotedPaymentAmount, 2000);
-        assert.equal(url, undefined);
-        assert.ok(typeof id === 'string');
-        assert.ok(typeof client_secret === 'string');
-        assert.ok(typeof winc === 'string');
-      });
+        },
+      );
     });
 
     describe('submitFundTransaction()', () => {


### PR DESCRIPTION
**A pull request from a fork can never go green on this repo, and seven tests are the whole reason.** This fixes that, and it is a prerequisite for merging [#453](https://github.com/ardriveapp/turbo-sdk/pull/453), which is currently `BLOCKED` on exactly these failures.

## The mechanism

GitHub does not pass repository secrets to a workflow triggered by a pull request from a fork, and a maintainer approving the run does not change that. `docker-compose.yml:202` then supplies its default:

```yaml
STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-secret-key}
```

Stripe rejects it, and the payment service answers 503 to every checkout and payment-intent request:

```
Failed request (Status 503): Error creating stripe payment session!
Invalid API Key provided: secret-key
```

Observed on #453: **477 tests, 453 pass, 7 fail**, every failure that same error. The contributor can neither see the cause nor fix it, and the red integration job is enough to block the merge. So today an external contributor's only possible outcome is a red branch.

## Why skipping is the right answer and not a weakening

Without a key the payment service **cannot create a session at all**, so there is nothing left for those tests to assert. They are not being made more permissive; they are being told the truth about their environment.

**Every run with a real key still executes them**: every same-repo pull request, and every run on `alpha` and `main`. Coverage on the branches that matter is unchanged.

## The condition is exact, not a guess

It matches unset, empty, and the `secret-key` placeholder that docker-compose supplies, which is the literal value in the failure. Verified in all three directions:

| `STRIPE_SECRET_KEY` | Result |
|---|---|
| unset | skipped |
| `secret-key` | skipped |
| a real key | runs |

## Scope

**Seven tests, matched by name against the failing run.** Five in `turbo.node.test.ts`, including the kyve checkout session, and two in `turbo.web.test.ts`.

The two `createCheckoutSession()` blocks asserting that a bad promo code is rejected are **deliberately untouched**: they expect a failure and pass without a key. Guarding them would have been the easy over-reach and would have cost real coverage.

`tsc` and `prettier` clean.

## Related, not fixed here

`textury/arlocal` publishes an amd64-only manifest, so `yarn test:docker` cannot start on an ARM machine at all. Between that and this, an external contributor currently has no route to a passing integration run either locally or in CI. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWHTFTDFMZ7XG9Hw79X4cT
