### PR TITLE
fix: close the second round of review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,11 +1243,14 @@ implement the interface directly rather than exposing a secret key:
 const owner = {
   getAddress: () => wallet.publicKey.toBase58(),
   signTransaction: async (txBase64) => {
+    // atob/btoa rather than Buffer: browsers do not provide Buffer unless the
+    // app polyfills it. The spread is safe here because a Solana transaction
+    // is capped at 1232 bytes.
     const tx = VersionedTransaction.deserialize(
-      Buffer.from(txBase64, 'base64'),
+      Uint8Array.from(atob(txBase64), (c) => c.charCodeAt(0)),
     );
     const signed = await wallet.signTransaction(tx);
-    return Buffer.from(signed.serialize()).toString('base64');
+    return btoa(String.fromCharCode(...signed.serialize()));
   },
   signMessage: (message) => wallet.signMessage(message),
 };
@@ -2029,9 +2032,9 @@ turbo list-shares --address 2cor...VUa --wallet-file ../path/to/my/wallet
 
 #### ArNS Commands
 
-Buy and manage [ArNS](#arns-names) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-purchase-status`.
+Buy and manage [ArNS](#arns-names) names by paying with Turbo Credits. Purchases resolve on-chain asynchronously: buy/extend/upgrade commands return a `nonce` you can poll with `arns-action-status`. (`arns-purchase-status` reads a separate namespace, the one a fiat quote lands in.)
 
-All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. Every write command requires a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`) to pay; the ANT-scoped ones (`transfer-arns-ant`, `set-arns-record`, `remove-arns-record`, `set-arns-record-metadata`, `remove-arns-record-metadata`, `transfer-arns-record`, `add-arns-controller`, `remove-arns-controller`) also require `--owner-key` for the owner proof. The read-only commands (`arns-price`, `arns-action-price`, `arns-purchase-status`, `arns-fiat-quote`) need neither.
+All ArNS commands accept the global `--payment-url <url>` option to target a specific bundler/payment service (e.g. a local or devnet bundler at `http://localhost:4001`), and `--token <token>` (e.g. `arweave`, `solana`, `ethereum`) to select the wallet/identity type. Every write command requires a wallet (`--wallet-file`, `--private-key`, or `--mnemonic`) to pay; the ANT-scoped ones (`transfer-arns-ant`, `set-arns-record`, `remove-arns-record`, `set-arns-record-metadata`, `remove-arns-record-metadata`, `transfer-arns-record`, `add-arns-controller`, `remove-arns-controller`) also require `--owner-key` for the owner proof. The read-only commands (`arns-price`, `arns-action-price`, `arns-purchase-status`, `arns-fiat-quote`) need neither. `arns-action-status` reads nothing on-chain either, but takes a wallet because `getArNSActionStatus` lives on the authenticated client.
 
 When a purchase is rejected for lack of Turbo Credits (HTTP 402), the command prints a clear "insufficient credits — top up your balance and retry" message and exits non-zero.
 
@@ -2176,6 +2179,23 @@ e.g:
 
 ```shell
 turbo arns-purchase-status --nonce 3f8c...e21 --payment-url http://localhost:4001
+```
+
+##### `arns-action-status`
+
+Status of a credit-paid ArNS action by its nonce: the four purchase actions and the eight non-purchase ones. This is the command the buy/extend/upgrade output points at.
+
+`arns-purchase-status` is a different namespace (`/arns/purchase/`), which is where a fiat quote's nonce lands. Passing an action nonce to it returns "Purchase status not found".
+
+Command Options:
+
+- `--nonce <nonce>` - ArNS action nonce to look up
+
+e.g:
+
+```shell
+turbo arns-action-status --nonce 3f8c...e21 \
+  --wallet-file ../path/to/my/wallet.json
 ```
 
 ##### `transfer-arns-ant`

--- a/packages/turbo-sdk/src/cli/cli.ts
+++ b/packages/turbo-sdk/src/cli/cli.ts
@@ -25,6 +25,7 @@ import { version } from '../version.js';
 import {
   addArNSController,
   arnsActionPrice,
+  arnsActionStatus,
   arnsFiatQuote,
   arnsPrice,
   arnsPurchaseStatus,
@@ -59,6 +60,7 @@ import { x402UploadUnsignedFile } from './commands/x402UploadUnsignedData.js';
 import {
   addArNSControllerOptions,
   arnsActionPriceOptions,
+  arnsActionStatusOptions,
   arnsFiatQuoteOptions,
   arnsPriceOptions,
   arnsPurchaseStatusOptions,
@@ -291,6 +293,17 @@ applyOptions(
   arnsPurchaseStatusOptions,
 ).action(async (_commandOptions, command: Command) => {
   await runCommand(command, arnsPurchaseStatus);
+});
+
+applyOptions(
+  program
+    .command('arns-action-status')
+    .description(
+      'Get the status of a credit-paid ArNS action by its nonce (buy, extend, upgrade, and the non-purchase actions)',
+    ),
+  arnsActionStatusOptions,
+).action(async (_commandOptions, command: Command) => {
+  await runCommand(command, arnsActionStatus);
 });
 
 applyOptions(

--- a/packages/turbo-sdk/src/cli/commands/arns.test.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.test.ts
@@ -23,18 +23,22 @@ import {
   InsufficientCreditsError,
 } from '../../utils/errors.js';
 import {
+  ArNSActionStatusOptions,
   ArNSPriceOptions,
   ArNSPurchaseOptions,
   ArNSPurchaseStatusOptions,
   RemoveArNSRecordOptions,
+  SetArNSRecordMetadataOptions,
   SetArNSRecordOptions,
   TransferArNSAntOptions,
 } from '../types.js';
 import {
+  ArNSActionStatusClient,
   ArNSCustodyClient,
   ArNSPriceClient,
   ArNSPurchaseClient,
   ArNSStatusClient,
+  arnsActionStatus,
   arnsFiatQuote,
   arnsPrice,
   arnsPriceParamsFromOptions,
@@ -44,6 +48,7 @@ import {
   increaseArNSUndernames,
   removeArNSRecord,
   setArNSRecord,
+  setArNSRecordMetadata,
   transferArNSAnt,
   upgradeArNSName,
 } from './arns.js';
@@ -55,7 +60,8 @@ class FakeTurbo
     ArNSPriceClient,
     ArNSStatusClient,
     ArNSPurchaseClient,
-    ArNSCustodyClient
+    ArNSCustodyClient,
+    ArNSActionStatusClient
 {
   public calls: { method: string; params: unknown }[] = [];
   public error: unknown = undefined;
@@ -164,6 +170,14 @@ class FakeTurbo
       antId: 'ant-1',
       messageId: 'm',
     } as never);
+  }
+  getArNSActionStatus(nonce: string) {
+    return this.record('getArNSActionStatus', nonce, {
+      nonce,
+      action: 'buy-name' as const,
+      status: 'completed' as const,
+      messageId: 'msg-1',
+    });
   }
   setArNSRecordMetadata(params: unknown) {
     return this.record('setArNSRecordMetadata', params, {
@@ -525,6 +539,57 @@ describe('ArNS CLI commands', () => {
             turbo,
           ),
         /nonce/,
+      );
+    });
+  });
+
+  describe('arnsActionStatus', () => {
+    it('reads the action namespace, not the purchase namespace', async () => {
+      await arnsActionStatus(
+        { token: 'arweave', nonce: 'nonce-123' } as ArNSActionStatusOptions,
+        turbo,
+      );
+      // A credit-paid buy returns an ACTION nonce. Looking it up through
+      // getArNSPurchaseStatus hits /arns/purchase/, a separate namespace that
+      // answers "Purchase status not found".
+      assert.equal(turbo.last.method, 'getArNSActionStatus');
+      assert.equal(turbo.last.params, 'nonce-123');
+    });
+
+    it('requires a --nonce', async () => {
+      await assert.rejects(
+        () =>
+          arnsActionStatus(
+            { token: 'arweave' } as ArNSActionStatusOptions,
+            turbo,
+          ),
+        /nonce/,
+      );
+    });
+  });
+
+  describe('setArNSRecordMetadata option conflicts', () => {
+    it('rejects a value and its --clear- partner together', async () => {
+      await assert.rejects(
+        () =>
+          setArNSRecordMetadata(
+            {
+              token: 'arweave',
+              antId: 'ant-123',
+              undername: 'docs',
+              ownerKey: TEST_OWNER_KEY,
+              displayName: 'My Docs',
+              clearDisplayName: true,
+            } as unknown as SetArNSRecordMetadataOptions,
+            turbo,
+          ),
+        /Cannot pass both --display-name and --clear-display-name/,
+      );
+      // Nothing may reach the signed mutation: the old behaviour silently let
+      // the clear win and discarded the supplied value.
+      assert.equal(
+        turbo.calls.filter((c) => c.method === 'setArNSRecordMetadata').length,
+        0,
       );
     });
   });

--- a/packages/turbo-sdk/src/cli/commands/arns.ts
+++ b/packages/turbo-sdk/src/cli/commands/arns.ts
@@ -29,7 +29,11 @@ import {
   Currency,
   arNSActions,
 } from '../../types.js';
-import { ArNSActionCompleted, ArNSOwnerSigner } from '../../types.js';
+import {
+  ArNSActionCompleted,
+  ArNSActionResult,
+  ArNSOwnerSigner,
+} from '../../types.js';
 import {
   FiatPaymentsDisabledError,
   InsufficientCreditsError,
@@ -38,6 +42,7 @@ import { wincPerCredit } from '../constants.js';
 import {
   AddArNSControllerOptions,
   ArNSActionPriceOptions,
+  ArNSActionStatusOptions,
   ArNSFiatQuoteOptions,
   ArNSPriceOptions,
   ArNSPurchaseOptions,
@@ -81,6 +86,11 @@ export type ArNSStatusClient = {
   getArNSPurchaseStatus(p: {
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse>;
+};
+export type ArNSActionStatusClient = {
+  getArNSActionStatus(
+    nonce: string,
+  ): Promise<ArNSActionResult & { failedDate?: string }>;
 };
 export type ArNSPurchaseClient = {
   buyArNSName(params: {
@@ -219,7 +229,16 @@ export function actionFromOptions(options: { action?: string }): ArNSAction {
 function metadataFieldFromOptions<T>(
   value: T | undefined,
   clear: boolean,
+  flag: string,
 ): T | null | undefined {
+  // Commander registers each value flag and its --clear-* partner separately, so
+  // it accepts both. Silently letting the clear win would discard a value the
+  // caller explicitly passed.
+  if (clear && value !== undefined) {
+    throw new Error(
+      `Cannot pass both --${flag} and --clear-${flag}. Pass one: the value to set it, or the clear flag to unset it.`,
+    );
+  }
   return clear ? null : value;
 }
 
@@ -292,13 +311,17 @@ function creditsFromWinc(winc: string): string {
 }
 
 /** Rethrow a 402 as a clear, actionable "top up" message. */
-async function withCreditErrorMapping<T>(fn: () => Promise<T>): Promise<T> {
+/**
+ * Takes the promise rather than a thunk: wrapping the call in a closure would
+ * discard the `undefined` narrowing each handler's guard clauses establish.
+ */
+async function withCreditErrorMapping<T>(promise: Promise<T>): Promise<T> {
   try {
-    return await fn();
+    return await promise;
   } catch (error) {
     if (error instanceof InsufficientCreditsError) {
       throw new Error(
-        'Insufficient Turbo credits to complete this ArNS purchase. ' +
+        'Insufficient Turbo credits to complete this ArNS action. ' +
           'Top up your balance (e.g. `turbo top-up` or `turbo crypto-fund`) and retry.',
       );
     }
@@ -321,8 +344,11 @@ function logPurchaseResult(action: string, result: ArNSActionCompleted): void {
       2,
     ),
   );
+  // Credit-paid buys go through the actions API, so the nonce lives in the
+  // action namespace. `arns-purchase-status` reads `/arns/purchase/`, a
+  // separate namespace that answers "Purchase status not found" for this nonce.
   console.log(
-    `\nTrack this purchase with:\n  turbo arns-purchase-status --nonce ${result.nonce}`,
+    `\nTrack this with:\n  turbo arns-action-status --nonce ${result.nonce}`,
   );
 }
 
@@ -444,7 +470,7 @@ export async function buyArNSName(
   const owner = ownerFromOptions(options);
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await withCreditErrorMapping(() =>
+  const result = await withCreditErrorMapping(
     type === 'lease'
       ? client.buyArNSName({
           name,
@@ -468,7 +494,7 @@ export async function extendArNSLease(
   const paidBy = paidByFromArNSOptions(options.paidBy);
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await withCreditErrorMapping(() =>
+  const result = await withCreditErrorMapping(
     client.extendArNSLease({ name, years, paidBy }),
   );
 
@@ -487,7 +513,7 @@ export async function increaseArNSUndernames(
   const paidBy = paidByFromArNSOptions(options.paidBy);
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await withCreditErrorMapping(() =>
+  const result = await withCreditErrorMapping(
     client.increaseArNSUndernameLimit({ name, increaseQty, paidBy }),
   );
 
@@ -502,7 +528,7 @@ export async function upgradeArNSName(
   const paidBy = paidByFromArNSOptions(options.paidBy);
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await withCreditErrorMapping(() =>
+  const result = await withCreditErrorMapping(
     client.upgradeArNSName({ name, paidBy }),
   );
 
@@ -530,6 +556,34 @@ export async function arnsPurchaseStatus(
   console.log(JSON.stringify({ state, ...status }, null, 2));
 }
 
+/**
+ * Status of a credit-paid ArNS action (buy, extend, upgrade, increase, and the
+ * eight non-purchase actions). Distinct from `arns-purchase-status`, which
+ * reads the `/arns/purchase/` namespace that fiat quotes land in.
+ *
+ * Authenticated because `getArNSActionStatus` lives on the authenticated
+ * client, though the route itself needs no signature.
+ */
+export async function arnsActionStatus(
+  options: ArNSActionStatusOptions,
+  turbo?: ArNSActionStatusClient,
+): Promise<void> {
+  if (options.nonce === undefined || options.nonce.length === 0) {
+    throw new Error('Must provide a --nonce to look up action status');
+  }
+  const client = turbo ?? (await turboFromOptions(options));
+  const status = await client.getArNSActionStatus(options.nonce);
+
+  const state =
+    status.failedDate !== undefined
+      ? 'failed'
+      : status.messageId
+      ? 'success'
+      : 'pending';
+
+  console.log(JSON.stringify({ state, ...status }, null, 2));
+}
+
 export async function transferArNSAnt(
   options: TransferArNSAntOptions,
   turbo?: ArNSCustodyClient,
@@ -542,11 +596,13 @@ export async function transferArNSAnt(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.transferArNSAnt({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    target: options.target,
-  });
+  const result = await withCreditErrorMapping(
+    client.transferArNSAnt({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      target: options.target,
+    }),
+  );
 
   console.log(
     JSON.stringify({ message: 'ANT transfer submitted!', ...result }, null, 2),
@@ -566,13 +622,15 @@ export async function setArNSRecord(
   const ttlSeconds = positiveIntFromOption(options.ttlSeconds, '--ttl-seconds');
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.setArNSRecord({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    undername: options.undername ?? '@',
-    transactionId: options.transactionId,
-    ttlSeconds,
-  });
+  const result = await withCreditErrorMapping(
+    client.setArNSRecord({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      undername: options.undername ?? '@',
+      transactionId: options.transactionId,
+      ttlSeconds,
+    }),
+  );
 
   console.log(
     JSON.stringify({ message: 'ArNS record set!', ...result }, null, 2),
@@ -591,11 +649,13 @@ export async function removeArNSRecord(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.removeArNSRecord({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    undername: options.undername,
-  });
+  const result = await withCreditErrorMapping(
+    client.removeArNSRecord({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      undername: options.undername,
+    }),
+  );
 
   console.log(
     JSON.stringify({ message: 'ArNS record removed!', ...result }, null, 2),
@@ -611,11 +671,13 @@ export async function addArNSController(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.addArNSController({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    target: options.target,
-  });
+  const result = await withCreditErrorMapping(
+    client.addArNSController({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      target: options.target,
+    }),
+  );
 
   console.log(
     JSON.stringify({ message: 'ArNS controller added!', ...result }, null, 2),
@@ -631,11 +693,13 @@ export async function removeArNSController(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.removeArNSController({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    target: options.target,
-  });
+  const result = await withCreditErrorMapping(
+    client.removeArNSController({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      target: options.target,
+    }),
+  );
 
   console.log(
     JSON.stringify({ message: 'ArNS controller removed!', ...result }, null, 2),
@@ -659,12 +723,14 @@ export async function transferArNSRecord(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.transferArNSRecord({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    undername: options.undername,
-    target: options.target,
-  });
+  const result = await withCreditErrorMapping(
+    client.transferArNSRecord({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      undername: options.undername,
+      target: options.target,
+    }),
+  );
 
   console.log(
     JSON.stringify({ message: 'ArNS record transferred!', ...result }, null, 2),
@@ -680,27 +746,33 @@ export async function setArNSRecordMetadata(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.setArNSRecordMetadata({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    undername: options.undername ?? '@',
-    displayName: metadataFieldFromOptions(
-      options.displayName,
-      options.clearDisplayName,
-    ),
-    recordLogo: metadataFieldFromOptions(
-      options.recordLogo,
-      options.clearRecordLogo,
-    ),
-    recordDescription: metadataFieldFromOptions(
-      options.recordDescription,
-      options.clearRecordDescription,
-    ),
-    recordKeywords: metadataFieldFromOptions(
-      options.recordKeywords,
-      options.clearRecordKeywords,
-    ),
-  });
+  const result = await withCreditErrorMapping(
+    client.setArNSRecordMetadata({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      undername: options.undername ?? '@',
+      displayName: metadataFieldFromOptions(
+        options.displayName,
+        options.clearDisplayName,
+        'display-name',
+      ),
+      recordLogo: metadataFieldFromOptions(
+        options.recordLogo,
+        options.clearRecordLogo,
+        'record-logo',
+      ),
+      recordDescription: metadataFieldFromOptions(
+        options.recordDescription,
+        options.clearRecordDescription,
+        'record-description',
+      ),
+      recordKeywords: metadataFieldFromOptions(
+        options.recordKeywords,
+        options.clearRecordKeywords,
+        'record-keywords',
+      ),
+    }),
+  );
 
   console.log(
     JSON.stringify(
@@ -723,11 +795,13 @@ export async function removeArNSRecordMetadata(
   }
 
   const client = turbo ?? (await turboFromOptions(options));
-  const result = await client.removeArNSRecordMetadata({
-    antId: options.antId,
-    owner: ownerFromOptions(options),
-    undername: options.undername,
-  });
+  const result = await withCreditErrorMapping(
+    client.removeArNSRecordMetadata({
+      antId: options.antId,
+      owner: ownerFromOptions(options),
+      undername: options.undername,
+    }),
+  );
 
   console.log(
     JSON.stringify(

--- a/packages/turbo-sdk/src/cli/options.ts
+++ b/packages/turbo-sdk/src/cli/options.ts
@@ -422,6 +422,8 @@ export const upgradeArNSNameOptions = [
 
 export const arnsPurchaseStatusOptions = [optionMap.arnsNonce];
 
+export const arnsActionStatusOptions = [...walletOptions, optionMap.arnsNonce];
+
 export const transferArNSAntOptions = [
   ...walletOptions,
   optionMap.arnsOwnerKey,

--- a/packages/turbo-sdk/src/cli/types.ts
+++ b/packages/turbo-sdk/src/cli/types.ts
@@ -139,6 +139,14 @@ export type ArNSPurchaseStatusOptions = GlobalOptions & {
   nonce: string | undefined;
 };
 
+/**
+ * Authenticated, unlike `ArNSPurchaseStatusOptions`: `getArNSActionStatus`
+ * lives on the authenticated client even though the route needs no signature.
+ */
+export type ArNSActionStatusOptions = WalletOptions & {
+  nonce: string | undefined;
+};
+
 export type TransferArNSAntOptions = ArNSOwnerKeyOption &
   WalletOptions & {
     antId: string | undefined;

--- a/packages/turbo-sdk/src/common/folderIndex.test.ts
+++ b/packages/turbo-sdk/src/common/folderIndex.test.ts
@@ -561,6 +561,26 @@ describe('createChainFolderIndex', () => {
     assert.deepEqual(await index.resolve?.([key]), { [key]: idA });
   });
 
+  it('skips a node whose tags are malformed alongside a valid hash tag', async () => {
+    const key = await keyFor(hashA, 'text/css');
+    // The hash tag is present and valid, so this node survives both earlier
+    // guards and reaches the key encoding, which reads .name/.value off every
+    // entry. An unguarded null here threw and took the whole sweep with it,
+    // and with it the uploadFolder call awaiting it.
+    const { fetchImpl } = fetchReturning(
+      gatewayResponse([
+        {
+          cursor: 'c1',
+          node: { id: idB, tags: [null, ...tagsFor(hashA, 'text/css')] },
+        },
+        { cursor: 'c2', node: { id: idA, tags: tagsFor(hashA, 'text/css') } },
+      ]),
+    );
+
+    const index = createChainFolderIndex({ owner, fetchImpl });
+    assert.deepEqual(await index.resolve?.([key]), { [key]: idA });
+  });
+
   it('stops on an empty page rather than re-issuing the same query', async () => {
     const { fetchImpl, requests } = fetchReturning(gatewayResponse([], true));
 

--- a/packages/turbo-sdk/src/common/folderIndex.ts
+++ b/packages/turbo-sdk/src/common/folderIndex.ts
@@ -316,6 +316,18 @@ export function createChainFolderIndex({
           if (typeof node?.id !== 'string' || !Array.isArray(tags)) {
             continue;
           }
+          // Every element is untrusted, not just the one carrying the hash.
+          // `folderIndexKey` reads `.name`/`.value` off each tag unguarded, so
+          // one malformed entry would throw out of the key encoding and take
+          // the whole sweep, and the upload awaiting it, with it.
+          if (
+            !tags.every(
+              (tag) =>
+                typeof tag?.name === 'string' && typeof tag?.value === 'string',
+            )
+          ) {
+            continue;
+          }
           const contentHash = tags.find((tag) => tag?.name === hashTagName)
             ?.value;
           if (!isValidContentHash(contentHash)) {

--- a/packages/turbo-sdk/src/common/http.ts
+++ b/packages/turbo-sdk/src/common/http.ts
@@ -116,7 +116,15 @@ export class TurboHTTPService implements TurboHTTPServiceInterface {
         async () =>
           fetchWithPay(this.baseURL + endpoint, {
             method: 'GET',
-            headers: { ...defaultHeaders, ...headers },
+            // This GET is not a read: it settles a payment and returns the
+            // resulting upload id. Nothing between here and the service may
+            // store or replay that response. Sent as a header rather than the
+            // `cache` init option, which undici does not honour consistently.
+            headers: {
+              ...defaultHeaders,
+              ...headers,
+              'Cache-Control': 'no-store',
+            },
             signal,
           }),
         allowedStatuses,

--- a/packages/turbo-sdk/src/common/payment.ts
+++ b/packages/turbo-sdk/src/common/payment.ts
@@ -121,7 +121,9 @@ export class TurboUnauthenticatedPaymentService
 
   public async getBalance(address: string): Promise<TurboBalanceResponse> {
     const balance = await this.httpService.get<TurboBalanceResponse>({
-      endpoint: `/account/balance/${this.token}?address=${address}`,
+      endpoint: `/account/balance/${this.token}?address=${encodeURIComponent(
+        address,
+      )}`,
       allowedStatuses: [200, 404],
     });
 
@@ -140,7 +142,7 @@ export class TurboUnauthenticatedPaymentService
     address: string,
   ): Promise<TurboFreeStatusResponse> {
     const status = await this.httpService.get<TurboFreeStatusResponse>({
-      endpoint: `/account/free?address=${address}`,
+      endpoint: `/account/free?address=${encodeURIComponent(address)}`,
       allowedStatuses: [200, 404],
     });
     // Normalize: preserve a legitimate `0` (free tier off) or `null` (unlimited),
@@ -245,9 +247,9 @@ export class TurboUnauthenticatedPaymentService
     // with `purchaseArNSName`) rather than a synchronous throw.
     this.validateArNSPurchaseParams(params);
     const price = await this.httpService.get<ArNSPriceResponse>({
-      endpoint: `/arns/price/${params.intent.toLowerCase()}/${
-        params.name
-      }${this.buildArNSPurchaseQuery(params)}`,
+      endpoint: `/arns/price/${params.intent.toLowerCase()}/${encodeURIComponent(
+        params.name,
+      )}${this.buildArNSPurchaseQuery(params)}`,
     });
     // Normalize the figure to charge into ONE field. `winc` is the name only
     // and excludes the ANT spawn surcharge — for a Buy-Name that surcharge can
@@ -362,7 +364,7 @@ export class TurboUnauthenticatedPaymentService
     nonce: string;
   }): Promise<ArNSPurchaseStatusResponse> {
     return this.httpService.get<ArNSPurchaseStatusResponse>({
-      endpoint: `/arns/purchase/${nonce}`,
+      endpoint: `/arns/purchase/${encodeURIComponent(nonce)}`,
     });
   }
 
@@ -640,7 +642,9 @@ export class TurboUnauthenticatedPaymentService
     const response = await this.httpService.get<
       GetCreditShareApprovalsResponse | undefined
     >({
-      endpoint: `/account/approvals/get?userAddress=${userAddress}`,
+      endpoint: `/account/approvals/get?userAddress=${encodeURIComponent(
+        userAddress,
+      )}`,
       allowedStatuses: [200, 404],
     });
     if (


### PR DESCRIPTION
## What this is

The second round of findings from the full review on #467, the stable release PR. Six of that review's seven findings, plus one that had been deferred from the first round.

Everything here is in code that has never shipped to `latest`, so none of it can regress an existing consumer.

## The one that mattered

**Credit-paid buys pointed users at the wrong status route.**

`buy-arns-name`, `extend-arns-lease`, `upgrade-arns-name` and `increase-arns-undernames` all run through `completeArNSAction`, so the nonce they print belongs to the action namespace. The CLI told the user to run `arns-purchase-status`, which reads `/arns/purchase/`. Both routes are live and they are separate namespaces:

```
GET /v1/arns/purchase/<uuid>   400  Purchase status not found
GET /v1/arns/actions/<uuid>    404  No action found for nonce <uuid>
```

So following the CLI's own instruction after a successful purchase reports that the purchase does not exist.

The SDK documentation already said to poll `getArNSActionStatus`. Nothing in the CLI exposed it, so the hint had nowhere correct to point. This adds `arns-action-status` and points the hint there. `arns-purchase-status` stays and remains correct for a fiat quote's nonce, which does land in the purchase namespace.

The new command is authenticated because `getArNSActionStatus` lives on the authenticated client, though the route needs no signature.

## The rest

**Conflicting metadata flags silently discarded your value.** `--display-name "X"` together with `--clear-display-name` cleared the field, because Commander registers each flag independently and the helper let the clear win. Now rejected, for all four pairs.

**Custody commands did not map HTTP 402.** They surfaced a raw `Failed request (Status 402)` rather than top-up guidance. All eight route through the mapping now, and its wording no longer says "purchase" for operations that are not purchases.

**Five endpoints interpolated caller-supplied strings unencoded.** The review flagged the free-status `address`; the same pattern was in the balance query, the ArNS price path, the purchase-status path and the approvals query. All five encoded. The sibling ArNS methods already did this, so this makes the boundary consistent rather than adding a new rule.

**The x402-paid GET could be cached.** It is not a read: it settles a payment and returns the resulting upload id. Now sends `Cache-Control: no-store`. Sent as a header rather than the `cache` init option, which undici does not honour consistently.

**A malformed gateway tag took down the whole sweep.** The node guard confirmed only that a valid hash tag was present; every other entry stayed untrusted and the whole array went to `folderIndexKey`, which reads `.name`/`.value` unguarded. A null entry alongside a real hash tag threw out of the key encoding and took the upload awaiting it with it. This one was deferred from the first round.

**The browser-wallet example used `Buffer`.** In a snippet whose entire point is that it runs in a browser. Uses `atob`/`btoa` now.

## Verification

| Check | Result |
|---|---|
| `yarn lint` | pass |
| `yarn format` | pass |
| `yarn build` | pass |
| unit suite | **258 passed, 0 failed** (was 254) |

Four tests added. The folder-index one was confirmed to fail against the unfixed source rather than merely pass beside it. The existing shape test used a node carrying no valid hash, so it was skipped a guard earlier and never reached the encoding; the new case pairs a null entry with a real hash tag, which is what actually reaches it.

One note on the implementation: `withCreditErrorMapping` now takes the promise rather than a thunk. Wrapping the calls in a closure discarded the `undefined` narrowing each handler's guard clauses establish, and the build caught it.

## Deliberately not fixed

**The owner secret key as a command-line argument.** A fair concern: it lands in shell history and process listings. But the remedy is a new input mode (a key file, stdin, or an interactive signer), not a correction, and that changes the surface this release ships. It wants a decision and its own change.

**Rejecting non-HTTPS before an x402 payment.** The README documents `--payment-url http://localhost:4001` as a supported flow, so a blanket HTTPS requirement would reject a configuration we tell people to use. It needs a loopback exemption and a deliberate call, not a silent behaviour change.

**The chunked uploader rebuilt inside `uploadFile`'s retry loop**, so a retried x402 chunked upload submits a second paid create. Still open from the first round: it touches money, and the bundler's refund behaviour for an abandoned paid upload needs checking before the right fix is obvious.

**The top-up path's unencoded segments.** Same class as the encoding fixes above, but it is a money route this review did not raise, and it deserves its own change rather than riding along here.
