### PR TITLE
docs(examples): add a runnable folder-index example

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,8 @@ const { manifest, fileResponses, manifestResponse } = await turbo.uploadFolder({
 
 ##### Incremental Folder Uploads
 
+A runnable version of everything below is in [`examples/folder-index`](examples/folder-index/index.mjs): it deploys the same folder three times and prints what each run uploaded and reused.
+
 An Arweave upload is permanent, so paying twice for byte identical files buys
 nothing. Pass a `folderIndex` and `uploadFolder` hashes every file, asks the
 index which of those files already have a data item on Arweave, and signs,

--- a/examples/folder-index/index.mjs
+++ b/examples/folder-index/index.mjs
@@ -1,0 +1,84 @@
+/**
+ * Incremental folder uploads: deploy the same folder twice and pay once.
+ *
+ * `uploadFolder` re-signs and re-pays for every file on every run. An Arweave
+ * upload is permanent, so paying a second time for byte-identical files buys
+ * nothing. Pass a `folderIndex` and only the files that actually changed are
+ * signed, uploaded and billed.
+ *
+ * Run: cd examples/folder-index && yarn && node index.mjs
+ * This uploads to the Turbo development environment, not production.
+ */
+import {
+  TurboFactory,
+  composeFolderIndex,
+  createChainFolderIndex,
+  createFileFolderIndex,
+  developmentTurboConfiguration,
+} from '@ardrive/turbo-sdk/node';
+import Arweave from 'arweave';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const jwk = await Arweave.init({}).wallets.generate();
+const turbo = TurboFactory.authenticated({
+  privateKey: jwk,
+  ...developmentTurboConfiguration,
+});
+
+// A folder shaped like a build output: an entry point and a couple of assets.
+const folder = mkdtempSync(join(tmpdir(), 'turbo-folder-index-'));
+mkdirSync(join(folder, 'assets'));
+writeFileSync(join(folder, 'index.html'), '<h1>hello</h1>');
+writeFileSync(join(folder, 'assets/app.js'), 'console.log(1)');
+writeFileSync(join(folder, 'assets/app.css'), 'body{color:red}');
+
+/**
+ * Two layers, and the order matters. The file index answers instantly on a
+ * machine that keeps its working directory between deploys. The chain index
+ * sweeps your own past uploads over a gateway's GraphQL, which is what lets a
+ * CI runner with an empty working directory still skip.
+ *
+ * `getPublicKey()` is passed rather than an address because a gateway indexes
+ * uploads under the base64url sha-256 of the public key, and a raw ed25519 key
+ * base64urls to the same 43 characters as that address. Guessing wrong matches
+ * nothing and silently re-uploads everything, so the SDK makes you say which
+ * you have.
+ */
+const folderIndex = composeFolderIndex([
+  createFileFolderIndex({ filePath: join(folder, '.turbo/index.jsonl') }),
+  createChainFolderIndex({ owner: await turbo.signer.getPublicKey() }),
+]);
+
+const deploy = async (label) => {
+  const { folderIndexSummary: s } = await turbo.uploadFolder({
+    folderPath: folder,
+    folderIndex,
+    // Deploy-varying tags belong on the manifest. A commit sha in
+    // `dataItemOpts` would change every file's key and re-upload the folder.
+    manifestDataItemOpts: {
+      tags: [{ name: 'Deploy', value: new Date().toISOString() }],
+    },
+  });
+  console.log(
+    `${label}: uploaded ${s.uploadedFiles}, reused ${s.reusedFiles} of ${s.totalFiles} files`,
+  );
+};
+
+try {
+  await deploy('first deploy ');
+  await deploy('unchanged   ');
+
+  writeFileSync(join(folder, 'assets/app.js'), 'console.log(2)');
+  await deploy('one file edit');
+} finally {
+  rmSync(folder, { recursive: true, force: true });
+}
+
+/**
+ * Expected:
+ *   first deploy : uploaded 3, reused 0 of 3 files
+ *   unchanged    : uploaded 0, reused 3 of 3 files
+ *   one file edit: uploaded 1, reused 2 of 3 files
+ */

--- a/examples/folder-index/package.json
+++ b/examples/folder-index/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@ardrive/turbo-sdk": "alpha",
+    "arweave": "^1.15.1"
+  }
+}

--- a/packages/turbo-sdk/package.json
+++ b/packages/turbo-sdk/package.json
@@ -65,6 +65,7 @@
     "examples": "yarn example:esm & yarn example:cjs & yarn example:ts:esm & yarn example:ts:cjs",
     "example:vite": "cd examples/vite && yarn && yarn start",
     "example:esm": "cd examples/esm && yarn && node index.mjs",
+    "example:folder-index": "cd examples/folder-index && yarn && node index.mjs",
     "example:cjs": "cd examples/cjs && yarn && node index.cjs",
     "example:web": "http-server --port 8080 --host -o examples/web",
     "example:ts:esm": "cd examples/typescript/esm && yarn && yarn test",


### PR DESCRIPTION
The feature shipped in `1.42.0-alpha.14` with a README section and **nothing to run.** `examples/` has cjs, esm, next, typescript, vite and web, and none mentions `folderIndex` — for a feature whose pitch is that a deploy script stops paying twice, that's where people look first.

The example deploys the same folder three times and prints what each run did:

```
first deploy : uploaded 3, reused 0 of 3 files
unchanged    : uploaded 0, reused 3 of 3 files
one file edit: uploaded 1, reused 2 of 3 files
```

**That sequence is the feature**, and it's more convincing in six lines of output than six paragraphs of README.

Uses `developmentTurboConfiguration` and a generated throwaway wallet, so running it costs nothing and touches nothing real.

## Two things are commented because they're what people get wrong

**Layer order.** The file index goes in front of the chain index — a local cache answers instantly, and the gateway sweep is what saves a CI runner with an empty working directory.

**Where the deploy timestamp goes.** In `manifestDataItemOpts`, not `dataItemOpts`. A per-file tag that changes every deploy changes every key and re-uploads the whole folder at full price, which is the one way to use this feature and get nothing from it.

Also wires `yarn example:folder-index` alongside the existing example scripts, and links it from the README section. `prettier --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWHTFTDFMZ7XG9Hw79X4cT
